### PR TITLE
Handle speaker clock resets in hub and UI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/src/Executive/Meetings/Meetings.Client/OpenAPIs/swagger.yaml
+++ b/src/Executive/Meetings/Meetings.Client/OpenAPIs/swagger.yaml
@@ -1826,6 +1826,92 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProblemDetails'
+      default:
+        description: ''
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProblemDetails'
+      security:
+      - JWT: []
+  /v1/Meetings/{id}/Discussions/SpeakingTime:
+    post:
+      tags:
+      - Chairman
+      operationId: Chairman_SetDiscussionSpeakingTime
+      parameters:
+      - name: organizationId
+        in: query
+        schema:
+          type: string
+        x-position: 1
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+        x-position: 2
+      requestBody:
+        x-name: request
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetDiscussionSpeakingTime'
+        required: true
+        x-position: 3
+      responses:
+        200:
+          description: ''
+        404:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+      security:
+      - JWT: []
+  /v1/Meetings/{id}/Discussions/Speakers/ExtendSpeakerTime:
+    post:
+      tags:
+      - Chairman
+      operationId: Chairman_ExtendSpeakerTime
+      parameters:
+      - name: organizationId
+        in: query
+        schema:
+          type: string
+        x-position: 1
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+        x-position: 2
+      requestBody:
+        x-name: request
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExtendSpeakerTime'
+        required: true
+        x-position: 3
+      responses:
+        200:
+          description: ''
+        404:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
         default:
           description: ''
           content:
@@ -4159,6 +4245,10 @@ components:
           type: string
         state:
           $ref: '#/components/schemas/DiscussionState'
+        speakingTimeLimitSeconds:
+          type: integer
+          format: int32
+          nullable: true
         speakerQueue:
           type: array
           items:
@@ -4167,6 +4257,9 @@ components:
           nullable: true
           oneOf:
           - $ref: '#/components/schemas/SpeakerRequest'
+        currentSpeakerClock:
+          nullable: true
+          $ref: '#/components/schemas/SpeakerClock'
     DiscussionState:
       type: integer
       description: ''
@@ -4190,6 +4283,25 @@ components:
           type: string
         attendeeId:
           type: string
+        allocatedSpeakingTimeSeconds:
+          type: integer
+          format: int32
+          nullable: true
+        hasExtendedSpeakingTime:
+          type: boolean
+    SpeakerClock:
+      type: object
+      additionalProperties: false
+      properties:
+        isRunning:
+          type: boolean
+        elapsedSeconds:
+          type: integer
+          format: int32
+        startedAtUtc:
+          type: string
+          format: date-time
+          nullable: true
     Voting:
       type: object
       additionalProperties: false
@@ -4330,6 +4442,33 @@ components:
       properties:
         agendaItemId:
           type: string
+    SetDiscussionSpeakingTime:
+      type: object
+      additionalProperties: false
+      properties:
+        agendaItemId:
+          type: string
+        speakingTimeLimitSeconds:
+          type: integer
+          format: int32
+          nullable: true
+      required:
+      - agendaItemId
+    ExtendSpeakerTime:
+      type: object
+      additionalProperties: false
+      properties:
+        agendaItemId:
+          type: string
+        speakerRequestId:
+          type: string
+        additionalSeconds:
+          type: integer
+          format: int32
+      required:
+      - agendaItemId
+      - speakerRequestId
+      - additionalSeconds
     CastBallot:
       type: object
       additionalProperties: false

--- a/src/Executive/Meetings/Meetings.Shared/IDiscussionsHub.cs
+++ b/src/Executive/Meetings/Meetings.Shared/IDiscussionsHub.cs
@@ -6,4 +6,10 @@ public interface IDiscussionsHub
 
     Task RequestSpeakerTime(string agendaItemId);
     Task RevokeSpeakerTime(string agendaItemId);
+
+    Task SetDiscussionSpeakingTime(string agendaItemId, int? speakingTimeLimitSeconds);
+    Task ExtendSpeakerTime(string agendaItemId, string speakerRequestId, int additionalSeconds);
+    Task StartCurrentSpeakerClock(string agendaItemId);
+    Task StopCurrentSpeakerClock(string agendaItemId);
+    Task ResetCurrentSpeakerClock(string agendaItemId);
 }

--- a/src/Executive/Meetings/Meetings.Shared/IDiscussionsHubClient.cs
+++ b/src/Executive/Meetings/Meetings.Shared/IDiscussionsHubClient.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace YourBrand.Meetings;
 
 public interface IDiscussionsHubClient
@@ -8,4 +10,10 @@ public interface IDiscussionsHubClient
 
     Task OnSpeakerRequestRevoked(string agendaItemId, string id);
     Task OnSpeakerRequestAdded(string agendaItemId, string id, string attendeeId, string name);
+
+    Task OnSpeakerTimeExtended(string agendaItemId, string speakerRequestId, int? allocatedSeconds);
+    Task OnDiscussionSpeakingTimeChanged(string agendaItemId, int? speakingTimeLimitSeconds);
+    Task OnSpeakerClockStarted(string agendaItemId, string speakerRequestId, int elapsedSeconds, DateTimeOffset startedAtUtc);
+    Task OnSpeakerClockStopped(string agendaItemId, string speakerRequestId, int elapsedSeconds);
+    Task OnSpeakerClockReset(string agendaItemId, string speakerRequestId, int elapsedSeconds);
 }

--- a/src/Executive/Meetings/Meetings.Shared/OpenAPIs/swagger.yaml
+++ b/src/Executive/Meetings/Meetings.Shared/OpenAPIs/swagger.yaml
@@ -1826,6 +1826,92 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProblemDetails'
+      default:
+        description: ''
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProblemDetails'
+      security:
+      - JWT: []
+  /v1/Meetings/{id}/Discussions/SpeakingTime:
+    post:
+      tags:
+      - Chairman
+      operationId: Chairman_SetDiscussionSpeakingTime
+      parameters:
+      - name: organizationId
+        in: query
+        schema:
+          type: string
+        x-position: 1
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+        x-position: 2
+      requestBody:
+        x-name: request
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetDiscussionSpeakingTime'
+        required: true
+        x-position: 3
+      responses:
+        200:
+          description: ''
+        404:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+      security:
+      - JWT: []
+  /v1/Meetings/{id}/Discussions/Speakers/ExtendSpeakerTime:
+    post:
+      tags:
+      - Chairman
+      operationId: Chairman_ExtendSpeakerTime
+      parameters:
+      - name: organizationId
+        in: query
+        schema:
+          type: string
+        x-position: 1
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+        x-position: 2
+      requestBody:
+        x-name: request
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExtendSpeakerTime'
+        required: true
+        x-position: 3
+      responses:
+        200:
+          description: ''
+        404:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
         default:
           description: ''
           content:
@@ -4159,6 +4245,10 @@ components:
           type: string
         state:
           $ref: '#/components/schemas/DiscussionState'
+        speakingTimeLimitSeconds:
+          type: integer
+          format: int32
+          nullable: true
         speakerQueue:
           type: array
           items:
@@ -4167,6 +4257,9 @@ components:
           nullable: true
           oneOf:
           - $ref: '#/components/schemas/SpeakerRequest'
+        currentSpeakerClock:
+          nullable: true
+          $ref: '#/components/schemas/SpeakerClock'
     DiscussionState:
       type: integer
       description: ''
@@ -4190,6 +4283,25 @@ components:
           type: string
         attendeeId:
           type: string
+        allocatedSpeakingTimeSeconds:
+          type: integer
+          format: int32
+          nullable: true
+        hasExtendedSpeakingTime:
+          type: boolean
+    SpeakerClock:
+      type: object
+      additionalProperties: false
+      properties:
+        isRunning:
+          type: boolean
+        elapsedSeconds:
+          type: integer
+          format: int32
+        startedAtUtc:
+          type: string
+          format: date-time
+          nullable: true
     Voting:
       type: object
       additionalProperties: false
@@ -4330,6 +4442,33 @@ components:
       properties:
         agendaItemId:
           type: string
+    SetDiscussionSpeakingTime:
+      type: object
+      additionalProperties: false
+      properties:
+        agendaItemId:
+          type: string
+        speakingTimeLimitSeconds:
+          type: integer
+          format: int32
+          nullable: true
+      required:
+      - agendaItemId
+    ExtendSpeakerTime:
+      type: object
+      additionalProperties: false
+      properties:
+        agendaItemId:
+          type: string
+        speakerRequestId:
+          type: string
+        additionalSeconds:
+          type: integer
+          format: int32
+      required:
+      - agendaItemId
+      - speakerRequestId
+      - additionalSeconds
     CastBallot:
       type: object
       additionalProperties: false

