### PR TITLE
Add secretary minutes workspace

### DIFF
--- a/src/Executive/Meetings/Meetings.UI/MeetingDetails/MeetingDetailsPage.razor
+++ b/src/Executive/Meetings/Meetings.UI/MeetingDetails/MeetingDetailsPage.razor
@@ -2,10 +2,11 @@
 
 @using System
 @using System.ComponentModel.DataAnnotations
-@using YourBrand.Meetings.Components
+@using YourBrand.Meetings.Dtos
 @using YourBrand.Meetings.MeetingDetails.Agenda
 @using YourBrand.Portal.Services
 @inject IMeetingsClient MeetingsClient
+@inject IMinutesClient MinutesClient
 @inject IChairmanClient ChairmanClient
 @inject ISnackbar Snackbar
 @inject IDialogService DialogService
@@ -129,6 +130,17 @@
 
     <MudButton Variant="Variant.Filled" Color="Color.Primary" Href="@($"/meetings/{Id}/attendee")" Class="ms-2 mb-4">Attendee</MudButton>
 
+    @if (MinutesId is not null)
+    {
+        <MudButton Variant="Variant.Filled" Color="Color.Info" Href="@($"/meetings/minutes/{MinutesId}/secretary")" Class="ms-2 mb-4">Secretary minutes</MudButton>
+    }
+    else
+    {
+        <MudTooltip Text="Create minutes to enable the secretary workspace">
+            <MudButton Variant="Variant.Filled" Color="Color.Info" Disabled="true" Class="ms-2 mb-4">Secretary minutes</MudButton>
+        </MudTooltip>
+    }
+
     <MudButton Variant="Variant.Filled" Color="Color.Secondary" OnClick="ResetMeetingProcedure" Class="ms-2 mb-4">Reset</MudButton>
 </MudPaper>
 
@@ -164,6 +176,8 @@
     public int QuorumRequiredNumber { get; set; }
 
     public MeetingState State { get; set; }
+
+    public int? MinutesId { get; set; }
 
     public bool ShowAgendaTimeEstimates { get; set; }
 
@@ -220,10 +234,31 @@
                 IsPresent = attendee.IsPresent
             }));
     
+        await LoadMinutes();
+
         context.OnFieldChanged += OnFieldChanged;
         context.MarkAsUnmodified();
 
         isDetailsModified = false;
+    }
+
+    private async Task LoadMinutes()
+    {
+        if (organization is null)
+        {
+            MinutesId = null;
+            return;
+        }
+
+        try
+        {
+            var result = await MinutesClient.GetMinutesAsync(organization.Id, Id, 1, 1, null, null, null);
+            MinutesId = result.Items.FirstOrDefault()?.Id;
+        }
+        catch (ApiException)
+        {
+            MinutesId = null;
+        }
     }
 
     bool isDetailsModified = false;
@@ -455,7 +490,7 @@
         OrganizationProvider.CurrentOrganizationChanged -= OnCurrentOrganizationChanged;
     }
 
-    async Task ResetMeetingProcedure() 
+    async Task ResetMeetingProcedure()
     {
         await ChairmanClient.ResetMeetingProcedureAsync(organization.Id, Id);
 
@@ -465,9 +500,8 @@
 
         Snackbar.Add("Procedure was reset");
     }
-}
 
