### PR TITLE
Add meeting adjourn and resume workflow

### DIFF
--- a/src/Executive/Meetings/Meetings.Client/OpenAPIs/swagger.yaml
+++ b/src/Executive/Meetings/Meetings.Client/OpenAPIs/swagger.yaml
@@ -912,6 +912,84 @@ paths:
                 $ref: '#/components/schemas/ProblemDetails'
       security:
       - JWT: []
+  /v1/Meetings/{id}/Adjourn:
+    post:
+      tags:
+      - Meetings
+      operationId: Meetings_AdjournMeeting
+      parameters:
+      - name: organizationId
+        in: query
+        schema:
+          type: string
+        x-position: 1
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+        x-position: 2
+      requestBody:
+        x-name: request
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdjournMeeting'
+        required: true
+        x-position: 3
+      responses:
+        200:
+          description: ''
+        404:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+      security:
+      - JWT: []
+  /v1/Meetings/{id}/Resume:
+    post:
+      tags:
+      - Meetings
+      operationId: Meetings_ResumeMeeting
+      parameters:
+      - name: organizationId
+        in: query
+        schema:
+          type: string
+        x-position: 1
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+        x-position: 2
+      responses:
+        200:
+          description: ''
+        404:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+      security:
+      - JWT: []
   /v1/Meetings/{id}/Agenda:
     get:
       tags:
@@ -3901,6 +3979,13 @@ components:
           nullable: true
         location:
           type: string
+        adjournmentMessage:
+          type: string
+          nullable: true
+        adjournedAt:
+          type: string
+          format: date-time
+          nullable: true
         quorum:
           $ref: '#/components/schemas/MeetingQuorum'
         attendees:
@@ -3926,6 +4011,7 @@ components:
       - Draft
       - Scheduled
       - InProgress
+      - Adjourned
       - Completed
       - Canceled
       enum:
@@ -3934,6 +4020,7 @@ components:
       - 2
       - 3
       - 4
+      - 5
     MeetingQuorum:
       type: object
       additionalProperties: false
@@ -4058,6 +4145,14 @@ components:
       properties:
         state:
           $ref: '#/components/schemas/MeetingState'
+    AdjournMeeting:
+      type: object
+      additionalProperties: false
+      properties:
+        message:
+          type: string
+      required:
+      - message
     PagedResultOfMeetingAttendee:
       type: object
       additionalProperties: false

