### PR TITLE
Improve meeting procedure speaker queue and voting

### DIFF
--- a/src/Executive/Meetings/Meetings.Shared/IDiscussionsHubClient.cs
+++ b/src/Executive/Meetings/Meetings.Shared/IDiscussionsHubClient.cs
@@ -4,7 +4,7 @@ public interface IDiscussionsHubClient
 {
     Task OnDiscussionStatusChanged(int status);
 
-    Task OnMovedToNextSpeaker(string id);
+    Task OnMovedToNextSpeaker(string agendaItemId, string? id);
 
     Task OnSpeakerRequestRevoked(string agendaItemId, string id);
     Task OnSpeakerRequestAdded(string agendaItemId, string id, string attendeeId, string name);

--- a/src/Executive/Meetings/Meetings.UI/Procedure/AttendeePage.razor.cs
+++ b/src/Executive/Meetings/Meetings.UI/Procedure/AttendeePage.razor.cs
@@ -206,7 +206,7 @@ public partial class AttendeePage : IMeetingsProcedureHubClient
         return Task.CompletedTask;
     }
 
-    public Task OnMovedToNextSpeaker(string id)
+    public Task OnMovedToNextSpeaker(string agendaItemId, string? id)
     {
         return Task.CompletedTask;
     }

--- a/src/Executive/Meetings/Meetings.UI/Procedure/ControlPage.razor
+++ b/src/Executive/Meetings/Meetings.UI/Procedure/ControlPage.razor
@@ -460,7 +460,7 @@ else
         return Task.CompletedTask;
     }
 
-    public Task OnMovedToNextSpeaker(string id)
+    public Task OnMovedToNextSpeaker(string agendaItemId, string? id)
     {
         return Task.CompletedTask;
     }

--- a/src/Executive/Meetings/Meetings.UI/Procedure/DisplayPage.razor.cs
+++ b/src/Executive/Meetings/Meetings.UI/Procedure/DisplayPage.razor.cs
@@ -261,7 +261,7 @@ public partial class DisplayPage : IMeetingsProcedureHubClient
         return Task.CompletedTask;
     }
 
-    public Task OnMovedToNextSpeaker(string id)
+    public Task OnMovedToNextSpeaker(string agendaItemId, string? id)
     {
         return Task.CompletedTask;
     }

--- a/src/Executive/Meetings/Meetings/Domain/Entities/Discussion.cs
+++ b/src/Executive/Meetings/Meetings/Domain/Entities/Discussion.cs
@@ -91,6 +91,7 @@ public sealed class Discussion : AggregateRoot<DiscussionId>, IAuditableEntity<D
         if (_speakerQueue.Count == 0)
         {
             CurrentSpeaker = null;
+            CurrentSpeakerId = null;
             State = DiscussionState.Completed;
         }
         else
@@ -109,11 +110,13 @@ public sealed class Discussion : AggregateRoot<DiscussionId>, IAuditableEntity<D
             if (CurrentSpeaker != null)
             {
                 CurrentSpeaker.Status = SpeakerRequestStatus.InProgress;
+                CurrentSpeakerId = CurrentSpeaker.Id;
             }
 
             if (CurrentSpeaker == null)
             {
                 State = DiscussionState.Completed;
+                CurrentSpeakerId = null;
             }
         }
 

--- a/src/Executive/Meetings/Meetings/Domain/Errors/Errors.cs
+++ b/src/Executive/Meetings/Meetings/Domain/Errors/Errors.cs
@@ -24,6 +24,8 @@ public static partial class Errors
 
         public static readonly Error YouHaveNoVotingRights = new Error(nameof(YouHaveNoVotingRights), "You have no voting rights.", string.Empty);
 
+        public static readonly Error YouHaveNoSpeakingRights = new Error(nameof(YouHaveNoSpeakingRights), "You have no speaking rights.", string.Empty);
+
         public static readonly Error OnlyChairpersonCanStartTheMeeting = new Error(nameof(OnlyChairpersonCanStartTheMeeting), "Only the chairperson can start the meeting.", string.Empty);
 
         public static readonly Error OnlyChairpersonCanMoveToNextAgendaItem = new Error(nameof(OnlyChairpersonCanMoveToNextAgendaItem), "Only the chairperson can move to the next agenda item.", string.Empty);
@@ -45,6 +47,8 @@ public static partial class Errors
         public static readonly Error OnlyChairpersonCanStartVoting = new Error(nameof(OnlyChairpersonCanStartVoting), "Only the Chairperson can start a voting session.", string.Empty);
 
         public static readonly Error OnlyChairpersonCanEndVoting = new Error(nameof(OnlyChairpersonCanEndVoting), "Only the Chairperson can end a voting session.", string.Empty);
+
+        public static readonly Error OnlyChairpersonCanManageSpeakerQueue = new Error(nameof(OnlyChairpersonCanManageSpeakerQueue), "Only the chairperson can manage the speaker queue.", string.Empty);
 
         public static readonly Result NotAnAttendantOfMeeting = new Error(nameof(NotAnAttendantOfMeeting), "Not an attendee of this meeting.", string.Empty);
 

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Attendee/RequestSpeakerTime.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Attendee/RequestSpeakerTime.cs
@@ -33,9 +33,9 @@ public sealed record RequestSpeakerTime(string OrganizationId, int Id, string Ag
                 return Errors.Meetings.YouAreNotAttendeeOfMeeting;
             }
 
-            if (!meeting.IsAttendeeAllowedToVote(attendee))
+            if (!meeting.IsAttendeeAllowedToSpeak(attendee))
             {
-                return Errors.Meetings.YouHaveNoVotingRights;
+                return Errors.Meetings.YouHaveNoSpeakingRights;
             }
 
             var agendaItem = meeting.GetAgendaItem(request.AgendaItemId);

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Attendee/RevokeSpeakerTime.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Attendee/RevokeSpeakerTime.cs
@@ -33,9 +33,9 @@ public sealed record RevokeSpeakerTime(string OrganizationId, int Id, string Age
                 return Errors.Meetings.YouAreNotAttendeeOfMeeting;
             }
 
-            if (!meeting.IsAttendeeAllowedToVote(attendee))
+            if (!meeting.IsAttendeeAllowedToSpeak(attendee))
             {
-                return Errors.Meetings.YouHaveNoVotingRights;
+                return Errors.Meetings.YouHaveNoSpeakingRights;
             }
 
             var agendaItem = meeting.GetAgendaItem(request.AgendaItemId);


### PR DESCRIPTION
## Summary
- add dedicated speaking-rights validation and errors while limiting speaker queue control to the chairperson
- harden the discussion speaker queue domain logic and move-to-next-signal payloads, including agenda item context
- fix agenda voting flow to tally results after ending sessions and allow redo scenarios, updating UI listeners for the new hub contract

## Testing
- `dotnet build src/Executive/Meetings/Meetings/Meetings.csproj` *(fails: proxy 403 while restoring Microsoft.* packages)*

------
https://chatgpt.com/codex/tasks/task_e_68fa293b3c60832f9635e1c4b8960a06