--- a/src/Executive/Meetings/Meetings.UI/Procedure/AttendeePage.razor.cs
+++ b/src/Executive/Meetings/Meetings.UI/Procedure/AttendeePage.razor.cs
@@ -1,4 +1,4 @@
-
+using System;
 
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.SignalR.Client;
@@ -207,6 +207,31 @@ public partial class AttendeePage : IMeetingsProcedureHubClient
     }
 
     public Task OnMovedToNextSpeaker(string agendaItemId, string? id)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task OnSpeakerTimeExtended(string agendaItemId, string speakerRequestId, int? allocatedSeconds)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task OnDiscussionSpeakingTimeChanged(string agendaItemId, int? speakingTimeLimitSeconds)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task OnSpeakerClockStarted(string agendaItemId, string speakerRequestId, int elapsedSeconds, DateTimeOffset startedAtUtc)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task OnSpeakerClockStopped(string agendaItemId, string speakerRequestId, int elapsedSeconds)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task OnSpeakerClockReset(string agendaItemId, string speakerRequestId, int elapsedSeconds)
     {
         return Task.CompletedTask;
     }

--- a/src/Executive/Meetings/Meetings.UI/Procedure/ControlPage.razor
+++ b/src/Executive/Meetings/Meetings.UI/Procedure/ControlPage.razor
@@ -1,5 +1,7 @@
 @page "/meetings/{MeetingId:int}/control"
 @using Microsoft.AspNetCore.SignalR.Client
+@using System
+@using System.Linq
 @using YourBrand.Portal.Services
 @inject IStringLocalizer<DisplayPage> T
 @inject IMeetingsClient MeetingsClient
@@ -178,18 +180,52 @@ else
                     </MudPaper>
                 }
 
-                @if (@currentAgendaItem?.State == AgendaItemState.UnderDiscussion) 
+                @if (@currentAgendaItem?.State == AgendaItemState.UnderDiscussion)
                 {
                     <MudPaper Class="pa-6 mb-4" Elevation="25">
                         <MudText Typo="@Typo.h4" GutterBottom="true">Discussion</MudText>
 
-                        <MudButton Variant="Variant.Filled" Class="me-2"
-                            OnClick="async () => await hubProxy.MoveToNextSpeaker()">Next speaker</MudButton>
-                            
+                        @if (discussion is not null)
+                        {
+                            <MudGrid Class="mb-4">
+                                <MudItem xs="12" md="6">
+                                    <MudNumericField T="int?" @bind-Value="speakingTimeLimitSecondsInput" Immediate="true" Clearable="true" Label="Default speaking time (seconds)" />
+                                    <MudButton Variant="Variant.Outlined" Color="Color.Primary" Class="mt-2"
+                                               OnClick="SetDiscussionSpeakingTimeAsync">Save</MudButton>
+                                </MudItem>
+                                <MudItem xs="12" md="6">
+                                    <MudSelect T="string" @bind-Value="selectedSpeakerRequestId" Dense="true" Label="Select speaker">
+                                        @foreach (var speaker in SpeakerRequestsForExtension)
+                                        {
+                                            <MudSelectItem Value="@speaker.Id">@speaker.Name</MudSelectItem>
+                                        }
+                                    </MudSelect>
+                                    <MudNumericField T="int" @bind-Value="additionalSpeakingTimeSeconds" Immediate="true" Min="1" Label="Additional speaking time (seconds)" />
+                                    <MudButton Variant="Variant.Outlined" Color="Color.Primary" Class="mt-2"
+                                               Disabled="@(!CanExtendSpeakerTime)"
+                                               OnClick="ExtendSpeakerTimeAsync">Extend</MudButton>
+                                </MudItem>
+                            </MudGrid>
+                        }
+
+                        <MudStack Direction="Row" Spacing="1" Class="mb-4">
+                            <MudButton Variant="Variant.Filled" Color="Color.Primary"
+                                       Disabled="@(!CanStartSpeakerClock)"
+                                       OnClick="StartSpeakerClockAsync">Start clock</MudButton>
+                            <MudButton Variant="Variant.Filled" Color="Color.Secondary"
+                                       Disabled="@(!CanStopSpeakerClock)"
+                                       OnClick="StopSpeakerClockAsync">Stop clock</MudButton>
+                            <MudButton Variant="Variant.Filled" Color="Color.Info"
+                                       Disabled="@(!CanResetSpeakerClock)"
+                                       OnClick="ResetSpeakerClockAsync">Reset clock</MudButton>
+                            <MudButton Variant="Variant.Filled"
+                                OnClick="async () => await hubProxy.MoveToNextSpeaker()">Next speaker</MudButton>
+                        </MudStack>
+
                         <SpeakerDisplay MeetingId="@MeetingId" />
 
                     </MudPaper>
-                } 
+                }
         </MudItem>
 
         <MudItem xs="12" md="4">
@@ -232,6 +268,28 @@ else
     private Discussion? discussion;
     private Voting? voting;
     private Election? election;
+
+    private int? speakingTimeLimitSecondsInput;
+    private string? selectedSpeakerRequestId;
+    private int additionalSpeakingTimeSeconds = 60;
+
+    private IEnumerable<SpeakerRequest> SpeakerRequestsForExtension =>
+        discussion is null
+            ? Enumerable.Empty<SpeakerRequest>()
+            : (discussion.CurrentSpeaker is not null
+                ? new[] { discussion.CurrentSpeaker }.Concat(discussion.SpeakerQueue ?? Enumerable.Empty<SpeakerRequest>())
+                : discussion.SpeakerQueue ?? Enumerable.Empty<SpeakerRequest>());
+
+    private bool CanExtendSpeakerTime => !string.IsNullOrEmpty(selectedSpeakerRequestId) && additionalSpeakingTimeSeconds > 0;
+
+    private bool CanStartSpeakerClock =>
+        discussion?.CurrentSpeaker is not null && discussion.CurrentSpeakerClock?.IsRunning != true;
+
+    private bool CanStopSpeakerClock =>
+        discussion?.CurrentSpeaker is not null && discussion.CurrentSpeakerClock?.IsRunning == true;
+
+    private bool CanResetSpeakerClock =>
+        discussion?.CurrentSpeaker is not null && discussion.CurrentSpeakerClock is not null;
 
     HubConnection procedureHub = null!;
     IDiscussionsHub hubProxy = default!;
@@ -302,6 +360,108 @@ else
         await procedureHub.StartAsync();
     }
 