--- a/src/Executive/Meetings/Meetings.Shared/IMeetingsProcedureHubClient.cs
+++ b/src/Executive/Meetings/Meetings.Shared/IMeetingsProcedureHubClient.cs
@@ -4,7 +4,7 @@ namespace YourBrand.Meetings;
 
 public interface IMeetingsProcedureHubClient : IVotingHubClient, IElectionsHubClient, IDiscussionsHubClient
 {
-    Task OnMeetingStateChanged(MeetingState state);
+    Task OnMeetingStateChanged(MeetingState state, string? adjournmentMessage);
 
     Task OnAgendaUpdated();
 

--- a/src/Executive/Meetings/Meetings.Shared/OpenAPIs/swagger.yaml
+++ b/src/Executive/Meetings/Meetings.Shared/OpenAPIs/swagger.yaml
@@ -912,6 +912,84 @@ paths:
                 $ref: '#/components/schemas/ProblemDetails'
       security:
       - JWT: []
+  /v1/Meetings/{id}/Adjourn:
+    post:
+      tags:
+      - Meetings
+      operationId: Meetings_AdjournMeeting
+      parameters:
+      - name: organizationId
+        in: query
+        schema:
+          type: string
+        x-position: 1
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+        x-position: 2
+      requestBody:
+        x-name: request
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdjournMeeting'
+        required: true
+        x-position: 3
+      responses:
+        200:
+          description: ''
+        404:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+      security:
+      - JWT: []
+  /v1/Meetings/{id}/Resume:
+    post:
+      tags:
+      - Meetings
+      operationId: Meetings_ResumeMeeting
+      parameters:
+      - name: organizationId
+        in: query
+        schema:
+          type: string
+        x-position: 1
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+        x-position: 2
+      responses:
+        200:
+          description: ''
+        404:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+      security:
+      - JWT: []
   /v1/Meetings/{id}/Agenda:
     get:
       tags:
@@ -3901,6 +3979,13 @@ components:
           nullable: true
         location:
           type: string
+        adjournmentMessage:
+          type: string
+          nullable: true
+        adjournedAt:
+          type: string
+          format: date-time
+          nullable: true
         quorum:
           $ref: '#/components/schemas/MeetingQuorum'
         attendees:
@@ -3926,6 +4011,7 @@ components:
       - Draft
       - Scheduled
       - InProgress
+      - Adjourned
       - Completed
       - Canceled
       enum:
@@ -3934,6 +4020,7 @@ components:
       - 2
       - 3
       - 4
+      - 5
     MeetingQuorum:
       type: object
       additionalProperties: false
@@ -4058,6 +4145,14 @@ components:
       properties:
         state:
           $ref: '#/components/schemas/MeetingState'
+    AdjournMeeting:
+      type: object
+      additionalProperties: false
+      properties:
+        message:
+          type: string
+      required:
+      - message
     PagedResultOfMeetingAttendee:
       type: object
       additionalProperties: false

--- a/src/Executive/Meetings/Meetings.UI/MeetingDetails/MeetingDetailsPage.razor
+++ b/src/Executive/Meetings/Meetings.UI/MeetingDetails/MeetingDetailsPage.razor
@@ -40,7 +40,7 @@
                     For="@(() => QuorumRequiredNumber)" Immediate="true" HelperText="Required number of attendees"  />
                 <MudSelect T="MeetingState" Label="State" Variant="Variant.Outlined" @bind-Value="State" Immediate="true"
                     Class="mt-4">
-                    @foreach (var state in Enum.GetValues<MeetingState>())
+                    @foreach (var state in Enum.GetValues<MeetingState>().Where(s => s != MeetingState.Adjourned))
                     {
                         <MudSelectItem T="MeetingState" Value="@state">@Enum.GetName(typeof(MeetingState), state)</MudSelectItem>
                     }

--- a/src/Executive/Meetings/Meetings.UI/Procedure/AdjournMeetingDialog.razor
+++ b/src/Executive/Meetings/Meetings.UI/Procedure/AdjournMeetingDialog.razor
@@ -1,0 +1,40 @@
+@using System.ComponentModel.DataAnnotations
+
+<MudDialog>
+    <DialogContent>
+        <MudText Typo="Typo.h6" GutterBottom="true">Confirm adjournment</MudText>
+        <MudText Typo="Typo.body2" GutterBottom="true">
+            Provide a message that will be shown to attendees while the meeting is adjourned.
+        </MudText>
+
+        <EditForm Model="this" OnValidSubmit="SubmitAsync">
+            <DataAnnotationsValidator />
+            <MudTextField Label="Message" @bind-Value="AdjournmentMessage" Lines="4" Required="true" Immediate="true" />
+        </EditForm>
+    </DialogContent>
+    <DialogActions>
+        <MudButton Variant="Variant.Text" Color="Color.Secondary" OnClick="Cancel">Cancel</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="SubmitAsync" Disabled="string.IsNullOrWhiteSpace(AdjournmentMessage)">Adjourn</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter]
+    private MudDialogInstance MudDialog { get; set; } = null!;
+
+    [Required]
+    public string AdjournmentMessage { get; set; } = string.Empty;
+
+    private void Cancel() => MudDialog.Cancel();
+
+    private Task SubmitAsync()
+    {
+        if(string.IsNullOrWhiteSpace(AdjournmentMessage))
+        {
+            return Task.CompletedTask;
+        }
+
+        MudDialog.Close(DialogResult.Ok(AdjournmentMessage.Trim()));
+        return Task.CompletedTask;
+    }
+}

--- a/src/Executive/Meetings/Meetings.UI/Procedure/AttendeePage.razor
+++ b/src/Executive/Meetings/Meetings.UI/Procedure/AttendeePage.razor
@@ -53,6 +53,15 @@ else
                         <MudText Typo="@Typo.body1" GutterBottom="true">@currentAgendaItem.State</MudText>
                     }
                 }