-    private static AttendeeRole CreateJoinRoleOrDefault(AttendeeRoleDto? roleDto)
+    private static AttendeeRole CreateJoinRoleOrDefault(AttendeeRole? roleDto)
     {
         if (roleDto is null || !IsAllowedOpenAccessRole(roleDto.Name))
         {
@@ -485,3 +519,4 @@
     private static bool IsAllowedOpenAccessRole(string? roleName) =>
         string.Equals(roleName, "Observer", StringComparison.OrdinalIgnoreCase)
             || string.Equals(roleName, "Attendee", StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Executive/Meetings/Meetings.UI/Minutes/Secretary/SecretaryMinutesItemViewModel.cs
+++ b/src/Executive/Meetings/Meetings.UI/Minutes/Secretary/SecretaryMinutesItemViewModel.cs
@@ -1,0 +1,66 @@
+using YourBrand.Meetings;
+
+namespace YourBrand.Meetings.Minutes.Secretary;
+
+public class SecretaryMinutesItemViewModel
+{
+    public string Id { get; set; } = null!;
+
+    public int Order { get; set; }
+
+    public AgendaItemType Type { get; set; } = default!;
+
+    public string Title { get; set; } = string.Empty;
+
+    public MinutesItemState State { get; set; }
+
+    public string Description { get; set; } = string.Empty;
+
+    public string ServerDescription { get; private set; } = string.Empty;
+
+    public int? AgendaId { get; set; }
+
+    public string? AgendaItemId { get; set; }
+
+    public int? MotionId { get; set; }
+
+    public bool IsSaving { get; set; }
+
+    public bool HasChanges => Description != ServerDescription;
+
+    public void UpdateFrom(MinutesItem item)
+    {
+        Order = item.Order;
+        Type = item.Type;
+        Title = item.Title ?? string.Empty;
+        State = item.State;
+        AgendaId = item.AgendaId;
+        AgendaItemId = item.AgendaItemId;
+        MotionId = item.MotionId;
+
+        ApplyServerDescription(item.Description ?? string.Empty);
+    }
+
+    public void ApplyServerDescription(string description)
+    {
+        var normalized = description ?? string.Empty;
+        var hadChanges = Description != ServerDescription;
+
+        ServerDescription = normalized;
+
+        if (!hadChanges)
+        {
+            Description = normalized;
+        }
+    }
+
+    public void AcceptChanges()
+    {
+        ServerDescription = Description;
+    }
+
+    public void ResetChanges()
+    {
+        Description = ServerDescription;
+    }
+}

--- a/src/Executive/Meetings/Meetings.UI/Minutes/Secretary/SecretaryMinutesPage.razor
+++ b/src/Executive/Meetings/Meetings.UI/Minutes/Secretary/SecretaryMinutesPage.razor
@@ -1,0 +1,460 @@
+@page "/meetings/minutes/{id:int}/secretary"
+
+@using Microsoft.AspNetCore.SignalR.Client
+@using YourBrand.Meetings.Minutes.Secretary
+@using YourBrand.Portal.Services
+@inject IMinutesClient MinutesClient
+@inject IMeetingsClient MeetingsClient
+@inject YourBrand.Portal.Services.IAccessTokenProvider AccessTokenProvider
+@inject IOrganizationProvider OrganizationProvider
+@inject ISnackbar Snackbar
+@inject NavigationManager NavigationManager
+
+@implements ISecretaryHubClient
+@implements IDisposable
+
+<AppPageTitle>Secretary minutes</AppPageTitle>
+
+@if (isLoading)
+{
+    <div class="d-flex justify-center mt-6">
+        <MudProgressCircular Size="Size.Large" Color="Color.Primary" Indeterminate="true" />
+    </div>
+}
+else if (!string.IsNullOrEmpty(loadError))
+{
+    <MudAlert Severity="Severity.Error" Elevation="25">@loadError</MudAlert>
+}
+else if (minutes is null)
+{
+    <MudAlert Severity="Severity.Warning" Elevation="25">
+        No minutes are available for this meeting yet. Create minutes to get started.
+    </MudAlert>
+}
+else
+{
+    <MudGrid Class="mb-4">
+        <MudItem xs="12" md="6">
+            <MudPaper Elevation="25" Class="pa-4 mb-4">
+                <MudText Typo="Typo.h4" GutterBottom="true">Meeting overview</MudText>
+
+                <MudText Typo="Typo.h5" Class="mb-2">@meeting?.Title</MudText>
+
+                <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
+                    @if (meeting is not null)
+                    {
+                        <MudChip T="string" Color="@GetMeetingStateColor(meeting.State)" Variant="Variant.Filled" Size="Size.Small">
+                            @meeting.State.ToString()
+                        </MudChip>
+                    }
+
+                    <MudChip T="string" Color="@GetMinutesStateColor(minutes.State)" Variant="Variant.Outlined" Size="Size.Small">
+                        @minutes.State.ToString()
+                    </MudChip>
+                </div>
+
+                @if (meeting?.ScheduledAt is not null)
+                {
+                    <MudText Typo="Typo.body2" Class="mb-1">
+                        <MudIcon Icon="@Icons.Material.Filled.Event" Class="me-1" />
+                        @meeting.ScheduledAt.Value.ToLocalTime().ToString("f")
+                    </MudText>
+                }
+
+                @if (!string.IsNullOrWhiteSpace(meeting?.Location))
+                {
+                    <MudText Typo="Typo.body2">
+                        <MudIcon Icon="@Icons.Material.Filled.Place" Class="me-1" />
+                        @meeting!.Location
+                    </MudText>
+                }
+            </MudPaper>
+        </MudItem>
+        <MudItem xs="12" md="6">
+            <MudPaper Elevation="25" Class="pa-4 mb-4">
+                <MudText Typo="Typo.h4" GutterBottom="true">Guidance</MudText>
+                <MudText Typo="Typo.body1">
+                    Use this workspace to capture the spoken details while the procedure is running. Agenda items, votes and
+                    other events are added automatically. Update the text for each item as the meeting progresses.
+                </MudText>
+            </MudPaper>
+        </MudItem>
+    </MudGrid>
+
+    <MudPaper Elevation="25" Class="pa-4">
+        <MudText Typo="Typo.h4" GutterBottom="true">Agenda items</MudText>
+
+        @if (MinutesItems.Count == 0)
+        {
+            <MudAlert Severity="Severity.Info" Elevation="0">Agenda items will appear here once the meeting starts working through the agenda.</MudAlert>
+        }
+        else
+        {
+            <div class="d-flex flex-column gap-4">
+                @foreach (var item in MinutesItems.OrderBy(x => x.Order))
+                {
+                    <MudPaper Elevation="1" Class="pa-4">
+                        <div class="d-flex flex-column flex-md-row justify-space-between align-items-start align-items-md-center gap-2">
+                            <div>
+                                <MudText Typo="Typo.subtitle1">@item.Title</MudText>
+                                <div class="d-flex align-items-center gap-2">
+                                    <MudChip T="string" Variant="Variant.Outlined" Color="Color.Primary" Size="Size.Small">@item.Type.Name</MudChip>
+                                    <MudChip T="string" Variant="Variant.Text" Color="@GetMinutesItemStateColor(item.State)" Size="Size.Small">@item.State</MudChip>
+                                    <MudText Typo="Typo.caption" Class="text-secondary">#@item.Order</MudText>
+                                </div>
+                            </div>
+                            <MudIconButton Icon="@Icons.Material.Filled.OpenInNew" Size="Size.Small" Color="Color.Primary"
+                                           Disabled="@string.IsNullOrEmpty(item.AgendaItemId)"
+                                           OnClick="() => NavigateToAgendaItem(item)"
+                                           AriaLabel="Open agenda item" />
+                        </div>
+
+                        <MudTextField @bind-Value="item.Description" Label="Notes" Variant="Variant.Outlined" Lines="6" Class="mt-3"
+                                      Disabled="item.IsSaving" Immediate="true" />
+
+                        <div class="d-flex justify-end gap-2 mt-2">
+                            <MudButton Variant="Variant.Text" Color="Color.Default" Disabled="@(!item.HasChanges || item.IsSaving)"
+                                       OnClick="() => ResetItem(item)">
+                                Reset
+                            </MudButton>
+                            <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!item.HasChanges || item.IsSaving)"
+                                       OnClick="async () => await SaveItemAsync(item)">
+                                @if (item.IsSaving)
+                                {
+                                    <MudProgressCircular Size="Size.Small" Class="me-2" Indeterminate="true" />
+                                }
+                                Save
+                            </MudButton>
+                        </div>
+                    </MudPaper>
+                }
+            </div>
+        }
+    </MudPaper>
+}
+
+@code {
+    [Parameter]
+    public int Id { get; set; }
+
+    private bool isLoading = true;
+    private string? loadError;
+
+    private Minutes? minutes;
+    private Meeting? meeting;
+
+    private List<SecretaryMinutesItemViewModel> MinutesItems { get; set; } = new();
+
+    private YourBrand.Portal.Services.Organization? organization;
+
+    private HubConnection? hubConnection;
+    private IDisposable? hubClientRegistration;
+    private int? hubMeetingId;
+    private bool disposed;
+
+    protected override async Task OnInitializedAsync()
+    {
+        organization = await OrganizationProvider.GetCurrentOrganizationAsync();
+
+        OrganizationProvider.CurrentOrganizationChanged += OnCurrentOrganizationChanged;
+
+        await RefreshMinutesAsync();
+
+        await EnsureHubConnectionAsync();
+
+        isLoading = false;
+
+        StateHasChanged();
+    }
+
+    private async Task RefreshMinutesAsync()
+    {
+        if (organization is null)
+        {
+            minutes = null;
+            MinutesItems.Clear();
+            return;
+        }
+
+        try
+        {
+            var response = await MinutesClient.GetMinutesByIdAsync(organization.Id, Id);
+            minutes = response;
+
+            MergeMinutesItems(response.Items);
+
+            if (meeting is null || meeting.Id != response.MeetingId)
+            {
+                meeting = await MeetingsClient.GetMeetingByIdAsync(organization.Id, response.MeetingId);
+            }
+
+            loadError = null;
+        }
+        catch (ApiException ex)
+        {
+            loadError = ex.Message;
+            Snackbar.Add($"Failed to load minutes: {ex.Message}", Severity.Error);
+            minutes = null;
+            MinutesItems.Clear();
+        }
+        catch (Exception ex)
+        {
+            loadError = ex.Message;
+            Snackbar.Add($"Failed to load minutes: {ex.Message}", Severity.Error);
+            minutes = null;
+            MinutesItems.Clear();
+        }
+
+        if (minutes is null && hubConnection is not null)
+        {
+            hubClientRegistration?.Dispose();
+            hubClientRegistration = null;
+            hubMeetingId = null;
+            await hubConnection.DisposeAsync();
+            hubConnection = null;
+        }
+
+    }
+
+    private async Task EnsureHubConnectionAsync()
+    {
+        if (minutes is null || organization is null)
+        {
+            return;
+        }
+
+        if (hubConnection is not null)
+        {
+            if (hubMeetingId == minutes.MeetingId)
+            {
+                if (hubConnection.State == HubConnectionState.Disconnected)
+                {
+                    await hubConnection.StartAsync();
+                }
+
+                return;
+            }
+
+            hubClientRegistration?.Dispose();
+            await hubConnection.DisposeAsync();
+            hubConnection = null;
+        }
+
+        hubMeetingId = minutes.MeetingId;
+
+        hubConnection = new HubConnectionBuilder()
+            .WithUrl($"{NavigationManager.BaseUri}api/meetings/hubs/meetings/secretary/?organizationId={organization.Id}&meetingId={minutes.MeetingId}", options =>
+            {
+                options.AccessTokenProvider = async () => await AccessTokenProvider.GetAccessTokenAsync();
+            })
+            .WithAutomaticReconnect()
+            .Build();
+
+        hubConnection.Closed += HubConnectionOnClosed;
+        hubConnection.Reconnected += HubConnectionOnReconnected;
+        hubConnection.Reconnecting += HubConnectionOnReconnecting;
+
+        hubClientRegistration = hubConnection.ClientRegistration<ISecretaryHubClient>(this);
+
+        await hubConnection.StartAsync();
+    }
+
+    private Task HubConnectionOnClosed(Exception? error)
+    {
+        if (error is not null)
+        {
+            Snackbar.Add(error.Message, Severity.Error, configure: options =>
+            {
+                options.Icon = Icons.Material.Filled.Cable;
+            });
+        }
+
+        Snackbar.Add("Disconnected from secretary updates", Severity.Warning, configure: options =>
+        {
+            options.Icon = Icons.Material.Filled.Cable;
+        });
+
+        return Task.CompletedTask;
+    }
+
+    private Task HubConnectionOnReconnected(string? arg)
+    {
+        Snackbar.Add("Reconnected to secretary updates", Severity.Success, configure: options =>
+        {
+            options.Icon = Icons.Material.Filled.Cable;
+        });
+
+        return Task.CompletedTask;
+    }
+
+    private Task HubConnectionOnReconnecting(Exception? error)
+    {
+        Snackbar.Add("Reconnecting to secretary updates", Severity.Info, configure: options =>
+        {
+            options.Icon = Icons.Material.Filled.Cable;
+        });
+
+        return Task.CompletedTask;
+    }
+
+    private void MergeMinutesItems(IEnumerable<MinutesItem> items)
+    {
+        var existingById = MinutesItems.ToDictionary(x => x.Id, StringComparer.OrdinalIgnoreCase);
+        var updated = new List<SecretaryMinutesItemViewModel>();
+
+        foreach (var item in items.OrderBy(x => x.Order))
+        {
+            if (existingById.TryGetValue(item.Id, out var existing))
+            {
+                existing.UpdateFrom(item);
+                existing.IsSaving = false;
+                updated.Add(existing);
+            }
+            else
+            {
+                var vm = new SecretaryMinutesItemViewModel
+                {
+                    Id = item.Id
+                };
+
+                vm.UpdateFrom(item);
+                updated.Add(vm);
+            }
+        }
+
+        MinutesItems = updated;
+    }
+
+    private async Task SaveItemAsync(SecretaryMinutesItemViewModel item)
+    {
+        if (organization is null)
+        {
+            return;
+        }
+
+        item.IsSaving = true;
+        StateHasChanged();
+
+        try
+        {
+            var request = new EditMinutesItem
+            {
+                Type = item.Type.Id,
+                Title = item.Title,
+                Description = item.Description,
+                MotionId = item.MotionId
+            };
+
+            await MinutesClient.EditMinutesItemAsync(organization.Id, Id, item.Id, request);
+
+            item.AcceptChanges();
+            Snackbar.Add("Minutes updated", Severity.Success);
+        }
+        catch (ApiException ex)
+        {
+            Snackbar.Add($"Unable to save minutes: {ex.Message}", Severity.Error);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add($"Unable to save minutes: {ex.Message}", Severity.Error);
+        }
+        finally
+        {
+            item.IsSaving = false;
+            StateHasChanged();
+        }
+    }
+
+    private void ResetItem(SecretaryMinutesItemViewModel item)
+    {
+        item.ResetChanges();
+        StateHasChanged();
+    }
+
+    private void NavigateToAgendaItem(SecretaryMinutesItemViewModel item)
+    {
+        if (meeting is null || string.IsNullOrEmpty(item.AgendaItemId))
+        {
+            return;
+        }
+
+        NavigationManager.NavigateTo($"/meetings/{meeting.Id}#agenda-{item.AgendaItemId}");
+    }
+
+    private Color GetMinutesItemStateColor(MinutesItemState state) => state switch
+    {
+        MinutesItemState.Approved => Color.Success,
+        MinutesItemState.Reviewing => Color.Info,
+        _ => Color.Default
+    };
+
+    private Color GetMinutesStateColor(MinutesState state) => state switch
+    {
+        MinutesState.Approved => Color.Success,
+        MinutesState.UnderReview => Color.Info,
+        _ => Color.Default
+    };
+
+    private Color GetMeetingStateColor(MeetingState state) => state switch
+    {
+        MeetingState.InProgress => Color.Success,
+        MeetingState.Adjourned => Color.Warning,
+        MeetingState.Completed => Color.Secondary,
+        MeetingState.Canceled => Color.Error,
+        _ => Color.Default
+    };
+
+    public Task OnMinutesUpdated() => InvokeAsync(async () =>
+    {
+        await RefreshMinutesAsync();
+        StateHasChanged();
+    });
+
+    public Task OnMinutesItemChanged(string minutesItemId) => InvokeAsync(async () =>
+    {
+        await RefreshMinutesAsync();
+        StateHasChanged();
+    });
+
+    public Task OnMinutesItemStatusChanged(string minutesItemId) => InvokeAsync(async () =>
+    {
+        await RefreshMinutesAsync();
+        StateHasChanged();
+    });
+
+    private async void OnCurrentOrganizationChanged(object? sender, EventArgs args)
+    {
+        var newOrganization = await OrganizationProvider.GetCurrentOrganizationAsync();
+
+        await InvokeAsync(async () =>
+        {
+            organization = newOrganization;
+            isLoading = true;
+            minutes = null;
+            MinutesItems.Clear();
+            await RefreshMinutesAsync();
+            await EnsureHubConnectionAsync();
+            isLoading = false;
+            StateHasChanged();
+        });
+    }
+
+    public void Dispose()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        disposed = true;
+
+        OrganizationProvider.CurrentOrganizationChanged -= OnCurrentOrganizationChanged;
+
+        hubClientRegistration?.Dispose();
+
+        if (hubConnection is not null)
+        {
+            _ = hubConnection.DisposeAsync();
+        }
+    }
+}

--- a/src/Executive/Meetings/Meetings.UI/NewMeeting/NewMeetingPage.razor
+++ b/src/Executive/Meetings/Meetings.UI/NewMeeting/NewMeetingPage.razor
@@ -3,7 +3,6 @@
 @using System
 @using System.ComponentModel.DataAnnotations
 @using System.Linq
-@using YourBrand.Meetings.Components
 @using YourBrand.Portal.Services
 @inject IMeetingsClient MeetingsClient
 @inject IAttendeeRolesClient AttendeeRolesClient
@@ -229,8 +228,8 @@
     {
         OrganizationProvider.CurrentOrganizationChanged -= OnCurrentOrganizationChanged;
     }
-}
 
     private static bool IsAllowedOpenAccessRole(AttendeeRole role) =>
         string.Equals(role.Name, "Observer", StringComparison.OrdinalIgnoreCase)
             || string.Equals(role.Name, "Attendee", StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Executive/Meetings/Meetings/WebApplicationExtensions.cs
+++ b/src/Executive/Meetings/Meetings/WebApplicationExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using YourBrand.Meetings.Features.Procedure;
 using YourBrand.Meetings.Features.Procedure.Discussions;
+using YourBrand.Meetings.Features.Minutes;
 
 //using YourBrand.Meetings.Meetings;
 
@@ -10,6 +11,7 @@ public static class WebApplicationExtensions
     public static WebApplication MapHubsForApp(this WebApplication app)
     {
         app.MapHub<MeetingsProcedureHub>("/hubs/meetings/procedure");
+        app.MapHub<SecretaryHub>("/hubs/meetings/secretary");
         //app.MapHub<DiscussionsHub>("/hubs/meetings/discussions");
 
         return app;


### PR DESCRIPTION
## Summary
- add a secretary-facing minutes console that live-syncs minutes items and lets the secretary edit notes
- expose the secretary SignalR hub endpoint and link to the new workspace from meeting details
- tidy meeting creation/details helpers so minutes metadata can be loaded without namespace issues

## Testing
- dotnet build src/Executive/Meetings/Meetings.UI/Meetings.UI.csproj

------
https://chatgpt.com/codex/tasks/task_e_68fa6566775c832f86a1ab6e080ff425