+    private async Task RefreshDiscussionAsync()
+    {
+        if (currentAgendaItem is null || currentAgendaItem.State != AgendaItemState.UnderDiscussion)
+        {
+            discussion = null;
+            speakingTimeLimitSecondsInput = null;
+            selectedSpeakerRequestId = null;
+            return;
+        }
+
+        try
+        {
+            var previousSelection = selectedSpeakerRequestId;
+
+            discussion = await DiscussionsClient.GetDiscussionAsync(organization.Id, MeetingId);
+            speakingTimeLimitSecondsInput = discussion.SpeakingTimeLimitSeconds;
+
+            if (previousSelection is not null && SpeakerRequestsForExtension.Any(x => x.Id == previousSelection))
+            {
+                selectedSpeakerRequestId = previousSelection;
+            }
+            else
+            {
+                selectedSpeakerRequestId = null;
+            }
+
+            StateHasChanged();
+        }
+        catch (ApiException ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+    private async Task SetDiscussionSpeakingTimeAsync()
+    {
+        if (currentAgendaItem is null)
+        {
+            return;
+        }
+
+        if (speakingTimeLimitSecondsInput is not null && speakingTimeLimitSecondsInput <= 0)
+        {
+            Snackbar.Add("Speaking time must be greater than zero.", Severity.Warning);
+            return;
+        }
+
+        await hubProxy.SetDiscussionSpeakingTime(currentAgendaItem.Id, speakingTimeLimitSecondsInput);
+    }
+
+    private async Task ExtendSpeakerTimeAsync()
+    {
+        if (currentAgendaItem is null)
+        {
+            return;
+        }
+
+        if (string.IsNullOrEmpty(selectedSpeakerRequestId))
+        {
+            Snackbar.Add("Select a speaker before extending time.", Severity.Warning);
+            return;
+        }
+
+        if (additionalSpeakingTimeSeconds <= 0)
+        {
+            Snackbar.Add("Additional speaking time must be greater than zero.", Severity.Warning);
+            return;
+        }
+
+        await hubProxy.ExtendSpeakerTime(currentAgendaItem.Id, selectedSpeakerRequestId, additionalSpeakingTimeSeconds);
+    }
+
+    private async Task StartSpeakerClockAsync()
+    {
+        if (currentAgendaItem is null)
+        {
+            return;
+        }
+
+        await hubProxy.StartCurrentSpeakerClock(currentAgendaItem.Id);
+    }
+
+    private async Task StopSpeakerClockAsync()
+    {
+        if (currentAgendaItem is null)
+        {
+            return;
+        }
+
+        await hubProxy.StopCurrentSpeakerClock(currentAgendaItem.Id);
+    }
+
+    private async Task ResetSpeakerClockAsync()
+    {
+        if (currentAgendaItem is null)
+        {
+            return;
+        }
+
+        await hubProxy.ResetCurrentSpeakerClock(currentAgendaItem.Id);
+    }
+
     private async Task ResetProcedure() 
     {
         var r = await DialogService.ShowMessageBox("Reset the procedure?", "This can't be undone.", "Yes", "No");
@@ -354,20 +514,23 @@ else
 
         if (currentAgendaItem is not null)
         {
+            discussion = null;
+            speakingTimeLimitSecondsInput = null;
+            selectedSpeakerRequestId = null;
+
             // Load the current motion associated with the agenda item
             if (currentAgendaItem.MotionId is not null)
             {
                 currentMotion = await MotionsClient.GetMotionByIdAsync(organization.Id, currentAgendaItem.MotionId.GetValueOrDefault());
             }
 
-            if(currentAgendaItem.State == AgendaItemState.UnderDiscussion) 
+            if(currentAgendaItem.State == AgendaItemState.UnderDiscussion)
             {
-                // fetch disc
-                discussion = await DiscussionsClient.GetDiscussionAsync(organization.Id, MeetingId);
+                await RefreshDiscussionAsync();
             }
-            else if(currentAgendaItem.State == AgendaItemState.Voting) 
+            else if(currentAgendaItem.State == AgendaItemState.Voting)
             {
-                if(currentAgendaItem.Type.Id == (int)AgendaItemTypeEnum.Voting) 
+                if(currentAgendaItem.Type.Id == (int)AgendaItemTypeEnum.Voting)
                 {
                     voting = await VotingClient.GetVotingAsync(organization.Id, MeetingId);
                 }
@@ -450,18 +613,99 @@ else
         return Task.CompletedTask;
     }
 
-    public Task OnSpeakerRequestRevoked(string agendaItemId, string id)
+    public async Task OnSpeakerRequestRevoked(string agendaItemId, string id)
     {
-        return Task.CompletedTask;
+        await RefreshDiscussionAsync();
     }
 
-    public Task OnSpeakerRequestAdded(string agendaItemId, string id, string attendeeId, string name)
+    public async Task OnSpeakerRequestAdded(string agendaItemId, string id, string attendeeId, string name)
     {
-        return Task.CompletedTask;
+        await RefreshDiscussionAsync();
     }
 
-    public Task OnMovedToNextSpeaker(string agendaItemId, string? id)
+    public async Task OnMovedToNextSpeaker(string agendaItemId, string? id)
     {
-        return Task.CompletedTask;
+        await RefreshDiscussionAsync();
+    }
+
+    public async Task OnSpeakerTimeExtended(string agendaItemId, string speakerRequestId, int? allocatedSeconds)
+    {
+        if (discussion is null)
+        {
+            return;
+        }
+
+        if (discussion.CurrentSpeaker?.Id == speakerRequestId)
+        {
+            discussion.CurrentSpeaker.AllocatedSpeakingTimeSeconds = allocatedSeconds;
+        }
+
+        if (discussion.SpeakerQueue is not null)
+        {
+            foreach (var speaker in discussion.SpeakerQueue)
+            {
+                if (speaker.Id == speakerRequestId)
+                {
+                    speaker.AllocatedSpeakingTimeSeconds = allocatedSeconds;
+                    break;
+                }
+            }
+        }
+
+        await InvokeAsync(StateHasChanged);
+    }
+
+    public async Task OnDiscussionSpeakingTimeChanged(string agendaItemId, int? speakingTimeLimitSeconds)
+    {
+        speakingTimeLimitSecondsInput = speakingTimeLimitSeconds;
+        await RefreshDiscussionAsync();
+    }
+
+    public async Task OnSpeakerClockStarted(string agendaItemId, string speakerRequestId, int elapsedSeconds, DateTimeOffset startedAtUtc)
+    {
+        if (discussion?.CurrentSpeaker?.Id != speakerRequestId)
+        {
+            await RefreshDiscussionAsync();
+            return;
+        }
+
+        discussion.CurrentSpeakerClock ??= new SpeakerClock();
+        discussion.CurrentSpeakerClock.IsRunning = true;
+        discussion.CurrentSpeakerClock.ElapsedSeconds = elapsedSeconds;
+        discussion.CurrentSpeakerClock.StartedAtUtc = startedAtUtc;
+
+        await InvokeAsync(StateHasChanged);
+    }
+
+    public async Task OnSpeakerClockStopped(string agendaItemId, string speakerRequestId, int elapsedSeconds)
+    {
+        if (discussion?.CurrentSpeaker?.Id != speakerRequestId)
+        {
+            await RefreshDiscussionAsync();
+            return;
+        }
+
+        discussion.CurrentSpeakerClock ??= new SpeakerClock();
+        discussion.CurrentSpeakerClock.IsRunning = false;
+        discussion.CurrentSpeakerClock.ElapsedSeconds = elapsedSeconds;
+        discussion.CurrentSpeakerClock.StartedAtUtc = null;
+
+        await InvokeAsync(StateHasChanged);
+    }
+
+    public async Task OnSpeakerClockReset(string agendaItemId, string speakerRequestId, int elapsedSeconds)
+    {
+        if (discussion?.CurrentSpeaker?.Id != speakerRequestId)
+        {
+            await RefreshDiscussionAsync();
+            return;
+        }
+
+        discussion.CurrentSpeakerClock ??= new SpeakerClock();
+        discussion.CurrentSpeakerClock.IsRunning = false;
+        discussion.CurrentSpeakerClock.ElapsedSeconds = elapsedSeconds;
+        discussion.CurrentSpeakerClock.StartedAtUtc = null;
+
+        await InvokeAsync(StateHasChanged);
     }
 }

--- a/src/Executive/Meetings/Meetings.UI/Procedure/DisplayPage.razor.cs
+++ b/src/Executive/Meetings/Meetings.UI/Procedure/DisplayPage.razor.cs
@@ -1,4 +1,4 @@
-
+using System;
 
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.SignalR.Client;
@@ -262,6 +262,31 @@ public partial class DisplayPage : IMeetingsProcedureHubClient
     }
 
     public Task OnMovedToNextSpeaker(string agendaItemId, string? id)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task OnSpeakerTimeExtended(string agendaItemId, string speakerRequestId, int? allocatedSeconds)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task OnDiscussionSpeakingTimeChanged(string agendaItemId, int? speakingTimeLimitSeconds)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task OnSpeakerClockStarted(string agendaItemId, string speakerRequestId, int elapsedSeconds, DateTimeOffset startedAtUtc)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task OnSpeakerClockStopped(string agendaItemId, string speakerRequestId, int elapsedSeconds)
+    {
+        return Task.CompletedTask;
+    }
+
+    public Task OnSpeakerClockReset(string agendaItemId, string speakerRequestId, int elapsedSeconds)
     {
         return Task.CompletedTask;
     }

--- a/src/Executive/Meetings/Meetings.UI/Procedure/SpeakerDisplay.razor
+++ b/src/Executive/Meetings/Meetings.UI/Procedure/SpeakerDisplay.razor
@@ -24,11 +24,23 @@
         @if (CurrentSpeaker is not null)
         {
             <MudText Typo="@Typo.body1" GutterBottom="true">@CurrentSpeaker.Name</MudText>
+            <MudText Typo="@Typo.caption" GutterBottom="true">Allocated time: @FormatDuration(CurrentSpeaker.AllocatedSpeakingTimeSeconds)</MudText>
+            <MudText Typo="@Typo.h3" Class="mb-1">@GetRemainingTimeDisplay()</MudText>
+            @if (!string.IsNullOrWhiteSpace(GetClockStatusDisplay()))
+            {
+                <MudText Typo="@Typo.caption" GutterBottom="true">@GetClockStatusDisplay()</MudText>
+            }
+            @if (CurrentSpeaker.HasExtendedSpeakingTime)
+            {
+                <MudChip T="string" Color="Color.Primary" Variant="Variant.Outlined" Class="mb-2">Extended</MudChip>
+            }
         }
         else
         {
             <MudText Typo="@Typo.body1" GutterBottom="true"><i>No speaker</i></MudText>
         }
+
+        <MudText Typo="@Typo.caption" GutterBottom="true">Default speaking time: @FormatDuration(speakingTimeLimitSeconds)</MudText>
 
     </MudItem>
 
@@ -40,13 +52,17 @@
             @foreach (var speakerRequest in speakerQueue)
             {
                 <li @key="speakerRequest.Id">
-                    @if (speakerRequest.Id == currentSpeaker?.Id)
+                    @if (speakerRequest.Id == CurrentSpeaker?.Id)
                     {
-                        <MudText Typo="@Typo.body1" Class="mb-2"><b>@speakerRequest.Name</b></MudText>
+                        <MudText Typo="@Typo.body1" Class="mb-2"><b>@speakerRequest.Name</b> (@FormatDuration(speakerRequest.AllocatedSpeakingTimeSeconds))</MudText>
                     }
                     else
                     {
-                        <MudText Typo="@Typo.body1" Class="mb-2">@speakerRequest.Name</MudText>
+                        <MudText Typo="@Typo.body1" Class="mb-2">@speakerRequest.Name (@FormatDuration(speakerRequest.AllocatedSpeakingTimeSeconds))</MudText>
+                    }
+                    @if (speakerRequest.HasExtendedSpeakingTime)
+                    {
+                        <MudChip T="string" Color="Color.Primary" Variant="Variant.Outlined" Dense="true" Class="mb-2">Extended</MudChip>
                     }
                 </li>
             }

--- a/src/Executive/Meetings/Meetings.UI/Procedure/SpeakerDisplay.razor.cs
+++ b/src/Executive/Meetings/Meetings.UI/Procedure/SpeakerDisplay.razor.cs
@@ -1,9 +1,10 @@
-
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.SignalR.Client;
-
-using System.Linq;
 
 using MudBlazor;
 
@@ -11,14 +12,17 @@ using YourBrand.Meetings;
 
 namespace YourBrand.Meetings.Procedure;
 
-
 public partial class SpeakerDisplay : IDiscussionsHubClient
 {
-    HubConnection hubConnection = null!;
-    IDiscussionsHub hubProxy = default!;
+    private HubConnection hubConnection = null!;
+    private IDiscussionsHub hubProxy = default!;
 
-    readonly SpeakerRequest? currentSpeaker;
-    Queue<SpeakerRequest> speakerQueue = new Queue<SpeakerRequest>();
+    private Queue<SpeakerRequest> speakerQueue = new();
+    private SpeakerClock? currentSpeakerClock;
+    private Timer? countdownTimer;
+    private readonly object timerLock = new();
+
+    private int? speakingTimeLimitSeconds;
 
     [Parameter]
     public int MeetingId { get; set; }
@@ -31,31 +35,20 @@ public partial class SpeakerDisplay : IDiscussionsHubClient
 
         OrganizationProvider.CurrentOrganizationChanged += OnCurrentOrganizationChanged;
 
-        var currentUserId = await UserContext.GetUserId()!;
-
         if (hubConnection is not null && hubConnection.State != HubConnectionState.Disconnected)
         {
             await hubConnection.DisposeAsync();
         }
 
-        var discussion = await DiscussionsClient.GetDiscussionAsync(organization!.Id, MeetingId);
+        await RefreshDiscussionAsync();
 
-        foreach(var speaker in discussion.SpeakerQueue) 
-        {
-            speakerQueue.Enqueue(speaker);
-        }
-
-        CurrentSpeaker = discussion.CurrentSpeaker;
-
-        hubConnection = new
-        HubConnectionBuilder().WithUrl($"{NavigationManager.BaseUri}api/meetings/hubs/meetings/procedure/?organizationId={organization.Id}&meetingId={MeetingId}",
-        options =>
-        {
-            options.AccessTokenProvider = async () =>
+        hubConnection = new HubConnectionBuilder()
+            .WithUrl($"{NavigationManager.BaseUri}api/meetings/hubs/meetings/procedure/?organizationId={organization.Id}&meetingId={MeetingId}", options =>
             {
-                return await AccessTokenProvider.GetAccessTokenAsync();
-            };
-        }).WithAutomaticReconnect().Build();
+                options.AccessTokenProvider = async () => await AccessTokenProvider.GetAccessTokenAsync();
+            })
+            .WithAutomaticReconnect()
+            .Build();
 
         hubProxy = hubConnection.ServerProxy<IMeetingsProcedureHub>();
         _ = hubConnection.ClientRegistration<IDiscussionsHubClient>(this);
@@ -101,41 +94,31 @@ public partial class SpeakerDisplay : IDiscussionsHubClient
         await hubConnection.StartAsync();
     }
 
-    YourBrand.Portal.Services.Organization organization = default!;
+    private YourBrand.Portal.Services.Organization organization = default!;
 
     private async void OnCurrentOrganizationChanged(object? sender, EventArgs ev)
     {
         organization = await OrganizationProvider.GetCurrentOrganizationAsync()!;
     }
 
-    public Task OnSpeakerRequestRevoked(string agendaItemId, string id)
+    public async Task OnSpeakerRequestRevoked(string agendaItemId, string id)
     {
-        var list = speakerQueue.Where(x => x.Id != id).ToList();
-        speakerQueue = new Queue<SpeakerRequest>(list);
-        if (CurrentSpeaker?.Id == id)
-        {
-            CurrentSpeaker = null;
-        }
-
-        StateHasChanged();
-
-        return Task.CompletedTask;
+        await RefreshDiscussionAsync();
     }
 
-    public Task OnSpeakerRequestAdded(string agendaItemId, string id, string attendeeId, string name)
+    public async Task OnSpeakerRequestAdded(string agendaItemId, string id, string attendeeId, string name)
     {
-        speakerQueue.Enqueue(new SpeakerRequest() { Id = id, Name = name, AttendeeId = attendeeId, });
-
-        Console.WriteLine("Added");
-
-        StateHasChanged();
-
-        return Task.CompletedTask;
+        await RefreshDiscussionAsync();
     }
 
     public void Dispose()
     {
         OrganizationProvider.CurrentOrganizationChanged -= OnCurrentOrganizationChanged;
+        StopTimer();
+        if (hubConnection is not null)
+        {
+            _ = hubConnection.DisposeAsync();
+        }
     }
 
     public Task OnDiscussionStatusChanged(int status)
@@ -143,53 +126,259 @@ public partial class SpeakerDisplay : IDiscussionsHubClient
         return Task.CompletedTask;
     }
 