+                else if (meeting.State == MeetingState.Adjourned)
+                {
+                    <MudText Typo="@Typo.body1" GutterBottom="true">Meeting is adjourned</MudText>
+
+                    @if (!string.IsNullOrWhiteSpace(meeting.AdjournmentMessage))
+                    {
+                        <MudAlert Severity="Severity.Info" Variant="Variant.Filled">@meeting.AdjournmentMessage</MudAlert>
+                    }
+                }
                 else if (meeting.State == MeetingState.Completed)
                 {
                     <MudText Typo="@Typo.body1" GutterBottom="true">Meeting has concluded</MudText>

--- a/src/Executive/Meetings/Meetings.UI/Procedure/AttendeePage.razor.cs
+++ b/src/Executive/Meetings/Meetings.UI/Procedure/AttendeePage.razor.cs
@@ -162,7 +162,7 @@ public partial class AttendeePage : IMeetingsProcedureHubClient
         OrganizationProvider.CurrentOrganizationChanged -= OnCurrentOrganizationChanged;
     }
 
-    public async Task OnMeetingStateChanged(MeetingState state)
+    public async Task OnMeetingStateChanged(MeetingState state, string? adjournmentMessage)
     {
         meeting = await MeetingsClient.GetMeetingByIdAsync(organization.Id, MeetingId);
 

--- a/src/Executive/Meetings/Meetings.UI/Procedure/ControlPage.razor
+++ b/src/Executive/Meetings/Meetings.UI/Procedure/ControlPage.razor
@@ -64,13 +64,27 @@ else
                                     <MudButton Variant="Variant.Filled" Color="Color.Primary" Class="me-2" OnClick="MoveToNextAgendaItem"
                                         Disabled="@(lastItem || currentAgendaItem?.State == AgendaItemState.Pending)">Next Agenda Item</MudButton>
                                     <MudButton Variant="Variant.Filled" Color="Color.Primary" Class="me-2"  OnClick="ResetProcedure">Reset procedure</MudButton>
+                                    <MudButton Variant="Variant.Filled" Color="Color.Warning" OnClick="AdjournMeeting">Adjourn</MudButton>
                                 </div>
                                 <div>
                                     <MudButton Variant="Variant.Filled" Color="Color.Secondary" Class="me-2" OnClick="EndMeeting"
                                         Disabled="@(!lastItem || currentAgendaItem?.State != AgendaItemState.Completed)">End Meeting</MudButton>
-                                    <MudButton Variant="Variant.Filled" Color="Color.Secondary" Class="me-2" OnClick="CancelMeeting" 
+                                    <MudButton Variant="Variant.Filled" Color="Color.Secondary" Class="me-2" OnClick="CancelMeeting"
                                         Disabled="@(lastItem && currentAgendaItem?.State == AgendaItemState.Completed)">Cancel Meeting</MudButton>
                                 </div>
+                            </div>
+                        }
+                        else if (meeting.State == MeetingState.Adjourned)
+                        {
+                            <div class="d-flex flex-column flex-grow-1 gap-2">
+                                <MudText Typo="Typo.subtitle1">The meeting is currently adjourned.</MudText>
+
+                                @if (!string.IsNullOrWhiteSpace(meeting.AdjournmentMessage))
+                                {
+                                    <MudAlert Severity="Severity.Info" Variant="Variant.Filled">@meeting.AdjournmentMessage</MudAlert>
+                                }
+
+                                <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="ResumeMeeting">Resume meeting</MudButton>
                             </div>
                         }
                         else if (meeting.State == MeetingState.Completed)
@@ -564,12 +578,37 @@ else
     {
         var r = await DialogService.ShowMessageBox("Cancel the meeting?", "This can't be undone.", "Yes", "No");
 
-        if(!r.GetValueOrDefault()) 
+        if(!r.GetValueOrDefault())
         {
             return;
         }
 
         await MeetingsClient.CancelMeetingAsync(organization.Id, MeetingId);
+        await LoadMeetingDetails();
+    }
+
+    private async Task AdjournMeeting()
+    {
+        var dialog = await DialogService.ShowAsync<AdjournMeetingDialog>("Adjourn meeting");
+
+        var result = await dialog.Result;
+
+        if(result.Canceled)
+        {
+            return;
+        }
+
+        var message = (string)result.Data!;
+
+        await MeetingsClient.AdjournMeetingAsync(organization.Id, MeetingId, new global::YourBrand.Meetings.AdjournMeeting { Message = message });
+
+        await LoadMeetingDetails();
+    }
+
+    private async Task ResumeMeeting()
+    {
+        await MeetingsClient.ResumeMeetingAsync(organization.Id, MeetingId);
+
         await LoadMeetingDetails();
     }
 

--- a/src/Executive/Meetings/Meetings.UI/Procedure/DisplayPage.razor
+++ b/src/Executive/Meetings/Meetings.UI/Procedure/DisplayPage.razor
@@ -46,6 +46,15 @@ else
                         <MudText Typo="@Typo.body1" GutterBottom="true">@agendaItem.State</MudText>
                     }
                 }
+                else if (meeting.State == MeetingState.Adjourned)
+                {
+                    <MudText Typo="@Typo.body1" GutterBottom="true">Meeting is adjourned</MudText>
+
+                    @if (!string.IsNullOrWhiteSpace(meeting.AdjournmentMessage))
+                    {
+                        <MudAlert Severity="Severity.Info" Variant="Variant.Filled">@meeting.AdjournmentMessage</MudAlert>
+                    }
+                }
                 else if (meeting.State == MeetingState.Completed)
                 {
                     <MudText Typo="@Typo.body1" GutterBottom="true">Meeting has concluded</MudText>

--- a/src/Executive/Meetings/Meetings.UI/Procedure/DisplayPage.razor.cs
+++ b/src/Executive/Meetings/Meetings.UI/Procedure/DisplayPage.razor.cs
@@ -158,16 +158,20 @@ public partial class DisplayPage : IMeetingsProcedureHubClient
         OrganizationProvider.CurrentOrganizationChanged -= OnCurrentOrganizationChanged;
     }
 
-    public Task OnMeetingStateChanged(MeetingState state)
+    public async Task OnMeetingStateChanged(MeetingState state, string? adjournmentMessage)
     {
+        meeting = await MeetingsClient.GetMeetingByIdAsync(organization.Id, MeetingId);
+
         if (state == MeetingState.Scheduled || state == MeetingState.Canceled || state == MeetingState.Completed)
         {
             agendaItem = null;
         }
+        else if (meeting?.CurrentAgendaItemIndex is not null)
+        {
+            await LoadAgendaItem();
+        }
 
         StateHasChanged();
-
-        return Task.CompletedTask;
     }
 
     public async Task OnAgendaItemStateChanged(string agendaItemId, AgendaItemState state)

--- a/src/Executive/Meetings/Meetings.UI/_Imports.razor
+++ b/src/Executive/Meetings/Meetings.UI/_Imports.razor
@@ -1,5 +1,6 @@
 ﻿@using System.Net.Http
 @using System.Net.Http.Json
+@using System.Linq
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web

--- a/src/Executive/Meetings/Meetings/Domain/Errors/Errors.cs
+++ b/src/Executive/Meetings/Meetings/Domain/Errors/Errors.cs
@@ -38,6 +38,10 @@ public static partial class Errors
 
         public static readonly Error OnlyChairpersonCanEndTheMeeting = new Error(nameof(OnlyChairpersonCanEndTheMeeting), "Only the chairperson can end the meeting.", string.Empty);
 
+        public static readonly Error OnlyChairpersonCanAdjournTheMeeting = new Error(nameof(OnlyChairpersonCanAdjournTheMeeting), "Only the chairperson can adjourn the meeting.", string.Empty);
+
+        public static readonly Error OnlyChairpersonCanResumeTheMeeting = new Error(nameof(OnlyChairpersonCanResumeTheMeeting), "Only the chairperson can resume the meeting.", string.Empty);
+
         public static readonly Error OnlyChairpersonCanResetTheMeetingProcedure = new Error(nameof(OnlyChairpersonCanResetTheMeetingProcedure), "Only the chairperson can reset the meeting procedure.", string.Empty);
 
         public static readonly Error OnlyChairpersonCanStartDiscussion = new Error(nameof(OnlyChairpersonCanStartDiscussion), "Only the Chairperson can start a discussion.", string.Empty);