-    public Task OnMovedToNextSpeaker(string agendaItemId, string? id)
+    public async Task OnMovedToNextSpeaker(string agendaItemId, string? id)
     {
-        if (string.IsNullOrEmpty(id))
+        await RefreshDiscussionAsync();
+    }
+
+    public async Task OnSpeakerTimeExtended(string agendaItemId, string speakerRequestId, int? allocatedSeconds)
+    {
+        var handled = false;
+
+        if (CurrentSpeaker?.Id == speakerRequestId)
         {
-            CurrentSpeaker = null;
-            speakerQueue.Clear();
-
-            StateHasChanged();
-
-            return Task.CompletedTask;
+            CurrentSpeaker.AllocatedSpeakingTimeSeconds = allocatedSeconds;
+            handled = true;
         }
 
-        var originalQueue = speakerQueue.ToList();
-        SpeakerRequest? nextSpeaker = null;
-        var remaining = new Queue<SpeakerRequest>();
-        var found = false;
-
-        foreach (var candidate in originalQueue)
+        foreach (var request in speakerQueue)
         {
-            if (!found && candidate.Id == id)
+            if (request.Id == speakerRequestId)
             {
-                nextSpeaker = candidate;
-                found = true;
-                continue;
-            }
-
-            if (found)
-            {
-                remaining.Enqueue(candidate);
+                request.AllocatedSpeakingTimeSeconds = allocatedSeconds;
+                handled = true;
+                break;
             }
         }
 
-        if (!found)
+        if (!handled)
         {
-            speakerQueue = new Queue<SpeakerRequest>(originalQueue);
-
-            StateHasChanged();
-
-            return Task.CompletedTask;
+            await RefreshDiscussionAsync();
+            return;
         }
 
-        speakerQueue = remaining;
+        await InvokeAsync(StateHasChanged);
+    }
 