--- a/src/Executive/Meetings/Meetings/Features/Commands/ChangeMeetingState.cs
+++ b/src/Executive/Meetings/Meetings/Features/Commands/ChangeMeetingState.cs
@@ -33,6 +33,11 @@ public record ChangeMeetingState(string OrganizationId, int Id, MeetingState New
 
             meeting.State = request.NewState;
 
+            if (meeting.State != MeetingState.Adjourned)
+            {
+                meeting.ClearAdjournment();
+            }
+
             context.Meetings.Update(meeting);
 
             await context.SaveChangesAsync(cancellationToken);

--- a/src/Executive/Meetings/Meetings/Features/Mapper.cs
+++ b/src/Executive/Meetings/Meetings/Features/Mapper.cs
@@ -7,7 +7,8 @@ namespace YourBrand.Meetings.Features;
 public static partial class Mappings
 {
     public static MeetingDto ToDto(this Meeting meeting) => 
-        new(meeting.Id, meeting.Title!, meeting.Description, meeting.State, meeting.ScheduledAt, meeting.Location, meeting.Quorum.ToDto(), 
+        new(meeting.Id, meeting.Title!, meeting.Description, meeting.State, meeting.ScheduledAt, meeting.Location,
+        meeting.AdjournmentMessage, meeting.AdjournedAt, meeting.Quorum.ToDto(),
         meeting.Attendees.Select(x => x.ToDto()), meeting.CurrentAgendaItemIndex, meeting.CurrentAgendaSubItemIndex, PrepareActions(meeting));
 
     private static IDictionary<string, DtoAction> PrepareActions(Meeting meeting)
@@ -32,6 +33,16 @@ public static partial class Mappings
         if (meeting.CanEnd)
         {
             actions.Add("end", new DtoAction("POST", $"/v1/Meetings/{meeting.Id}/End"));
+        }
+
+        if (meeting.State == MeetingState.InProgress)
+        {
+            actions.Add("adjourn", new DtoAction("POST", $"/v1/Meetings/{meeting.Id}/Adjourn"));
+        }
+
+        if (meeting.State == MeetingState.Adjourned)
+        {
+            actions.Add("resume", new DtoAction("POST", $"/v1/Meetings/{meeting.Id}/Resume"));
         }
 
         return actions;

--- a/src/Executive/Meetings/Meetings/Features/MeetingsController.cs
+++ b/src/Executive/Meetings/Meetings/Features/MeetingsController.cs
@@ -27,6 +27,8 @@ public sealed record ChangeMeetingQuorumDto(int RequiredNumber);
 
 public sealed record ChangeMeetingStateDto(MeetingState State);
 
+public sealed record AdjournMeetingDto(string Message);
+
 public sealed record AddMeetingAttendeeDto(string Name, string? UserId, string Email, int Role, bool? HasSpeakingRights, bool? HasVotingRights);
 
 public sealed record EditMeetingAttendeeDto(string Name, string? UserId, string Email, int Role, bool? HasSpeakingRights, bool? HasVotingRights);
@@ -197,6 +199,26 @@ public sealed partial class MeetingsController(IMediator mediator) : ControllerB
     public async Task<ActionResult> StartMeeting([FromQuery] string organizationId, int id, CancellationToken cancellationToken)
     {
         var result = await mediator.Send(new StartMeeting(organizationId, id), cancellationToken);
+        return this.HandleResult(result);
+    }
+
+    [HttpPost("{id}/Adjourn")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
+    [ProducesDefaultResponseType]
+    public async Task<ActionResult> AdjournMeeting([FromQuery] string organizationId, int id, AdjournMeetingDto request, CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new AdjournMeeting(organizationId, id, request.Message), cancellationToken);
+        return this.HandleResult(result);
+    }
+
+    [HttpPost("{id}/Resume")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
+    [ProducesDefaultResponseType]
+    public async Task<ActionResult> ResumeMeeting([FromQuery] string organizationId, int id, CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new ResumeMeeting(organizationId, id), cancellationToken);
         return this.HandleResult(result);
     }
 

--- a/src/Executive/Meetings/Meetings/Features/MeetingsDto.cs
+++ b/src/Executive/Meetings/Meetings/Features/MeetingsDto.cs
@@ -1,7 +1,7 @@
 namespace YourBrand.Meetings.Features;
 
-public sealed record MeetingDto(int Id, string Title, string? Description, MeetingState State, DateTimeOffset? ScheduledAt, string Location, 
-    MeetingQuorumDto Quorum, IEnumerable<MeetingAttendeeDto> Attendees, int? CurrentAgendaItemIndex, int? CurrentAgendaSubItemIndex,
+public sealed record MeetingDto(int Id, string Title, string? Description, MeetingState State, DateTimeOffset? ScheduledAt, string Location,
+    string? AdjournmentMessage, DateTimeOffset? AdjournedAt, MeetingQuorumDto Quorum, IEnumerable<MeetingAttendeeDto> Attendees, int? CurrentAgendaItemIndex, int? CurrentAgendaSubItemIndex,
     IDictionary<string, DtoAction> Actions);
 
 public sealed record MeetingQuorumDto(int RequiredNumber);

--- a/src/Executive/Meetings/Meetings/Features/Procedure/AdjournMeeting.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/AdjournMeeting.cs
@@ -1,0 +1,60 @@
+using FluentValidation;
+
+using MediatR;
+
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Identity;
+
+namespace YourBrand.Meetings.Features.Procedure.Command;
+
+public sealed record AdjournMeeting(string OrganizationId, int Id, string Message) : IRequest<Result>
+{
+    public sealed class Validator : AbstractValidator<AdjournMeeting>
+    {
+        public Validator()
+        {
+            RuleFor(x => x.Message).NotEmpty();
+        }
+    }
+
+    public sealed class Handler(IApplicationDbContext context, IUserContext userContext, IHubContext<MeetingsProcedureHub, IMeetingsProcedureHubClient> hubContext) : IRequestHandler<AdjournMeeting, Result>
+    {
+        public async Task<Result> Handle(AdjournMeeting request, CancellationToken cancellationToken)
+        {
+            var meeting = await context.Meetings
+                .InOrganization(request.OrganizationId)
+                .FirstOrDefaultAsync(x => x.Id == request.Id, cancellationToken);
+
+            if (meeting is null)
+            {
+                return Errors.Meetings.MeetingNotFound;
+            }
+
+            var attendee = meeting.GetAttendeeByUserId(userContext.UserId);
+
+            if (attendee is null)
+            {
+                return Errors.Meetings.YouAreNotAttendeeOfMeeting;
+            }
+
+            if (attendee.Role != AttendeeRole.Chairperson)
+            {
+                return Errors.Meetings.OnlyChairpersonCanAdjournTheMeeting;
+            }
+
+            meeting.AdjournMeeting(request.Message.Trim());
+
+            context.Meetings.Update(meeting);
+
+            await context.SaveChangesAsync(cancellationToken);
+
+            await hubContext.Clients
+                .Group($"meeting-{meeting.Id}")
+                .OnMeetingStateChanged((Dtos.MeetingState)meeting.State, meeting.AdjournmentMessage);
+
+            return Result.Success;
+        }
+    }
+}

--- a/src/Executive/Meetings/Meetings/Features/Procedure/CancelMeeting.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/CancelMeeting.cs
@@ -42,7 +42,7 @@ public sealed record CancelMeeting(string OrganizationId, int Id) : IRequest<Res
 
             await hubContext.Clients
                 .Group($"meeting-{meeting.Id}")
-                .OnMeetingStateChanged((Dtos.MeetingState)meeting.State);
+                .OnMeetingStateChanged((Dtos.MeetingState)meeting.State, meeting.AdjournmentMessage);
 
             return Result.Success;
         }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/EndMeeting.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/EndMeeting.cs
@@ -42,7 +42,7 @@ public sealed record EndMeeting(string OrganizationId, int Id) : IRequest<Result
 
             await hubContext.Clients
                 .Group($"meeting-{meeting.Id}")
-                .OnMeetingStateChanged((Dtos.MeetingState)meeting.State);
+                .OnMeetingStateChanged((Dtos.MeetingState)meeting.State, meeting.AdjournmentMessage);
 
             return Result.Success;
         }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/ResetMeetingProcedure.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/ResetMeetingProcedure.cs
@@ -54,7 +54,7 @@ public record ResetMeetingProcedure(string OrganizationId, int Id) : IRequest<Re
 
             await hubContext.Clients
                 .Group($"meeting-{meeting.Id}")
-                .OnMeetingStateChanged((Dtos.MeetingState)meeting.State);
+                .OnMeetingStateChanged((Dtos.MeetingState)meeting.State, meeting.AdjournmentMessage);
 
             return meeting.ToDto();
         }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/ResumeMeeting.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/ResumeMeeting.cs
@@ -1,0 +1,50 @@
+using MediatR;
+
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Identity;
+
+namespace YourBrand.Meetings.Features.Procedure.Command;
+
+public sealed record ResumeMeeting(string OrganizationId, int Id) : IRequest<Result>
+{
+    public sealed class Handler(IApplicationDbContext context, IUserContext userContext, IHubContext<MeetingsProcedureHub, IMeetingsProcedureHubClient> hubContext) : IRequestHandler<ResumeMeeting, Result>
+    {
+        public async Task<Result> Handle(ResumeMeeting request, CancellationToken cancellationToken)
+        {
+            var meeting = await context.Meetings
+                .InOrganization(request.OrganizationId)
+                .FirstOrDefaultAsync(x => x.Id == request.Id, cancellationToken);
+
+            if (meeting is null)
+            {
+                return Errors.Meetings.MeetingNotFound;
+            }
+
+            var attendee = meeting.GetAttendeeByUserId(userContext.UserId);
+
+            if (attendee is null)
+            {
+                return Errors.Meetings.YouAreNotAttendeeOfMeeting;
+            }
+
+            if (attendee.Role != AttendeeRole.Chairperson)
+            {
+                return Errors.Meetings.OnlyChairpersonCanResumeTheMeeting;
+            }
+
+            meeting.ResumeMeeting();
+
+            context.Meetings.Update(meeting);
+
+            await context.SaveChangesAsync(cancellationToken);
+
+            await hubContext.Clients
+                .Group($"meeting-{meeting.Id}")
+                .OnMeetingStateChanged((Dtos.MeetingState)meeting.State, meeting.AdjournmentMessage);
+
+            return Result.Success;
+        }
+    }
+}

--- a/src/Executive/Meetings/Meetings/Features/Procedure/StartMeeting.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/StartMeeting.cs
@@ -42,7 +42,7 @@ public sealed record StartMeeting(string OrganizationId, int Id) : IRequest<Resu
 
             await hubContext.Clients
                 .Group($"meeting-{meeting.Id}")
-                .OnMeetingStateChanged((Dtos.MeetingState)meeting.State);
+                .OnMeetingStateChanged((Dtos.MeetingState)meeting.State, meeting.AdjournmentMessage);
 
             await hubContext.Clients
                 .Group($"meeting-{meeting.Id}")

--- a/src/Executive/Meetings/Meetings/Infrastructure/Persistence/Configurations/MeetingConfiguration.cs
+++ b/src/Executive/Meetings/Meetings/Infrastructure/Persistence/Configurations/MeetingConfiguration.cs
@@ -34,6 +34,9 @@ public sealed class MeetingConfiguration : IEntityTypeConfiguration<Meeting>
 
         builder.OwnsOne(x => x.Quorum);
 
+        builder.Property(x => x.AdjournmentMessage)
+            .HasMaxLength(1024);
+
         builder.HasOne(x => x.CreatedBy)
             .WithMany()
             .OnDelete(DeleteBehavior.NoAction);


### PR DESCRIPTION
## Summary
- extend meetings domain to support adjourned state with message metadata
- expose adjourn and resume endpoints plus hub notifications and DTO/action updates
- add chairman dialog and attendee/display messaging for adjourned meetings

## Testing
- `dotnet build src/Executive/Meetings/Meetings/Meetings.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68fa4b021858832f8245f05f614b5014