-        CurrentSpeaker = nextSpeaker;
+    public async Task OnDiscussionSpeakingTimeChanged(string agendaItemId, int? speakingTimeLimitSeconds)
+    {
+        await RefreshDiscussionAsync();
+    }
 
-        StateHasChanged();
+    public async Task OnSpeakerClockStarted(string agendaItemId, string speakerRequestId, int elapsedSeconds, DateTimeOffset startedAtUtc)
+    {
+        if (CurrentSpeaker?.Id != speakerRequestId)
+        {
+            await RefreshDiscussionAsync();
+            return;
+        }
 
-        return Task.CompletedTask;
+        currentSpeakerClock ??= new SpeakerClock();
+        currentSpeakerClock.IsRunning = true;
+        currentSpeakerClock.ElapsedSeconds = elapsedSeconds;
+        currentSpeakerClock.StartedAtUtc = startedAtUtc;
+
+        StartTimer();
+
+        await InvokeAsync(StateHasChanged);
+    }
+
+    public async Task OnSpeakerClockStopped(string agendaItemId, string speakerRequestId, int elapsedSeconds)
+    {
+        if (CurrentSpeaker?.Id != speakerRequestId)
+        {
+            await RefreshDiscussionAsync();
+            return;
+        }
+
+        currentSpeakerClock ??= new SpeakerClock();
+        currentSpeakerClock.IsRunning = false;
+        currentSpeakerClock.ElapsedSeconds = elapsedSeconds;
+        currentSpeakerClock.StartedAtUtc = null;
+
+        StopTimer();
+
+        await InvokeAsync(StateHasChanged);
+    }
+
+    public async Task OnSpeakerClockReset(string agendaItemId, string speakerRequestId, int elapsedSeconds)
+    {
+        if (CurrentSpeaker?.Id != speakerRequestId)
+        {
+            await RefreshDiscussionAsync();
+            return;
+        }
+
+        currentSpeakerClock ??= new SpeakerClock();
+        currentSpeakerClock.IsRunning = false;
+        currentSpeakerClock.ElapsedSeconds = elapsedSeconds;
+        currentSpeakerClock.StartedAtUtc = null;
+
+        StopTimer();
+
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task RefreshDiscussionAsync()
+    {
+        if (organization is null)
+        {
+            return;
+        }
+
+        try
+        {
+            var discussion = await DiscussionsClient.GetDiscussionAsync(organization.Id, MeetingId);
+
+            speakerQueue = new Queue<SpeakerRequest>(discussion.SpeakerQueue ?? Array.Empty<SpeakerRequest>());
+            CurrentSpeaker = discussion.CurrentSpeaker;
+            currentSpeakerClock = discussion.CurrentSpeakerClock;
+            speakingTimeLimitSeconds = discussion.SpeakingTimeLimitSeconds;
+
+            RestartTimerBasedOnClock();
+
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (ApiException ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+    private void RestartTimerBasedOnClock()
+    {
+        StopTimer();
+
+        if (CurrentSpeaker is null || currentSpeakerClock is null)
+        {
+            return;
+        }
+
+        if (currentSpeakerClock.IsRunning && currentSpeakerClock.StartedAtUtc.HasValue)
+        {
+            StartTimer();
+        }
+    }
+
+    private void StartTimer()
+    {
+        lock (timerLock)
+        {
+            countdownTimer?.Dispose();
+            countdownTimer = new Timer(OnTimerTick, null, TimeSpan.Zero, TimeSpan.FromSeconds(1));
+        }
+    }
+
+    private void StopTimer()
+    {
+        lock (timerLock)
+        {
+            countdownTimer?.Dispose();
+            countdownTimer = null;
+        }
+    }
+
+    private void OnTimerTick(object? state)
+    {
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    private string GetRemainingTimeDisplay()
+    {
+        if (CurrentSpeaker is null)
+        {
+            return "--:--";
+        }
+
+        var remaining = GetCurrentRemainingTime();
+        return remaining is null ? "--:--" : FormatTimeSpan(remaining.Value);
+    }
+
+    private string GetClockStatusDisplay()
+    {
+        if (CurrentSpeaker is null)
+        {
+            return string.Empty;
+        }
+
+        if (currentSpeakerClock is null)
+        {
+            return "Clock not started";
+        }
+
+        var status = currentSpeakerClock.IsRunning ? "Running" : "Paused";
+        var elapsed = GetCurrentElapsedTime();
+        var elapsedText = elapsed is null ? "--:--" : FormatTimeSpan(elapsed.Value);
+
+        return $"{status} · Elapsed {elapsedText}";
+    }
+
+    private TimeSpan? GetCurrentElapsedTime()
+    {
+        if (CurrentSpeaker is null || currentSpeakerClock is null)
+        {
+            return null;
+        }
+
+        var elapsed = TimeSpan.FromSeconds(currentSpeakerClock.ElapsedSeconds);
+
+        if (currentSpeakerClock.IsRunning && currentSpeakerClock.StartedAtUtc.HasValue)
+        {
+            var additional = DateTimeOffset.UtcNow - currentSpeakerClock.StartedAtUtc.Value;
+            if (additional > TimeSpan.Zero)
+            {
+                elapsed += additional;
+            }
+        }
+
+        return elapsed < TimeSpan.Zero ? TimeSpan.Zero : elapsed;
+    }
+
+    private TimeSpan? GetCurrentRemainingTime()
+    {
+        var allocatedSeconds = CurrentSpeaker?.AllocatedSpeakingTimeSeconds;
+
+        if (allocatedSeconds is null)
+        {
+            return null;
+        }
+
+        var allocated = TimeSpan.FromSeconds(allocatedSeconds.Value);
+        var elapsed = GetCurrentElapsedTime();
+
+        if (elapsed is null)
+        {
+            return allocated;
+        }
+
+        var remaining = allocated - elapsed.Value;
+        return remaining < TimeSpan.Zero ? TimeSpan.Zero : remaining;
+    }
+
+    private string FormatTimeSpan(TimeSpan value)
+    {
+        return FormatDuration((int)Math.Max(0, Math.Round(value.TotalSeconds)));
+    }
+
+    private string FormatDuration(int? seconds)
+    {
+        if (seconds is null)
+        {
+            return "Not set";
+        }
+
+        var duration = TimeSpan.FromSeconds(seconds.Value);
+
+        if (duration.TotalHours >= 1)
+        {
+            return $"{(int)duration.TotalHours}h {duration.Minutes:D2}m {duration.Seconds:D2}s";
+        }
+
+        if (duration.TotalMinutes >= 1)
+        {
+            return $"{(int)duration.TotalMinutes}m {duration.Seconds:D2}s";
+        }
+
+        return $"{duration.Seconds}s";
     }
 }

--- a/src/Executive/Meetings/Meetings/Domain/Entities/SpeakerRequest.cs
+++ b/src/Executive/Meetings/Meetings/Domain/Entities/SpeakerRequest.cs
@@ -30,8 +30,35 @@ public sealed class SpeakerRequest : Entity<SpeakerRequestId>, IAuditableEntity<
     public DateTimeOffset RequestedTime { get; set; }
     public TimeSpan? ActualSpeakingTime { get; set; }
 
+    public TimeSpan? AllocatedSpeakingTime { get; private set; }
+
+    public bool HasExtendedSpeakingTime { get; private set; }
+
     // New status field
     public SpeakerRequestStatus Status { get; set; } = SpeakerRequestStatus.Pending;  // Default to Pending
+
+    public void ApplyDefaultSpeakingTime(TimeSpan? speakingTime)
+    {
+        if (HasExtendedSpeakingTime)
+        {
+            return;
+        }
+
+        AllocatedSpeakingTime = speakingTime;
+    }
+
+    [Throws(typeof(InvalidOperationException))]
+    public void ExtendSpeakingTime(TimeSpan additionalSpeakingTime)
+    {
+        if (additionalSpeakingTime <= TimeSpan.Zero)
+        {
+            throw new InvalidOperationException("Additional speaking time must be greater than zero.");
+        }
+
+        var current = AllocatedSpeakingTime ?? TimeSpan.Zero;
+        AllocatedSpeakingTime = current + additionalSpeakingTime;
+        HasExtendedSpeakingTime = true;
+    }
 
     public User? CreatedBy { get; set; } = null!;
     public UserId? CreatedById { get; set; } = null!;

--- a/src/Executive/Meetings/Meetings/Domain/Errors/Errors.cs
+++ b/src/Executive/Meetings/Meetings/Domain/Errors/Errors.cs
@@ -50,6 +50,17 @@ public static partial class Errors
 
         public static readonly Error OnlyChairpersonCanManageSpeakerQueue = new Error(nameof(OnlyChairpersonCanManageSpeakerQueue), "Only the chairperson can manage the speaker queue.", string.Empty);
 
+        public static readonly Error SpeakingTimeNotConfigured = new Error(nameof(SpeakingTimeNotConfigured), "Speaking time limit has not been configured for the discussion.", string.Empty);
+
+        public static readonly Error SpeakerRequestNotFound = new Error(nameof(SpeakerRequestNotFound), "Speaker request not found.", string.Empty);
+
+        public static readonly Error InvalidSpeakingTimeLimit = new Error(nameof(InvalidSpeakingTimeLimit), "Speaking time limit must be greater than zero.", string.Empty);
+
+        public static readonly Error InvalidAdditionalSpeakingTime = new Error(nameof(InvalidAdditionalSpeakingTime), "Additional speaking time must be greater than zero.", string.Empty);
+        public static readonly Error NoCurrentSpeaker = new Error(nameof(NoCurrentSpeaker), "No current speaker is active.", string.Empty);
+        public static readonly Error SpeakerClockAlreadyRunning = new Error(nameof(SpeakerClockAlreadyRunning), "The speaker clock is already running.", string.Empty);
+        public static readonly Error SpeakerClockNotRunning = new Error(nameof(SpeakerClockNotRunning), "The speaker clock is not running.", string.Empty);
+
         public static readonly Result NotAnAttendantOfMeeting = new Error(nameof(NotAnAttendantOfMeeting), "Not an attendee of this meeting.", string.Empty);
 
         public static readonly Result CandidateAlreadyProposed = new Error(nameof(CandidateAlreadyProposed), "Attendee has already been proposed as a candidate.", string.Empty);

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/ChairmanController.Discussions.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/ChairmanController.Discussions.cs
@@ -11,6 +11,10 @@ public sealed record RequestSpeakerTimeDto(string AgendaItemId);
 
 public sealed record RevokeSpeakerTimeDto(string AgendaItemId);
 
+public sealed record SetDiscussionSpeakingTimeDto(string AgendaItemId, int? SpeakingTimeLimitSeconds);
+
+public sealed record ExtendSpeakerTimeDto(string AgendaItemId, string SpeakerRequestId, int AdditionalSeconds);
+
 public sealed partial class ChairmanController : ControllerBase
 {
     [HttpPost("{id}/Discussions/Start")]
@@ -30,6 +34,26 @@ public sealed partial class ChairmanController : ControllerBase
     public async Task<ActionResult> EndDiscussion([FromQuery] string organizationId, int id, CancellationToken cancellationToken)
     {
         var result = await mediator.Send(new EndDiscussions(organizationId, id), cancellationToken);
+        return this.HandleResult(result);
+    }
+
+    [HttpPost("{id}/Discussions/SpeakingTime")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
+    [ProducesDefaultResponseType]
+    public async Task<ActionResult> SetDiscussionSpeakingTime([FromQuery] string organizationId, int id, SetDiscussionSpeakingTimeDto request, CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new SetDiscussionSpeakingTime(organizationId, id, request.AgendaItemId, request.SpeakingTimeLimitSeconds), cancellationToken);
+        return this.HandleResult(result);
+    }
+
+    [HttpPost("{id}/Discussions/Speakers/Extend")] 
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
+    [ProducesDefaultResponseType]
+    public async Task<ActionResult> ExtendSpeakerTime([FromQuery] string organizationId, int id, ExtendSpeakerTimeDto request, CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new ExtendSpeakerTime(organizationId, id, request.AgendaItemId, request.SpeakerRequestId, request.AdditionalSeconds), cancellationToken);
         return this.HandleResult(result);
     }
 }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/ExtendSpeakerTime.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/ExtendSpeakerTime.cs
@@ -1,0 +1,92 @@
+using System.Linq;
+
+using MediatR;
+
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Identity;
+using YourBrand.Meetings.Features.Agendas;
+using YourBrand.Meetings.Features.Procedure.Command;
+using YourBrand.Meetings.Features.Procedure.Discussions;
+
+namespace YourBrand.Meetings.Features.Procedure.Chairman;
+
+public sealed record ExtendSpeakerTime(string OrganizationId, int Id, string AgendaItemId, string SpeakerRequestId, int AdditionalSeconds) : IRequest<Result>
+{
+    public sealed class Handler(IApplicationDbContext context, IUserContext userContext, IHubContext<MeetingsProcedureHub, IMeetingsProcedureHubClient> hubContext)
+        : IRequestHandler<ExtendSpeakerTime, Result>
+    {
+        public async Task<Result> Handle(ExtendSpeakerTime request, CancellationToken cancellationToken)
+        {
+            if (request.AdditionalSeconds <= 0)
+            {
+                return Errors.Meetings.InvalidAdditionalSpeakingTime;
+            }
+
+            var meeting = await context.Meetings
+                .InOrganization(request.OrganizationId)
+                .Include(x => x.Agenda)
+                .ThenInclude(x => x.Items.OrderBy(x => x.Order))
+                .FirstOrDefaultAsync(x => x.Id == request.Id, cancellationToken);
+
+            if (meeting is null)
+            {
+                return Errors.Meetings.MeetingNotFound;
+            }
+
+            var attendee = meeting.GetAttendeeByUserId(userContext.UserId);
+
+            if (attendee is null)
+            {
+                return Errors.Meetings.YouAreNotAttendeeOfMeeting;
+            }
+
+            if (attendee.Role != AttendeeRole.Chairperson)
+            {
+                return Errors.Meetings.OnlyChairpersonCanManageSpeakerQueue;
+            }
+
+            var agendaItem = meeting.GetAgendaItem(request.AgendaItemId);
+
+            if (agendaItem is null)
+            {
+                return Errors.Meetings.AgendaItemNotFound;
+            }
+
+            if (agendaItem.Discussion is null)
+            {
+                return Errors.Meetings.NoOngoingDiscussionSession;
+            }
+
+            try
+            {
+                agendaItem.Discussion.ExtendSpeakerTime(request.SpeakerRequestId, TimeSpan.FromSeconds(request.AdditionalSeconds));
+            }
+            catch (InvalidOperationException)
+            {
+                return Errors.Meetings.SpeakerRequestNotFound;
+            }
+
+            context.Meetings.Update(meeting);
+
+            await context.SaveChangesAsync(cancellationToken);
+
+            var speakerRequests = agendaItem.Discussion.GetOrderedSpeakerQueue()
+                .Concat(agendaItem.Discussion.CurrentSpeaker is null
+                    ? Enumerable.Empty<SpeakerRequest>()
+                    : new[] { agendaItem.Discussion.CurrentSpeaker });
+
+            var updatedSpeaker = speakerRequests.FirstOrDefault(x => x.Id == request.SpeakerRequestId);
+
+            await hubContext.Clients
+                .Group($"meeting-{meeting.Id}")
+                .OnSpeakerTimeExtended(
+                    agendaItem.Id,
+                    request.SpeakerRequestId,
+                    (int?)updatedSpeaker?.AllocatedSpeakingTime?.TotalSeconds);
+
+            return Result.Success;
+        }
+    }
+}

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/ResetSpeakerClock.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/ResetSpeakerClock.cs
@@ -1,0 +1,82 @@
+using System;
+
+using MediatR;
+
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Identity;
+using YourBrand.Meetings.Features.Agendas;
+using YourBrand.Meetings.Features.Procedure.Command;
+
+namespace YourBrand.Meetings.Features.Procedure.Chairman;
+
+public sealed record ResetSpeakerClock(string OrganizationId, int Id, string AgendaItemId) : IRequest<Result>
+{
+    public sealed class Handler(
+        IApplicationDbContext context,
+        IUserContext userContext,
+        IHubContext<MeetingsProcedureHub, IMeetingsProcedureHubClient> hubContext)
+        : IRequestHandler<ResetSpeakerClock, Result>
+    {
+        public async Task<Result> Handle(ResetSpeakerClock request, CancellationToken cancellationToken)
+        {
+            var meeting = await context.Meetings
+                .InOrganization(request.OrganizationId)
+                .Include(x => x.Agenda)
+                .ThenInclude(x => x.Items.OrderBy(x => x.Order))
+                .FirstOrDefaultAsync(x => x.Id == request.Id, cancellationToken);
+
+            if (meeting is null)
+            {
+                return Errors.Meetings.MeetingNotFound;
+            }
+
+            var attendee = meeting.GetAttendeeByUserId(userContext.UserId);
+
+            if (attendee is null)
+            {
+                return Errors.Meetings.YouAreNotAttendeeOfMeeting;
+            }
+
+            if (attendee.Role != AttendeeRole.Chairperson)
+            {
+                return Errors.Meetings.OnlyChairpersonCanManageSpeakerQueue;
+            }
+
+            var agendaItem = meeting.GetAgendaItem(request.AgendaItemId);
+
+            if (agendaItem is null)
+            {
+                return Errors.Meetings.AgendaItemNotFound;
+            }
+
+            if (agendaItem.Discussion is null)
+            {
+                return Errors.Meetings.NoOngoingDiscussionSession;
+            }
+
+            if (agendaItem.Discussion.CurrentSpeaker is null)
+            {
+                return Errors.Meetings.NoCurrentSpeaker;
+            }
+
+            agendaItem.Discussion.ResetCurrentSpeakerClock();
+
+            context.Meetings.Update(meeting);
+
+            await context.SaveChangesAsync(cancellationToken);
+
+            var now = DateTimeOffset.UtcNow;
+            var snapshot = agendaItem.Discussion.GetCurrentSpeakerClockSnapshot(now);
+            var currentSpeakerId = agendaItem.Discussion.CurrentSpeaker!.Id.Value;
+            var elapsedSeconds = (int)Math.Max(0, Math.Round(snapshot.Elapsed.TotalSeconds));
+
+            await hubContext.Clients
+                .Group($"meeting-{meeting.Id}")
+                .OnSpeakerClockReset(agendaItem.Id, currentSpeakerId, elapsedSeconds);
+
+            return Result.Success;
+        }
+    }
+}

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/SetDiscussionSpeakingTime.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/SetDiscussionSpeakingTime.cs
@@ -1,0 +1,81 @@
+using MediatR;
+
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Identity;
+using YourBrand.Meetings.Features.Agendas;
+using YourBrand.Meetings.Features.Procedure.Command;
+using YourBrand.Meetings.Features.Procedure.Discussions;
+
+namespace YourBrand.Meetings.Features.Procedure.Chairman;
+
+public sealed record SetDiscussionSpeakingTime(string OrganizationId, int Id, string AgendaItemId, int? SpeakingTimeLimitSeconds) : IRequest<Result>
+{
+    public sealed class Handler(IApplicationDbContext context, IUserContext userContext, IHubContext<MeetingsProcedureHub, IMeetingsProcedureHubClient> hubContext)
+        : IRequestHandler<SetDiscussionSpeakingTime, Result>
+    {
+        public async Task<Result> Handle(SetDiscussionSpeakingTime request, CancellationToken cancellationToken)
+        {
+            var meeting = await context.Meetings
+            .InOrganization(request.OrganizationId)
+            .Include(x => x.Agenda)
+            .ThenInclude(x => x.Items.OrderBy(x => x.Order))
+            .FirstOrDefaultAsync(x => x.Id == request.Id, cancellationToken);
+
+            if (meeting is null)
+            {
+                return Errors.Meetings.MeetingNotFound;
+            }
+
+            var attendee = meeting.GetAttendeeByUserId(userContext.UserId);
+
+            if (attendee is null)
+            {
+                return Errors.Meetings.YouAreNotAttendeeOfMeeting;
+            }
+
+            if (attendee.Role != AttendeeRole.Chairperson)
+            {
+                return Errors.Meetings.OnlyChairpersonCanManageSpeakerQueue;
+            }
+
+            var agendaItem = meeting.GetAgendaItem(request.AgendaItemId);
+
+            if (agendaItem is null)
+            {
+                return Errors.Meetings.AgendaItemNotFound;
+            }
+
+            agendaItem.Discussion ??= new Discussion
+            {
+                OrganizationId = meeting.OrganizationId,
+                TenantId = meeting.TenantId,
+                AgendaItemId = agendaItem.Id
+            };
+
+            TimeSpan? speakingTime = request.SpeakingTimeLimitSeconds is null
+                ? null
+                : TimeSpan.FromSeconds(request.SpeakingTimeLimitSeconds.Value);
+
+            try
+            {
+                agendaItem.Discussion.SetSpeakingTimeLimit(speakingTime);
+            }
+            catch (InvalidOperationException)
+            {
+                return Errors.Meetings.InvalidSpeakingTimeLimit;
+            }
+
+            context.Meetings.Update(meeting);
+
+            await context.SaveChangesAsync(cancellationToken);
+
+            await hubContext.Clients
+                .Group($"meeting-{meeting.Id}")
+                .OnDiscussionSpeakingTimeChanged(agendaItem.Id, request.SpeakingTimeLimitSeconds);
+
+            return Result.Success;
+        }
+    }
+}

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/StartSpeakerClock.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/StartSpeakerClock.cs
@@ -1,0 +1,86 @@
+using System;
+
+using MediatR;
+
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Identity;
+using YourBrand.Meetings.Features.Agendas;
+using YourBrand.Meetings.Features.Procedure.Command;
+
+namespace YourBrand.Meetings.Features.Procedure.Chairman;
+
+public sealed record StartSpeakerClock(string OrganizationId, int Id, string AgendaItemId) : IRequest<Result>
+{
+    public sealed class Handler(IApplicationDbContext context, IUserContext userContext, IHubContext<MeetingsProcedureHub, IMeetingsProcedureHubClient> hubContext)
+        : IRequestHandler<StartSpeakerClock, Result>
+    {
+        public async Task<Result> Handle(StartSpeakerClock request, CancellationToken cancellationToken)
+        {
+            var meeting = await context.Meetings
+                .InOrganization(request.OrganizationId)
+                .Include(x => x.Agenda)
+                .ThenInclude(x => x.Items.OrderBy(x => x.Order))
+                .FirstOrDefaultAsync(x => x.Id == request.Id, cancellationToken);
+
+            if (meeting is null)
+            {
+                return Errors.Meetings.MeetingNotFound;
+            }
+
+            var attendee = meeting.GetAttendeeByUserId(userContext.UserId);
+
+            if (attendee is null)
+            {
+                return Errors.Meetings.YouAreNotAttendeeOfMeeting;
+            }
+
+            if (attendee.Role != AttendeeRole.Chairperson)
+            {
+                return Errors.Meetings.OnlyChairpersonCanManageSpeakerQueue;
+            }
+
+            var agendaItem = meeting.GetAgendaItem(request.AgendaItemId);
+
+            if (agendaItem is null)
+            {
+                return Errors.Meetings.AgendaItemNotFound;
+            }
+
+            if (agendaItem.Discussion is null)
+            {
+                return Errors.Meetings.NoOngoingDiscussionSession;
+            }
+
+            if (agendaItem.Discussion.CurrentSpeaker is null)
+            {
+                return Errors.Meetings.NoCurrentSpeaker;
+            }
+
+            if (agendaItem.Discussion.IsCurrentSpeakerClockRunning)
+            {
+                return Errors.Meetings.SpeakerClockAlreadyRunning;
+            }
+
+            var now = DateTimeOffset.UtcNow;
+
+            agendaItem.Discussion.StartCurrentSpeakerClock(now);
+
+            context.Meetings.Update(meeting);
+
+            await context.SaveChangesAsync(cancellationToken);
+
+            var snapshot = agendaItem.Discussion.GetCurrentSpeakerClockSnapshot(now);
+            var currentSpeakerId = agendaItem.Discussion.CurrentSpeaker!.Id.Value;
+            var elapsedSeconds = (int)Math.Max(0, Math.Round(snapshot.Elapsed.TotalSeconds));
+            var startedAtUtc = snapshot.StartedAtUtc ?? now;
+
+            await hubContext.Clients
+                .Group($"meeting-{meeting.Id}")
+                .OnSpeakerClockStarted(agendaItem.Id, currentSpeakerId, elapsedSeconds, startedAtUtc);
+
+            return Result.Success;
+        }
+    }
+}

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/StopSpeakerClock.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/StopSpeakerClock.cs
@@ -1,0 +1,85 @@
+using System;
+
+using MediatR;
+
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Identity;
+using YourBrand.Meetings.Features.Agendas;
+using YourBrand.Meetings.Features.Procedure.Command;
+
+namespace YourBrand.Meetings.Features.Procedure.Chairman;
+
+public sealed record StopSpeakerClock(string OrganizationId, int Id, string AgendaItemId) : IRequest<Result>
+{
+    public sealed class Handler(IApplicationDbContext context, IUserContext userContext, IHubContext<MeetingsProcedureHub, IMeetingsProcedureHubClient> hubContext)
+        : IRequestHandler<StopSpeakerClock, Result>
+    {
+        public async Task<Result> Handle(StopSpeakerClock request, CancellationToken cancellationToken)
+        {
+            var meeting = await context.Meetings
+                .InOrganization(request.OrganizationId)
+                .Include(x => x.Agenda)
+                .ThenInclude(x => x.Items.OrderBy(x => x.Order))
+                .FirstOrDefaultAsync(x => x.Id == request.Id, cancellationToken);
+
+            if (meeting is null)
+            {
+                return Errors.Meetings.MeetingNotFound;
+            }
+
+            var attendee = meeting.GetAttendeeByUserId(userContext.UserId);
+
+            if (attendee is null)
+            {
+                return Errors.Meetings.YouAreNotAttendeeOfMeeting;
+            }
+
+            if (attendee.Role != AttendeeRole.Chairperson)
+            {
+                return Errors.Meetings.OnlyChairpersonCanManageSpeakerQueue;
+            }
+
+            var agendaItem = meeting.GetAgendaItem(request.AgendaItemId);
+
+            if (agendaItem is null)
+            {
+                return Errors.Meetings.AgendaItemNotFound;
+            }
+
+            if (agendaItem.Discussion is null)
+            {
+                return Errors.Meetings.NoOngoingDiscussionSession;
+            }
+
+            if (agendaItem.Discussion.CurrentSpeaker is null)
+            {
+                return Errors.Meetings.NoCurrentSpeaker;
+            }
+
+            if (!agendaItem.Discussion.IsCurrentSpeakerClockRunning)
+            {
+                return Errors.Meetings.SpeakerClockNotRunning;
+            }
+
+            var now = DateTimeOffset.UtcNow;
+
+            agendaItem.Discussion.StopCurrentSpeakerClock(now);
+
+            context.Meetings.Update(meeting);
+
+            await context.SaveChangesAsync(cancellationToken);
+
+            var snapshot = agendaItem.Discussion.GetCurrentSpeakerClockSnapshot(now);
+            var currentSpeakerId = agendaItem.Discussion.CurrentSpeaker!.Id.Value;
+            var elapsedSeconds = (int)Math.Max(0, Math.Round(snapshot.Elapsed.TotalSeconds));
+
+            await hubContext.Clients
+                .Group($"meeting-{meeting.Id}")
+                .OnSpeakerClockStopped(agendaItem.Id, currentSpeakerId, elapsedSeconds);
+
+            return Result.Success;
+        }
+    }
+}

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Discussions/DiscussionDto.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Discussions/DiscussionDto.cs
@@ -1,5 +1,9 @@
+using System;
+
 namespace YourBrand.Meetings.Features.Procedure.Discussions;
 
-public sealed record DiscussionDto(string Id, DiscussionState State, IEnumerable<SpeakerRequestDto> SpeakerQueue, SpeakerRequestDto? CurrentSpeaker);
+public sealed record DiscussionDto(string Id, DiscussionState State, int? SpeakingTimeLimitSeconds, IEnumerable<SpeakerRequestDto> SpeakerQueue, SpeakerRequestDto? CurrentSpeaker, SpeakerClockDto? CurrentSpeakerClock);
 
-public sealed record SpeakerRequestDto(string Id, string Name, string AttendeeId);
+public sealed record SpeakerRequestDto(string Id, string Name, string AttendeeId, int? AllocatedSpeakingTimeSeconds, bool HasExtendedSpeakingTime);
+
+public sealed record SpeakerClockDto(bool IsRunning, int ElapsedSeconds, DateTimeOffset? StartedAtUtc);

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Discussions/Mapper.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Discussions/Mapper.cs
@@ -1,12 +1,39 @@
-﻿using YourBrand.Meetings.Features.Organizations;
+using System;
+using System.Linq;
+
+using YourBrand.Meetings.Features.Organizations;
 using YourBrand.Meetings.Features.Users;
 
 namespace YourBrand.Meetings.Features.Procedure.Discussions;
 
 public static partial class Mappings
 {
-    public static DiscussionDto ToDto(this Discussion discussion) => new(discussion.Id, discussion.State, 
-        discussion.GetOrderedSpeakerQueue().Select(x => x.ToDto()), discussion.CurrentSpeaker?.ToDto());
+    public static DiscussionDto ToDto(this Discussion discussion)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var currentSpeakerDto = discussion.CurrentSpeaker?.ToDto();
+        var clockDto = discussion.CurrentSpeaker is null
+            ? null
+            : discussion.GetCurrentSpeakerClockSnapshot(now).ToDto();
 
-    public static SpeakerRequestDto ToDto(this SpeakerRequest speakerRequest) => new(speakerRequest.Id, speakerRequest.Name, speakerRequest.AttendeeId);
+        return new DiscussionDto(
+            discussion.Id,
+            discussion.State,
+            (int?)discussion.SpeakingTimeLimit?.TotalSeconds,
+            discussion.GetOrderedSpeakerQueue().Select(x => x.ToDto()),
+            currentSpeakerDto,
+            clockDto);
+    }
+
+    public static SpeakerRequestDto ToDto(this SpeakerRequest speakerRequest) => new(
+        speakerRequest.Id,
+        speakerRequest.Name,
+        speakerRequest.AttendeeId,
+        (int?)speakerRequest.AllocatedSpeakingTime?.TotalSeconds,
+        speakerRequest.HasExtendedSpeakingTime);
+
+    public static SpeakerClockDto ToDto(this SpeakerClockSnapshot snapshot) => new(
+        snapshot.IsRunning,
+        (int)Math.Max(0, Math.Round(snapshot.Elapsed.TotalSeconds)),
+        snapshot.StartedAtUtc);
 }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/MeetingsProcedureHub.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/MeetingsProcedureHub.cs
@@ -82,6 +82,56 @@ public sealed class MeetingsProcedureHub(IMediator mediator, ISettableUserContex
               new RevokeSpeakerTime(connectionState.OrganizationId, connectionState.MeetingId, agendaItemId));
     }
 
+    public async Task SetDiscussionSpeakingTime(string agendaItemId, int? speakingTimeLimitSeconds)
+    {
+        var connectionState = state[Context.ConnectionId];
+
+        SetContext(userContext, tenantContext, connectionState);
+
+        await mediator.Send(
+            new SetDiscussionSpeakingTime(connectionState.OrganizationId, connectionState.MeetingId, agendaItemId, speakingTimeLimitSeconds));
+    }
+
+    public async Task ExtendSpeakerTime(string agendaItemId, string speakerRequestId, int additionalSeconds)
+    {
+        var connectionState = state[Context.ConnectionId];
+
+        SetContext(userContext, tenantContext, connectionState);
+
+        await mediator.Send(
+            new ExtendSpeakerTime(connectionState.OrganizationId, connectionState.MeetingId, agendaItemId, speakerRequestId, additionalSeconds));
+    }
+
+    public async Task StartCurrentSpeakerClock(string agendaItemId)
+    {
+        var connectionState = state[Context.ConnectionId];
+
+        SetContext(userContext, tenantContext, connectionState);
+
+        await mediator.Send(
+            new StartSpeakerClock(connectionState.OrganizationId, connectionState.MeetingId, agendaItemId));
+    }
+
+    public async Task StopCurrentSpeakerClock(string agendaItemId)
+    {
+        var connectionState = state[Context.ConnectionId];
+
+        SetContext(userContext, tenantContext, connectionState);
+
+        await mediator.Send(
+            new StopSpeakerClock(connectionState.OrganizationId, connectionState.MeetingId, agendaItemId));
+    }
+
+    public async Task ResetCurrentSpeakerClock(string agendaItemId)
+    {
+        var connectionState = state[Context.ConnectionId];
+
+        SetContext(userContext, tenantContext, connectionState);
+
+        await mediator.Send(
+            new ResetSpeakerClock(connectionState.OrganizationId, connectionState.MeetingId, agendaItemId));
+    }
+
     private void SetContext(ISettableUserContext userContext, ISettableTenantContext tenantContext, ConnectionState s)
     {
         tenantContext.SetTenantId(s.TenantId);


### PR DESCRIPTION
## Summary
- add a reset-speaker-clock command and hub method so the chair can clear the active speaker timer
- update discussions hub contracts and UI controls to expose the reset action and new clock events
- drive the speaker display countdown from hub notifications so it reacts instantly to start/stop/reset and extension updates

## Testing
- dotnet build src/Executive/Meetings/Meetings.UI/Meetings.UI.csproj

------
https://chatgpt.com/codex/tasks/task_e_68fa2dbd8410832f9b5bfc2ccc3826e5