### PR TITLE
Support meeting function elections and interim control

### DIFF
--- a/src/Executive/Meetings/Meetings.Client/OpenAPIs/swagger.yaml
+++ b/src/Executive/Meetings/Meetings.Client/OpenAPIs/swagger.yaml
@@ -4081,6 +4081,18 @@ components:
         description:
           type: string
           nullable: true
+    MeetingFunction:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: integer
+          format: int32
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
     PagedResultOfMeeting:
       type: object
       additionalProperties: false
@@ -4178,6 +4190,10 @@ components:
           type: string
         role:
           $ref: '#/components/schemas/AttendeeRole'
+        functions:
+          type: array
+          items:
+            $ref: '#/components/schemas/MeetingFunction'
         email:
           type: string
           nullable: true
@@ -4252,6 +4268,12 @@ components:
           nullable: true
         hasVotingRights:
           type: boolean
+          nullable: true
+        functionIds:
+          type: array
+          items:
+            type: integer
+            format: int32
           nullable: true
     UpdateMeetingTitle:
       type: object
@@ -4346,6 +4368,12 @@ components:
         hasVotingRights:
           type: boolean
           nullable: true
+        functionIds:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
     AddAttendeesFromGroup:
       type: object
       additionalProperties: false
@@ -4372,6 +4400,12 @@ components:
           nullable: true
         hasVotingRights:
           type: boolean
+          nullable: true
+        functionIds:
+          type: array
+          items:
+            type: integer
+            format: int32
           nullable: true
     MarkAttendeeAsPresent:
       type: object
@@ -4612,6 +4646,9 @@ components:
           nullable: true
           oneOf:
           - $ref: '#/components/schemas/ElectionCandidate'
+        meetingFunction:
+          nullable: true
+          $ref: '#/components/schemas/MeetingFunction'
     ElectionState:
       type: integer
       description: ''

--- a/src/Executive/Meetings/Meetings.Shared/OpenAPIs/swagger.yaml
+++ b/src/Executive/Meetings/Meetings.Shared/OpenAPIs/swagger.yaml
@@ -4081,6 +4081,18 @@ components:
         description:
           type: string
           nullable: true
+    MeetingFunction:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: integer
+          format: int32
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
     PagedResultOfMeeting:
       type: object
       additionalProperties: false
@@ -4178,6 +4190,10 @@ components:
           type: string
         role:
           $ref: '#/components/schemas/AttendeeRole'
+        functions:
+          type: array
+          items:
+            $ref: '#/components/schemas/MeetingFunction'
         email:
           type: string
           nullable: true
@@ -4252,6 +4268,12 @@ components:
           nullable: true
         hasVotingRights:
           type: boolean
+          nullable: true
+        functionIds:
+          type: array
+          items:
+            type: integer
+            format: int32
           nullable: true
     UpdateMeetingTitle:
       type: object
@@ -4346,6 +4368,12 @@ components:
         hasVotingRights:
           type: boolean
           nullable: true
+        functionIds:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
     AddAttendeesFromGroup:
       type: object
       additionalProperties: false
@@ -4372,6 +4400,12 @@ components:
           nullable: true
         hasVotingRights:
           type: boolean
+          nullable: true
+        functionIds:
+          type: array
+          items:
+            type: integer
+            format: int32
           nullable: true
     MarkAttendeeAsPresent:
       type: object
@@ -4612,6 +4646,9 @@ components:
           nullable: true
           oneOf:
           - $ref: '#/components/schemas/ElectionCandidate'
+        meetingFunction:
+          nullable: true
+          $ref: '#/components/schemas/MeetingFunction'
     ElectionState:
       type: integer
       description: ''

--- a/src/Executive/Meetings/Meetings.UI/MeetingDetails/AttendeeViewModel.cs
+++ b/src/Executive/Meetings/Meetings.UI/MeetingDetails/AttendeeViewModel.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
 namespace YourBrand.Meetings.MeetingDetails;
@@ -21,6 +22,8 @@ public class AttendeeViewModel
 
     public bool IsPresent { get; set; }
 
+    public List<int> FunctionIds { get; set; } = new();
+
     public AttendeeViewModel Clone()
     {
         return new AttendeeViewModel
@@ -31,7 +34,8 @@ public class AttendeeViewModel
             Email = Email,
             User = User,
             HasVotingRights = HasVotingRights,
-            IsPresent = IsPresent
+            IsPresent = IsPresent,
+            FunctionIds = new List<int>(FunctionIds)
         };
     }
 }

--- a/src/Executive/Meetings/Meetings.UI/MeetingDetails/MeetingDetailsPage.razor
+++ b/src/Executive/Meetings/Meetings.UI/MeetingDetails/MeetingDetailsPage.razor
@@ -1,6 +1,8 @@
 @page "/meetings/{id:int}"
 
 @using System
+@using System.Collections.Generic
+@using System.Linq
 @using System.ComponentModel.DataAnnotations
 @using YourBrand.Meetings.Dtos
 @using YourBrand.Meetings.MeetingDetails.Agenda
@@ -231,7 +233,8 @@
                 Email = attendee.Email,
                 //User = x.User,
                 HasVotingRights = attendee.HasVotingRights,
-                IsPresent = attendee.IsPresent
+                IsPresent = attendee.IsPresent,
+                FunctionIds = attendee.Functions?.Select(f => f.Id).ToList() ?? new List<int>()
             }));
     
         await LoadMinutes();
@@ -390,11 +393,13 @@
             Email = attendeeModel.Email,
             UserId = attendeeModel.User?.Id,
             HasVotingRights = attendeeModel.HasVotingRights,
+            FunctionIds = attendeeModel.FunctionIds
         };
 
         var model = await MeetingsClient.AddAttendeeAsync(organization.Id, Id, dto);
 
         attendeeModel.Id = model.Id;
+        attendeeModel.FunctionIds = model.Functions?.Select(f => f.Id).ToList() ?? new List<int>();
 
         Attendees.Add(attendeeModel);
     }
@@ -416,7 +421,7 @@
             GroupId = meetingGroup.Id
         });
 
-        foreach(var attendee in meeting.Attendees) 
+        foreach(var attendee in meeting.Attendees)
         {
             Attendees.Add(new AttendeeViewModel ()
             {
@@ -426,7 +431,8 @@
                 Email = attendee.Email,
                 //User = x.User,
                 HasVotingRights = attendee.HasVotingRights,
-                IsPresent = attendee.IsPresent
+                IsPresent = attendee.IsPresent,
+                FunctionIds = attendee.Functions?.Select(f => f.Id).ToList() ?? new List<int>()
             });
         }
     }
@@ -453,10 +459,13 @@
             Role = editedModel.Role.Id,
             Email = editedModel.Email,
             UserId = editedModel.User?.Id,
-            HasVotingRights = editedModel.HasVotingRights
+            HasVotingRights = editedModel.HasVotingRights,
+            FunctionIds = editedModel.FunctionIds
         };
-        
-        await MeetingsClient.EditAttendeeAsync(organization.Id, Id, attendee.Id, dto);
+
+        var updatedAttendee = await MeetingsClient.EditAttendeeAsync(organization.Id, Id, attendee.Id, dto);
+
+        editedModel.FunctionIds = updatedAttendee.Functions?.Select(f => f.Id).ToList() ?? new List<int>();
 
         var index = Attendees.IndexOf(originalAttendee);
         Attendees[index] = editedModel;
@@ -518,5 +527,5 @@
 
     private static bool IsAllowedOpenAccessRole(string? roleName) =>
         string.Equals(roleName, "Observer", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(roleName, "Attendee", StringComparison.OrdinalIgnoreCase);
+            || string.Equals(roleName, "Member", StringComparison.OrdinalIgnoreCase);
 }

--- a/src/Executive/Meetings/Meetings.UI/NewMeeting/AddEditAttendeeViewModel.cs
+++ b/src/Executive/Meetings/Meetings.UI/NewMeeting/AddEditAttendeeViewModel.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
 namespace YourBrand.Meetings.NewMeeting;
@@ -17,6 +18,8 @@ public class AddEditAttendeeViewModel
 
     public bool? HasVotingRights { get; set; }
 
+    public List<int> FunctionIds { get; set; } = new();
+
     public AddEditAttendeeViewModel Clone()
     {
         return new AddEditAttendeeViewModel
@@ -25,7 +28,8 @@ public class AddEditAttendeeViewModel
             Role = Role,
             Email = Email,
             User = User,
-            HasVotingRights = HasVotingRights
+            HasVotingRights = HasVotingRights,
+            FunctionIds = new List<int>(FunctionIds)
         };
     }
 }

--- a/src/Executive/Meetings/Meetings.UI/NewMeeting/NewMeetingPage.razor
+++ b/src/Executive/Meetings/Meetings.UI/NewMeeting/NewMeetingPage.razor
@@ -1,6 +1,7 @@
 @page "/meetings/new"
 
 @using System
+@using System.Collections.Generic
 @using System.ComponentModel.DataAnnotations
 @using System.Linq
 @using YourBrand.Portal.Services
@@ -136,7 +137,7 @@
             .ToList() ?? new List<AttendeeRole>();
 
         JoinAsRole = allowedRoles.FirstOrDefault(r => string.Equals(r.Name, "Observer", StringComparison.OrdinalIgnoreCase))
-            ?? allowedRoles.FirstOrDefault(r => string.Equals(r.Name, "Attendee", StringComparison.OrdinalIgnoreCase))
+            ?? allowedRoles.FirstOrDefault(r => string.Equals(r.Name, "Member", StringComparison.OrdinalIgnoreCase))
             ?? new AttendeeRole();
     }
 
@@ -168,7 +169,8 @@
                         Role = model.Role.Id,
                         Email = model.Email,
                         UserId = model.User?.Id,
-                        HasVotingRights = model.HasVotingRights
+                        HasVotingRights = model.HasVotingRights,
+                        FunctionIds = model.FunctionIds
                     };
                 }).ToList()
             });
@@ -231,5 +233,5 @@
 
     private static bool IsAllowedOpenAccessRole(AttendeeRole role) =>
         string.Equals(role.Name, "Observer", StringComparison.OrdinalIgnoreCase)
-            || string.Equals(role.Name, "Attendee", StringComparison.OrdinalIgnoreCase);
+            || string.Equals(role.Name, "Member", StringComparison.OrdinalIgnoreCase);
 }

--- a/src/Executive/Meetings/Meetings/Domain/Entities/AgendaItem.cs
+++ b/src/Executive/Meetings/Meetings/Domain/Entities/AgendaItem.cs
@@ -360,6 +360,11 @@ public class AgendaItem : Entity<AgendaItemId>, IAuditableEntity<AgendaItemId>, 
         item.Order = order;
         item.Election = election;
 
+        if (election?.MeetingFunction is not null)
+        {
+            item.Position = election.MeetingFunction.Name;
+        }
+
         _subItems.Add(item);
         return item;
     }

--- a/src/Executive/Meetings/Meetings/Domain/Entities/AgendaItemType.cs
+++ b/src/Executive/Meetings/Meetings/Domain/Entities/AgendaItemType.cs
@@ -9,7 +9,9 @@ public class AgendaItemType : IEntity
     public string? Description { get; private set; } // Optional description
 
     // Rule properties
-    public AttendeeRole? HandledByRole { get; private set; }
+    public MeetingFunction? HandledByFunction { get; private set; }
+
+    public int? HandledByFunctionId { get; private set; }
 
     public bool RequiresDiscussion { get; private set; }
     public bool RequiresVoting { get; private set; }
@@ -21,8 +23,8 @@ public class AgendaItemType : IEntity
 
     private AgendaItemType(int id, string name, string? description = null,
         bool requiresDiscussion = false, bool requiresVoting = false,
-        bool canBePostponed = true, bool canBeSkipped = true, bool isMandatory = false, 
-        AttendeeRole? handledByRole = null)
+        bool canBePostponed = true, bool canBeSkipped = true, bool isMandatory = false,
+        MeetingFunction? handledByFunction = null)
     {
         Id = id;
         Name = name;
@@ -33,13 +35,14 @@ public class AgendaItemType : IEntity
         CanBeSkipped = canBeSkipped;
         IsMandatory = isMandatory;
 
-        HandledByRole = handledByRole;
+        HandledByFunction = handledByFunction;
+        HandledByFunctionId = handledByFunction?.Id;
     }
 
     // Static instances with rule settings
     public static readonly AgendaItemType CallToOrder = new(1, "Call To Order", "Opening the meeting formally", isMandatory: true, canBePostponed: false, canBeSkipped: false);
-    public static readonly AgendaItemType RollCall = new(2, "Roll Call", "Attendance check", isMandatory: true, canBePostponed: false, canBeSkipped: false, handledByRole: AttendeeRole.Secretary);
-    public static readonly AgendaItemType QuorumCheck = new(3, "Quorum Check", "Verification of quorum", isMandatory: true, canBePostponed: false, canBeSkipped: false, handledByRole: AttendeeRole.Secretary);
+    public static readonly AgendaItemType RollCall = new(2, "Roll Call", "Attendance check", isMandatory: true, canBePostponed: false, canBeSkipped: false, handledByFunction: MeetingFunction.Secretary);
+    public static readonly AgendaItemType QuorumCheck = new(3, "Quorum Check", "Verification of quorum", isMandatory: true, canBePostponed: false, canBeSkipped: false, handledByFunction: MeetingFunction.Secretary);
     public static readonly AgendaItemType ApprovalOfMinutes = new(4, "Approval Of Minutes", "Approval of previous meeting's minutes", requiresVoting: true);
     public static readonly AgendaItemType ApprovalOfAgenda = new(5, "Approval Of Agenda", "Approval of the current meeting's agenda", requiresVoting: true, canBePostponed: false);
     public static readonly AgendaItemType ConsentAgenda = new(6, "Consent Agenda", "Routine items grouped for a single vote", requiresVoting: true);

--- a/src/Executive/Meetings/Meetings/Domain/Entities/AttendeeRole.cs
+++ b/src/Executive/Meetings/Meetings/Domain/Entities/AttendeeRole.cs
@@ -38,13 +38,14 @@ public class AttendeeRole : IEntity
         !Equals(left, right);
 
     // Static readonly instances for each attendee role
-    public static readonly AttendeeRole Chairperson = new(1, "Chairperson", true, true, true, "Leads the meeting");
-    public static readonly AttendeeRole Secretary = new(2, "Secretary", false, true, false, "Takes notes and records minutes");
-    public static readonly AttendeeRole Attendee = new(3, "Attendee", true, true, true, "Active participant");
-    public static readonly AttendeeRole Observer = new(4, "Observer", false, false, false, "Present without active participation");
+    public static readonly AttendeeRole Member = new(1, "Member", true, true, true, "Full member with standard participation rights.");
+    public static readonly AttendeeRole Alternate = new(2, "Alternate", true, true, true, "Alternate member who can step in for a full member.");
+    public static readonly AttendeeRole Observer = new(3, "Observer", false, false, false, "Present without active participation.");
+    public static readonly AttendeeRole Guest = new(4, "Guest", false, true, false, "Invited guest with limited rights.");
+    public static readonly AttendeeRole ExternalPresenter = new(5, "External Presenter", false, true, false, "External presenter invited to share information.");
 
     // List of all static instances for seeding purposes
     public static readonly AttendeeRole[] AllRoles = {
-        Chairperson, Secretary, Attendee, Observer
+        Member, Alternate, Observer, Guest, ExternalPresenter
     };
 }

--- a/src/Executive/Meetings/Meetings/Domain/Entities/Election.cs
+++ b/src/Executive/Meetings/Meetings/Domain/Entities/Election.cs
@@ -35,8 +35,8 @@ public sealed class Election : AggregateRoot<ElectionId>, IAuditableEntity<Elect
     public DateTimeOffset? StartTime { get; private set; }
     public DateTimeOffset? EndTime { get; private set; }
 
-    public MemberRole? Position { get; set; }
-    public int? PositionId { get; set; }
+    public MeetingFunction? MeetingFunction { get; set; }
+    public int? MeetingFunctionId { get; set; }
     public MeetingGroupId? GroupId { get; set; }
 
     public int MinimumVotesToWin { get; set; } = 1;

--- a/src/Executive/Meetings/Meetings/Domain/Entities/Entity.cs
+++ b/src/Executive/Meetings/Meetings/Domain/Entities/Entity.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations.Schema;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Text.Json.Serialization;
 
 using YourBrand.Domain;

--- a/src/Executive/Meetings/Meetings/Domain/Entities/MeetingAttendeeFunction.cs
+++ b/src/Executive/Meetings/Meetings/Domain/Entities/MeetingAttendeeFunction.cs
@@ -1,0 +1,46 @@
+using System;
+using YourBrand.Auditability;
+using YourBrand.Domain;
+using YourBrand.Identity;
+using YourBrand.Meetings.Domain.ValueObjects;
+using YourBrand.Tenancy;
+
+namespace YourBrand.Meetings.Domain.Entities;
+
+public class MeetingAttendeeFunction : Entity<MeetingAttendeeFunctionId>, IAuditableEntity<MeetingAttendeeFunctionId>, IHasTenant, IHasOrganization
+{
+    public MeetingAttendeeFunction()
+        : base(new MeetingAttendeeFunctionId())
+    {
+    }
+
+    public TenantId TenantId { get; set; }
+
+    public OrganizationId OrganizationId { get; set; }
+
+    public MeetingId MeetingId { get; set; }
+
+    public MeetingAttendeeId MeetingAttendeeId { get; set; }
+
+    public MeetingAttendee MeetingAttendee { get; set; } = null!;
+
+    public MeetingFunction Function { get; set; } = null!;
+
+    public int MeetingFunctionId { get; set; }
+
+    public DateTimeOffset AssignedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    public DateTimeOffset? RevokedAt { get; set; }
+
+    public User? CreatedBy { get; set; } = null!;
+
+    public UserId? CreatedById { get; set; } = null!;
+
+    public DateTimeOffset Created { get; set; }
+
+    public User? LastModifiedBy { get; set; }
+
+    public UserId? LastModifiedById { get; set; }
+
+    public DateTimeOffset? LastModified { get; set; }
+}

--- a/src/Executive/Meetings/Meetings/Domain/Entities/MeetingFunction.cs
+++ b/src/Executive/Meetings/Meetings/Domain/Entities/MeetingFunction.cs
@@ -1,0 +1,51 @@
+using YourBrand.Domain;
+
+namespace YourBrand.Meetings.Domain.Entities;
+
+public class MeetingFunction : IEntity
+{
+    public int Id { get; private set; }
+
+    public string Name { get; private set; } = null!;
+
+    public string? Description { get; private set; }
+
+    protected MeetingFunction()
+    {
+    }
+
+    public MeetingFunction(int id, string name, string? description = null)
+    {
+        Id = id;
+        Name = name;
+        Description = description;
+    }
+
+    public override bool Equals(object? obj) =>
+        obj is MeetingFunction other && Id == other.Id;
+
+    public override int GetHashCode() => Id.GetHashCode();
+
+    public static bool operator ==(MeetingFunction? left, MeetingFunction? right) =>
+        Equals(left, right);
+
+    public static bool operator !=(MeetingFunction? left, MeetingFunction? right) =>
+        !Equals(left, right);
+
+    public static readonly MeetingFunction Chairperson = new(1, "Chairperson", "Leads the meeting and maintains order.");
+    public static readonly MeetingFunction Secretary = new(2, "Secretary", "Records minutes and handles documentation.");
+    public static readonly MeetingFunction MinuteAdjuster = new(3, "Minute Adjuster", "Reviews and adjusts meeting minutes.");
+    public static readonly MeetingFunction Teller = new(4, "Teller", "Counts votes during elections.");
+    public static readonly MeetingFunction Timekeeper = new(5, "Timekeeper", "Tracks speaking time and agenda timing.");
+    public static readonly MeetingFunction Facilitator = new(6, "Facilitator", "Supports discussions and keeps the meeting on track.");
+
+    public static readonly MeetingFunction[] AllFunctions =
+    {
+        Chairperson,
+        Secretary,
+        MinuteAdjuster,
+        Teller,
+        Timekeeper,
+        Facilitator
+    };
+}

--- a/src/Executive/Meetings/Meetings/Domain/Entities/MeetingGroupMember.cs
+++ b/src/Executive/Meetings/Meetings/Domain/Entities/MeetingGroupMember.cs
@@ -32,7 +32,7 @@ public class MeetingGroupMember : Entity<MeetingGroupMemberId>, IAuditableEntity
 
     public UserId? UserId { get; set; }
 
-    public AttendeeRole Role { get; set; } = AttendeeRole.Attendee;
+    public AttendeeRole Role { get; set; } = AttendeeRole.Member;
     public int RoleId{ get; set; }
 
     public bool? HasSpeakingRights { get; set; }

--- a/src/Executive/Meetings/Meetings/Domain/IApplicationDbContext.cs
+++ b/src/Executive/Meetings/Meetings/Domain/IApplicationDbContext.cs
@@ -10,7 +10,11 @@ public interface IApplicationDbContext
 
     DbSet<MeetingAttendee> MeetingAttendees { get; }
 
+    DbSet<MeetingAttendeeFunction> MeetingAttendeeFunctions { get; }
+
     DbSet<AttendeeRole> AttendeeRoles { get; }
+
+    DbSet<MeetingFunction> MeetingFunctions { get; }
 
     DbSet<Agenda> Agendas { get; }
 

--- a/src/Executive/Meetings/Meetings/Domain/ValueObjects/MeetingAttendeeFunctionId.cs
+++ b/src/Executive/Meetings/Meetings/Domain/ValueObjects/MeetingAttendeeFunctionId.cs
@@ -1,0 +1,55 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+
+namespace YourBrand.Meetings.Domain.ValueObjects;
+
+public struct MeetingAttendeeFunctionId
+{
+    public MeetingAttendeeFunctionId(string value) => Value = value;
+
+    public MeetingAttendeeFunctionId() => Value = Guid.NewGuid().ToString();
+
+    public string Value { get; set; }
+
+    public override bool Equals([NotNullWhen(true)] object? obj)
+    {
+        return base.Equals(obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return (Value ?? string.Empty).GetHashCode();
+    }
+
+    public override string ToString()
+    {
+        return (Value ?? string.Empty).ToString();
+    }
+
+    public static bool operator ==(MeetingAttendeeFunctionId lhs, MeetingAttendeeFunctionId rhs) => lhs.Value == rhs.Value;
+
+    public static bool operator !=(MeetingAttendeeFunctionId lhs, MeetingAttendeeFunctionId rhs) => lhs.Value != rhs.Value;
+
+    public static implicit operator MeetingAttendeeFunctionId(string id) => new MeetingAttendeeFunctionId(id);
+
+    public static implicit operator MeetingAttendeeFunctionId?(string? id) => id is null ? (MeetingAttendeeFunctionId?)null : new MeetingAttendeeFunctionId(id);
+
+    public static implicit operator string(MeetingAttendeeFunctionId id) => id.Value;
+
+    public static bool TryParse(string? value, out MeetingAttendeeFunctionId channelAttendeeFunctionId)
+    {
+        return TryParse(value, CultureInfo.CurrentCulture, out channelAttendeeFunctionId);
+    }
+
+    public static bool TryParse(string? value, IFormatProvider? provider, out MeetingAttendeeFunctionId channelAttendeeFunctionId)
+    {
+        if (value is null)
+        {
+            channelAttendeeFunctionId = default;
+            return false;
+        }
+
+        channelAttendeeFunctionId = value;
+        return true;
+    }
+}

--- a/src/Executive/Meetings/Meetings/Features/Commands/AddAttendee.cs
+++ b/src/Executive/Meetings/Meetings/Features/Commands/AddAttendee.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using FluentValidation;
 
 using MediatR;
@@ -5,10 +8,11 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 
 using YourBrand.Identity;
+using YourBrand.Meetings.Domain.Entities;
 
 namespace YourBrand.Meetings.Features.Command;
 
-public record AddAttendee(string OrganizationId, int Id, string Name, string? UserId, string Email, int Role, bool? HasSpeakingRights, bool? HasVotingRights) : IRequest<Result<MeetingAttendeeDto>>
+public record AddAttendee(string OrganizationId, int Id, string Name, string? UserId, string Email, int Role, bool? HasSpeakingRights, bool? HasVotingRights, IEnumerable<int>? FunctionIds) : IRequest<Result<MeetingAttendeeDto>>
 {
     public class Validator : AbstractValidator<AddAttendee>
     {
@@ -38,7 +42,20 @@ public record AddAttendee(string OrganizationId, int Id, string Name, string? Us
                 throw new Exception("Invalid role");
             }
 
-            var attendee = meeting.AddAttendee(request.Name, request.UserId, request.Email, role, request.HasSpeakingRights, request.HasVotingRights);
+            var functionIds = request.FunctionIds?.Distinct().ToArray();
+
+            var functions = functionIds is null || functionIds.Length == 0
+                ? new List<MeetingFunction>()
+                : await context.MeetingFunctions
+                    .Where(x => functionIds.Contains(x.Id))
+                    .ToListAsync(cancellationToken);
+
+            if (functionIds is not null && functions.Count != functionIds.Length)
+            {
+                throw new Exception("Invalid meeting function");
+            }
+
+            var attendee = meeting.AddAttendee(request.Name, request.UserId, request.Email, role, request.HasSpeakingRights, request.HasVotingRights, functions);
 
             context.Meetings.Update(meeting);
 

--- a/src/Executive/Meetings/Meetings/Features/Commands/ChangeMeetingOpenAccess.cs
+++ b/src/Executive/Meetings/Meetings/Features/Commands/ChangeMeetingOpenAccess.cs
@@ -30,7 +30,7 @@ public sealed record ChangeMeetingOpenAccess(string OrganizationId, int Id, bool
                 throw new Exception("Invalid role");
             }
 
-            if (request.CanAnyoneJoin && joinRole.Id != AttendeeRole.Attendee.Id && joinRole.Id != AttendeeRole.Observer.Id)
+            if (request.CanAnyoneJoin && joinRole.Id != AttendeeRole.Member.Id && joinRole.Id != AttendeeRole.Observer.Id)
             {
                 return Errors.Meetings.InvalidOpenAccessRole;
             }

--- a/src/Executive/Meetings/Meetings/Features/Commands/EditAttendee.cs
+++ b/src/Executive/Meetings/Meetings/Features/Commands/EditAttendee.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using FluentValidation;
 
 using MediatR;
@@ -5,10 +8,11 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 
 using YourBrand.Identity;
+using YourBrand.Meetings.Domain.Entities;
 
 namespace YourBrand.Meetings.Features.Command;
 
-public record EditAttendee(string OrganizationId, int Id, string AttendeeId, string Name, string? UserId, string Email, int Role, bool? HasSpeakingRights, bool? HasVotingRights) : IRequest<Result<MeetingAttendeeDto>>
+public record EditAttendee(string OrganizationId, int Id, string AttendeeId, string Name, string? UserId, string Email, int Role, bool? HasSpeakingRights, bool? HasVotingRights, IEnumerable<int>? FunctionIds) : IRequest<Result<MeetingAttendeeDto>>
 {
     public class Validator : AbstractValidator<EditAttendee>
     {
@@ -51,6 +55,22 @@ public record EditAttendee(string OrganizationId, int Id, string AttendeeId, str
             attendee.Role = role;
             attendee.HasSpeakingRights = request.HasSpeakingRights;
             attendee.HasVotingRights = request.HasVotingRights;
+
+            if (request.FunctionIds is not null)
+            {
+                var functionIds = request.FunctionIds.Distinct().ToArray();
+
+                var functions = await context.MeetingFunctions
+                    .Where(x => functionIds.Contains(x.Id))
+                    .ToListAsync(cancellationToken);
+
+                if (functions.Count != functionIds.Length)
+                {
+                    throw new Exception("Invalid meeting function");
+                }
+
+                attendee.SetFunctions(functions);
+            }
 
             context.Meetings.Update(meeting);
 

--- a/src/Executive/Meetings/Meetings/Features/Commands/JoinMeeting.cs
+++ b/src/Executive/Meetings/Meetings/Features/Commands/JoinMeeting.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using MediatR;
 
 using Microsoft.EntityFrameworkCore;
@@ -43,7 +46,7 @@ public sealed record JoinMeeting(string OrganizationId, int Id) : IRequest<Resul
                     ?? throw new Exception("Invalid role");
             }
 
-            if (meeting.CanAnyoneJoin && joinRole.Id != AttendeeRole.Attendee.Id && joinRole.Id != AttendeeRole.Observer.Id)
+            if (meeting.CanAnyoneJoin && joinRole.Id != AttendeeRole.Member.Id && joinRole.Id != AttendeeRole.Observer.Id)
             {
                 return Errors.Meetings.InvalidOpenAccessRole;
             }
@@ -56,7 +59,7 @@ public sealed record JoinMeeting(string OrganizationId, int Id) : IRequest<Resul
 
             if (attendee is null)
             {
-                attendee = meeting.AddAttendee(displayName, userId, email, joinRole, joinRole.CanSpeak, joinRole.CanVote);
+                attendee = meeting.AddAttendee(displayName, userId, email, joinRole, joinRole.CanSpeak, joinRole.CanVote, Enumerable.Empty<MeetingFunction>());
             }
             else
             {
@@ -67,6 +70,7 @@ public sealed record JoinMeeting(string OrganizationId, int Id) : IRequest<Resul
                 attendee.RoleId = joinRole.Id;
                 attendee.HasSpeakingRights = joinRole.CanSpeak;
                 attendee.HasVotingRights = joinRole.CanVote;
+                attendee.SetFunctions(Array.Empty<MeetingFunction>());
             }
 
             attendee.JoinedAt = now;

--- a/src/Executive/Meetings/Meetings/Features/Mapper.cs
+++ b/src/Executive/Meetings/Meetings/Features/Mapper.cs
@@ -1,4 +1,5 @@
-﻿
+﻿using System.Linq;
+
 using YourBrand.Meetings.Features.Organizations;
 using YourBrand.Meetings.Features.Users;
 
@@ -31,7 +32,6 @@ public static partial class Mappings
         {
             actions.Add("cancel", new DtoAction("POST", $"/v1/Meetings/{meeting.Id}/Cancel"));
         }
-
         if (meeting.CanEnd)
         {
             actions.Add("end", new DtoAction("POST", $"/v1/Meetings/{meeting.Id}/End"));
@@ -52,9 +52,12 @@ public static partial class Mappings
 
     public static MeetingQuorumDto ToDto(this Quorum quorum) => new(quorum.RequiredNumber);
 
-    public static MeetingAttendeeDto ToDto(this MeetingAttendee attendee) => 
-        new(attendee.Id, attendee.Name!, attendee.Role.ToDto(), attendee.Email, attendee.UserId, attendee.HasSpeakingRights, attendee.HasVotingRights, attendee.IsPresent);
+    public static MeetingAttendeeDto ToDto(this MeetingAttendee attendee) =>
+        new(attendee.Id, attendee.Name!, attendee.Role.ToDto(), attendee.Functions.Select(x => x.Function.ToDto()), attendee.Email, attendee.UserId, attendee.HasSpeakingRights, attendee.HasVotingRights, attendee.IsPresent);
 
     public static AttendeeRoleDto ToDto(this AttendeeRole role) =>
         new(role.Id, role.Name, role.Description);
+
+    public static MeetingFunctionDto ToDto(this MeetingFunction function) =>
+        new(function.Id, function.Name, function.Description);
 }

--- a/src/Executive/Meetings/Meetings/Features/MeetingsController.cs
+++ b/src/Executive/Meetings/Meetings/Features/MeetingsController.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Asp.Versioning;
 
 using MediatR;
@@ -32,9 +33,9 @@ public sealed record ChangeMeetingOpenAccessDto(bool CanAnyoneJoin, int? JoinAsR
 
 public sealed record AdjournMeetingDto(string Message);
 
-public sealed record AddMeetingAttendeeDto(string Name, string? UserId, string Email, int Role, bool? HasSpeakingRights, bool? HasVotingRights);
+public sealed record AddMeetingAttendeeDto(string Name, string? UserId, string Email, int Role, bool? HasSpeakingRights, bool? HasVotingRights, IEnumerable<int>? FunctionIds);
 
-public sealed record EditMeetingAttendeeDto(string Name, string? UserId, string Email, int Role, bool? HasSpeakingRights, bool? HasVotingRights);
+public sealed record EditMeetingAttendeeDto(string Name, string? UserId, string Email, int Role, bool? HasSpeakingRights, bool? HasVotingRights, IEnumerable<int>? FunctionIds);
 
 public sealed record AddAttendeesFromGroupDto(int GroupId);
 
@@ -171,7 +172,7 @@ public sealed partial class MeetingsController(IMediator mediator) : ControllerB
     [ProducesDefaultResponseType]
     public async Task<ActionResult<MeetingAttendeeDto>> AddAttendee(string organizationId, int id, AddMeetingAttendeeDto request, CancellationToken cancellationToken)
     {
-        var result = await mediator.Send(new AddAttendee(organizationId, id, request.Name, request.UserId, request.Email, request.Role, request.HasSpeakingRights, request.HasVotingRights), cancellationToken);
+        var result = await mediator.Send(new AddAttendee(organizationId, id, request.Name, request.UserId, request.Email, request.Role, request.HasSpeakingRights, request.HasVotingRights, request.FunctionIds), cancellationToken);
         return this.HandleResult(result);
     }
 
@@ -191,7 +192,7 @@ public sealed partial class MeetingsController(IMediator mediator) : ControllerB
     [ProducesDefaultResponseType]
     public async Task<ActionResult<MeetingAttendeeDto>> EditAttendee(string organizationId, int id, string attendeeId, EditMeetingAttendeeDto request, CancellationToken cancellationToken)
     {
-        var result = await mediator.Send(new EditAttendee(organizationId, id, attendeeId, request.Name, request.UserId, request.Email, request.Role, request.HasSpeakingRights, request.HasVotingRights), cancellationToken);
+        var result = await mediator.Send(new EditAttendee(organizationId, id, attendeeId, request.Name, request.UserId, request.Email, request.Role, request.HasSpeakingRights, request.HasVotingRights, request.FunctionIds), cancellationToken);
         return this.HandleResult(result);
     }
 

--- a/src/Executive/Meetings/Meetings/Features/MeetingsDto.cs
+++ b/src/Executive/Meetings/Meetings/Features/MeetingsDto.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace YourBrand.Meetings.Features;
 
 public sealed record MeetingDto(int Id, string Title, string? Description, MeetingState State, DateTimeOffset? ScheduledAt, string Location,
@@ -7,8 +9,10 @@ public sealed record MeetingDto(int Id, string Title, string? Description, Meeti
 
 public sealed record MeetingQuorumDto(int RequiredNumber);
 
-public sealed record MeetingAttendeeDto(string Id, string Name, AttendeeRoleDto Role, string? Email, string? UserId, bool? HasSpeakingRights, bool? HasVotingRights, bool IsPresent);
+public sealed record MeetingAttendeeDto(string Id, string Name, AttendeeRoleDto Role, IEnumerable<MeetingFunctionDto> Functions, string? Email, string? UserId, bool? HasSpeakingRights, bool? HasVotingRights, bool IsPresent);
 
 public sealed record AttendeeRoleDto(int Id, string Name, string? Description);
+
+public sealed record MeetingFunctionDto(int Id, string Name, string? Description);
 
 public sealed record DtoAction(string Method, string Href);

--- a/src/Executive/Meetings/Meetings/Features/Procedure/AdjournMeeting.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/AdjournMeeting.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using YourBrand.Meetings.Domain.Entities;
 
 using MediatR;
 
@@ -39,7 +40,7 @@ public sealed record AdjournMeeting(string OrganizationId, int Id, string Messag
                 return Errors.Meetings.YouAreNotAttendeeOfMeeting;
             }
 
-            if (attendee.Role != AttendeeRole.Chairperson)
+            if (!meeting.CanAttendeeActAsChair(attendee))
             {
                 return Errors.Meetings.OnlyChairpersonCanAdjournTheMeeting;
             }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Attendee/NominateCandidate.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Attendee/NominateCandidate.cs
@@ -47,7 +47,7 @@ public sealed record NominateCandidate(string OrganizationId, int Id, string Att
                 return Errors.Meetings.NoOngoingVoting;
             }
 
-            var candidateAttendee = meeting.GetAttendeeByUserId(request.AttendeeId);
+            var candidateAttendee = meeting.GetAttendeeById(request.AttendeeId);
 
             if (candidateAttendee is null)
             {
@@ -61,7 +61,7 @@ public sealed record NominateCandidate(string OrganizationId, int Id, string Att
                 return Errors.Meetings.CandidateAlreadyProposed;
             }
 
-            election.NominateCandidate(timeProvider, candidateAttendee.Id, "", request.Statement, "", null);
+            election.NominateCandidate(timeProvider, candidateAttendee, request.Statement);
 
             context.Meetings.Update(meeting);
 

--- a/src/Executive/Meetings/Meetings/Features/Procedure/CancelAgendaItem.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/CancelAgendaItem.cs
@@ -1,4 +1,5 @@
 using MediatR;
+using YourBrand.Meetings.Domain.Entities;
 
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
@@ -38,7 +39,7 @@ public sealed record CancelAgendaItem(string OrganizationId, int Id) : IRequest<
                 return Errors.Meetings.NoActiveAgendaItem;
             }
 
-            if (attendee.Role != AttendeeRole.Chairperson)
+            if (!meeting.CanAttendeeActAsChair(attendee))
             {
                 return Errors.Meetings.OnlyChairpersonCanCancelAgendaItem;
             }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/CancelMeeting.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/CancelMeeting.cs
@@ -1,4 +1,5 @@
 using MediatR;
+using YourBrand.Meetings.Domain.Entities;
 
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
@@ -29,7 +30,7 @@ public sealed record CancelMeeting(string OrganizationId, int Id) : IRequest<Res
                 return Errors.Meetings.YouAreNotAttendeeOfMeeting;
             }
 
-            if (attendee.Role != AttendeeRole.Chairperson)
+            if (!meeting.CanAttendeeActAsChair(attendee))
             {
                 return Errors.Meetings.OnlyChairpersonCanEndTheMeeting;
             }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/EndDiscussions.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/EndDiscussions.cs
@@ -1,4 +1,5 @@
 using MediatR;
+using YourBrand.Meetings.Domain.Entities;
 
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
@@ -39,7 +40,7 @@ public sealed record EndDiscussions(string OrganizationId, int Id) : IRequest<Re
                 return Errors.Meetings.NoActiveAgendaItem;
             }
 
-            if (attendee.Role != AttendeeRole.Chairperson)
+            if (!meeting.CanAttendeeActAsChair(attendee))
             {
                 return Errors.Meetings.OnlyChairpersonCanEndDiscussion;
             }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/EndVoting.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/EndVoting.cs
@@ -1,4 +1,5 @@
 using MediatR;
+using YourBrand.Meetings.Domain.Entities;
 
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
@@ -39,7 +40,7 @@ public sealed record EndVoting(string OrganizationId, int Id) : IRequest<Result>
                 return Errors.Meetings.NoActiveAgendaItem;
             }
 
-            if (attendee.Role != AttendeeRole.Chairperson)
+            if (!meeting.CanAttendeeActAsChair(attendee))
             {
                 return Errors.Meetings.OnlyChairpersonCanEndVoting;
             }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/ExtendSpeakerTime.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/ExtendSpeakerTime.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using YourBrand.Meetings.Domain.Entities;
 
 using MediatR;
 
@@ -42,7 +43,7 @@ public sealed record ExtendSpeakerTime(string OrganizationId, int Id, string Age
                 return Errors.Meetings.YouAreNotAttendeeOfMeeting;
             }
 
-            if (attendee.Role != AttendeeRole.Chairperson)
+            if (!meeting.CanAttendeeActAsChair(attendee))
             {
                 return Errors.Meetings.OnlyChairpersonCanManageSpeakerQueue;
             }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/MoveToNextSpeaker.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/MoveToNextSpeaker.cs
@@ -1,4 +1,5 @@
 using System;
+using YourBrand.Meetings.Domain.Entities;
 
 using MediatR;
 
@@ -36,7 +37,7 @@ public sealed record MoveToNextSpeaker(string OrganizationId, int Id) : IRequest
                 return Errors.Meetings.YouAreNotAttendeeOfMeeting;
             }
 
-            if (attendee.Role != AttendeeRole.Chairperson)
+            if (!meeting.CanAttendeeActAsChair(attendee))
             {
                 return Errors.Meetings.OnlyChairpersonCanManageSpeakerQueue;
             }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/ResetSpeakerClock.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/ResetSpeakerClock.cs
@@ -1,4 +1,5 @@
 using System;
+using YourBrand.Meetings.Domain.Entities;
 
 using MediatR;
 
@@ -39,7 +40,7 @@ public sealed record ResetSpeakerClock(string OrganizationId, int Id, string Age
                 return Errors.Meetings.YouAreNotAttendeeOfMeeting;
             }
 
-            if (attendee.Role != AttendeeRole.Chairperson)
+            if (!meeting.CanAttendeeActAsChair(attendee))
             {
                 return Errors.Meetings.OnlyChairpersonCanManageSpeakerQueue;
             }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/SetDiscussionSpeakingTime.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/SetDiscussionSpeakingTime.cs
@@ -1,4 +1,5 @@
 using MediatR;
+using YourBrand.Meetings.Domain.Entities;
 
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
@@ -35,7 +36,7 @@ public sealed record SetDiscussionSpeakingTime(string OrganizationId, int Id, st
                 return Errors.Meetings.YouAreNotAttendeeOfMeeting;
             }
 
-            if (attendee.Role != AttendeeRole.Chairperson)
+            if (!meeting.CanAttendeeActAsChair(attendee))
             {
                 return Errors.Meetings.OnlyChairpersonCanManageSpeakerQueue;
             }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/StartDiscussions.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/StartDiscussions.cs
@@ -1,4 +1,5 @@
 using MediatR;
+using YourBrand.Meetings.Domain.Entities;
 
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
@@ -39,7 +40,7 @@ public sealed record StartDiscussions(string OrganizationId, int Id) : IRequest<
                 return Errors.Meetings.NoActiveAgendaItem;
             }
 
-            if (attendee.Role != AttendeeRole.Chairperson)
+            if (!meeting.CanAttendeeActAsChair(attendee))
             {
                 return Errors.Meetings.OnlyChairpersonCanStartDiscussion;
             }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/StartElection.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/StartElection.cs
@@ -1,4 +1,5 @@
 using MediatR;
+using YourBrand.Meetings.Domain.Entities;
 
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
@@ -40,7 +41,7 @@ public sealed record StartElection(string OrganizationId, int Id) : IRequest<Res
                 return Errors.Meetings.NoActiveAgendaItem;
             }
 
-            if (attendee.Role != AttendeeRole.Chairperson)
+            if (!meeting.CanAttendeeActAsChair(attendee))
             {
                 return Errors.Meetings.OnlyChairpersonCanStartVoting;
             }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/StartSpeakerClock.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/StartSpeakerClock.cs
@@ -1,4 +1,5 @@
 using System;
+using YourBrand.Meetings.Domain.Entities;
 
 using MediatR;
 
@@ -36,7 +37,7 @@ public sealed record StartSpeakerClock(string OrganizationId, int Id, string Age
                 return Errors.Meetings.YouAreNotAttendeeOfMeeting;
             }
 
-            if (attendee.Role != AttendeeRole.Chairperson)
+            if (!meeting.CanAttendeeActAsChair(attendee))
             {
                 return Errors.Meetings.OnlyChairpersonCanManageSpeakerQueue;
             }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/StartVoting.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/StartVoting.cs
@@ -1,4 +1,5 @@
 using MediatR;
+using YourBrand.Meetings.Domain.Entities;
 
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
@@ -40,7 +41,7 @@ public sealed record StartVoting(string OrganizationId, int Id) : IRequest<Resul
                 return Errors.Meetings.NoActiveAgendaItem;
             }
 
-            if (attendee.Role != AttendeeRole.Chairperson)
+            if (!meeting.CanAttendeeActAsChair(attendee))
             {
                 return Errors.Meetings.OnlyChairpersonCanStartVoting;
             }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/StopSpeakerClock.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/StopSpeakerClock.cs
@@ -1,4 +1,5 @@
 using System;
+using YourBrand.Meetings.Domain.Entities;
 
 using MediatR;
 
@@ -36,7 +37,7 @@ public sealed record StopSpeakerClock(string OrganizationId, int Id, string Agen
                 return Errors.Meetings.YouAreNotAttendeeOfMeeting;
             }
 
-            if (attendee.Role != AttendeeRole.Chairperson)
+            if (!meeting.CanAttendeeActAsChair(attendee))
             {
                 return Errors.Meetings.OnlyChairpersonCanManageSpeakerQueue;
             }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/CompleteAgendaItem.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/CompleteAgendaItem.cs
@@ -1,4 +1,5 @@
 using MediatR;
+using YourBrand.Meetings.Domain.Entities;
 
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
@@ -38,7 +39,7 @@ public sealed record CompleteAgendaItem(string OrganizationId, int Id) : IReques
                 return Errors.Meetings.NoActiveAgendaItem;
             }
 
-            if (attendee.Role != AttendeeRole.Chairperson)
+            if (!meeting.CanAttendeeActAsChair(attendee))
             {
                 return Errors.Meetings.OnlyChairpersonCanCompleteAgendaItem;
             }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Elections/ElectionDto.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Elections/ElectionDto.cs
@@ -1,5 +1,6 @@
+using YourBrand.Meetings.Features;
 using YourBrand.Meetings.Features.Agendas;
 
 namespace YourBrand.Meetings.Features.Procedure.Elections;
 
-public sealed record ElectionDto(string Id, ElectionState State, IEnumerable<ElectionCandidateDto> Candidates, ElectionCandidateDto? ElectedCandidate);
+public sealed record ElectionDto(string Id, ElectionState State, IEnumerable<ElectionCandidateDto> Candidates, ElectionCandidateDto? ElectedCandidate, MeetingFunctionDto? MeetingFunction);

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Elections/Mappings.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Elections/Mappings.cs
@@ -1,8 +1,15 @@
+using YourBrand.Meetings.Features;
 using YourBrand.Meetings.Features.Agendas;
 
 namespace YourBrand.Meetings.Features.Procedure.Elections;
 
 public static partial class Mappings
 {
-    public static ElectionDto ToDto(this Domain.Entities.Election election) => new(election.Id, election.State, election.Candidates.Select(x => x.ToDto()), election.ElectedCandidate?.ToDto());
+    public static ElectionDto ToDto(this Domain.Entities.Election election) =>
+        new(
+            election.Id,
+            election.State,
+            election.Candidates.Select(x => x.ToDto()),
+            election.ElectedCandidate?.ToDto(),
+            election.MeetingFunction?.ToDto());
 }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/EndMeeting.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/EndMeeting.cs
@@ -1,4 +1,5 @@
 using MediatR;
+using YourBrand.Meetings.Domain.Entities;
 
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
@@ -29,7 +30,7 @@ public sealed record EndMeeting(string OrganizationId, int Id) : IRequest<Result
                 return Errors.Meetings.YouAreNotAttendeeOfMeeting;
             }
 
-            if (attendee.Role != AttendeeRole.Chairperson)
+            if (!meeting.CanAttendeeActAsChair(attendee))
             {
                 return Errors.Meetings.OnlyChairpersonCanEndTheMeeting;
             }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/MoveToNextAgendaItem.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/MoveToNextAgendaItem.cs
@@ -1,4 +1,5 @@
 using MediatR;
+using YourBrand.Meetings.Domain.Entities;
 
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
@@ -33,7 +34,7 @@ public sealed record MoveToNextAgendaItem(string OrganizationId, int Id) : IRequ
                 return Errors.Meetings.YouAreNotAttendeeOfMeeting;
             }
 
-            if (attendee.Role != AttendeeRole.Chairperson)
+            if (!meeting.CanAttendeeActAsChair(attendee))
             {
                 return Errors.Meetings.OnlyChairpersonCanMoveToNextAgendaItem;
             }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/PostponeAgendaItem.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/PostponeAgendaItem.cs
@@ -1,4 +1,5 @@
 using MediatR;
+using YourBrand.Meetings.Domain.Entities;
 
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
@@ -38,7 +39,7 @@ public sealed record PostponeAgendaItem(string OrganizationId, int Id) : IReques
                 return Errors.Meetings.NoActiveAgendaItem;
             }
 
-            if (attendee.Role != AttendeeRole.Chairperson)
+            if (!meeting.CanAttendeeActAsChair(attendee))
             {
                 return Errors.Meetings.OnlyChairpersonCanPostponeAgendaItem;
             }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/ResetMeetingProcedure.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/ResetMeetingProcedure.cs
@@ -1,4 +1,5 @@
 using FluentValidation;
+using YourBrand.Meetings.Domain.Entities;
 
 using MediatR;
 
@@ -41,7 +42,7 @@ public record ResetMeetingProcedure(string OrganizationId, int Id) : IRequest<Re
                 return Errors.Meetings.YouAreNotAttendeeOfMeeting;
             }
 
-            if (attendee.Role != AttendeeRole.Chairperson)
+            if (!meeting.CanAttendeeActAsChair(attendee))
             {
                 return Errors.Meetings.OnlyChairpersonCanResetTheMeetingProcedure;
             }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/ResumeMeeting.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/ResumeMeeting.cs
@@ -1,4 +1,5 @@
 using MediatR;
+using YourBrand.Meetings.Domain.Entities;
 
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
@@ -29,7 +30,7 @@ public sealed record ResumeMeeting(string OrganizationId, int Id) : IRequest<Res
                 return Errors.Meetings.YouAreNotAttendeeOfMeeting;
             }
 
-            if (attendee.Role != AttendeeRole.Chairperson)
+            if (!meeting.CanAttendeeActAsChair(attendee))
             {
                 return Errors.Meetings.OnlyChairpersonCanResumeTheMeeting;
             }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/StartMeeting.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/StartMeeting.cs
@@ -1,4 +1,5 @@
 using MediatR;
+using YourBrand.Meetings.Domain.Entities;
 
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
@@ -29,7 +30,7 @@ public sealed record StartMeeting(string OrganizationId, int Id) : IRequest<Resu
                 return Errors.Meetings.YouAreNotAttendeeOfMeeting;
             }
 
-            if (attendee.Role != AttendeeRole.Chairperson)
+            if (!meeting.CanAttendeeActAsChair(attendee))
             {
                 return Errors.Meetings.OnlyChairpersonCanStartTheMeeting;
             }

--- a/src/Executive/Meetings/Meetings/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/src/Executive/Meetings/Meetings/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore;
 
 using YourBrand.Domain;
 using YourBrand.Identity;
+using YourBrand.Meetings.Domain.Entities;
 using YourBrand.Meetings.Domain.ValueObjects;
 using YourBrand.Meetings.Infrastructure.Persistence.ValueConverters;
 using YourBrand.Tenancy;
@@ -37,6 +38,7 @@ public sealed class ApplicationDbContext(
 
         configurationBuilder.Properties<MeetingId>().HaveConversion<MeetingIdConverter>();
         configurationBuilder.Properties<MeetingAttendeeId>().HaveConversion<MeetingAttendeeIdConverter>();
+        configurationBuilder.Properties<MeetingAttendeeFunctionId>().HaveConversion<MeetingAttendeeFunctionIdConverter>();
 
         configurationBuilder.Properties<DebateId>().HaveConversion<DebateIdConverter>();
         configurationBuilder.Properties<DebateEntryId>().HaveConversion<DebateEntryIdConverter>();
@@ -72,7 +74,11 @@ public sealed class ApplicationDbContext(
 
     public DbSet<MeetingAttendee> MeetingAttendees { get; set; }
 
+    public DbSet<MeetingAttendeeFunction> MeetingAttendeeFunctions { get; set; }
+
     public DbSet<AttendeeRole> AttendeeRoles { get; set; }
+
+    public DbSet<MeetingFunction> MeetingFunctions { get; set; }
 
     public DbSet<Agenda> Agendas { get; set; }
 

--- a/src/Executive/Meetings/Meetings/Infrastructure/Persistence/Configurations/AgendaItemTypeConfiguration.cs
+++ b/src/Executive/Meetings/Meetings/Infrastructure/Persistence/Configurations/AgendaItemTypeConfiguration.cs
@@ -1,6 +1,8 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
+using YourBrand.Meetings.Domain.Entities;
+
 namespace YourBrand.Agendas.Infrastructure.Persistence.Configurations;
 
 public sealed class AgendaItemTypeConfiguration : IEntityTypeConfiguration<AgendaItemType>
@@ -19,6 +21,11 @@ public sealed class AgendaItemTypeConfiguration : IEntityTypeConfiguration<Agend
             
         builder.Property(e => e.Description)
             .HasMaxLength(250); // Adjust length as needed
+
+        builder.HasOne(x => x.HandledByFunction)
+            .WithMany()
+            .HasForeignKey(x => x.HandledByFunctionId)
+            .OnDelete(DeleteBehavior.NoAction);
 
     }
 }

--- a/src/Executive/Meetings/Meetings/Infrastructure/Persistence/Configurations/ElectionConfiguration.cs
+++ b/src/Executive/Meetings/Meetings/Infrastructure/Persistence/Configurations/ElectionConfiguration.cs
@@ -25,6 +25,12 @@ public sealed class ElectionConfiguration : IEntityTypeConfiguration<Election>
 
         builder.Navigation(x => x.Ballots).AutoInclude();
 
+        builder.HasOne(x => x.MeetingFunction)
+            .WithMany()
+            .HasForeignKey(x => x.MeetingFunctionId);
+
+        builder.Navigation(x => x.MeetingFunction).AutoInclude();
+
         builder.HasOne(x => x.ElectedCandidate)
             .WithMany()
             .HasForeignKey(x => new { x.OrganizationId, x.ElectedCandidateId });

--- a/src/Executive/Meetings/Meetings/Infrastructure/Persistence/Configurations/MeetingAttendeeConfiguration.cs
+++ b/src/Executive/Meetings/Meetings/Infrastructure/Persistence/Configurations/MeetingAttendeeConfiguration.cs
@@ -1,6 +1,8 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
+using YourBrand.Meetings.Domain.Entities;
+
 namespace YourBrand.Meetings.Infrastructure.Persistence.Configurations;
 
 public sealed class MeetingAttendeeConfiguration : IEntityTypeConfiguration<MeetingAttendee>
@@ -17,7 +19,13 @@ public sealed class MeetingAttendeeConfiguration : IEntityTypeConfiguration<Meet
                .WithMany()
                .OnDelete(DeleteBehavior.NoAction);
 
+        builder.HasMany(x => x.Functions)
+               .WithOne(x => x.MeetingAttendee)
+               .HasForeignKey(x => new { x.OrganizationId, x.MeetingId, x.MeetingAttendeeId })
+               .OnDelete(DeleteBehavior.Cascade);
+
         builder.Navigation(x => x.Role).AutoInclude();
+        builder.Navigation(x => x.Functions).AutoInclude();
 
         builder.HasOne(x => x.CreatedBy)
             .WithMany()

--- a/src/Executive/Meetings/Meetings/Infrastructure/Persistence/Configurations/MeetingAttendeeFunctionConfiguration.cs
+++ b/src/Executive/Meetings/Meetings/Infrastructure/Persistence/Configurations/MeetingAttendeeFunctionConfiguration.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using YourBrand.Meetings.Domain.Entities;
+
+namespace YourBrand.Meetings.Infrastructure.Persistence.Configurations;
+
+public sealed class MeetingAttendeeFunctionConfiguration : IEntityTypeConfiguration<MeetingAttendeeFunction>
+{
+    public void Configure(EntityTypeBuilder<MeetingAttendeeFunction> builder)
+    {
+        builder.ToTable("MeetingAttendeeFunctions");
+
+        builder.HasKey(x => new { x.OrganizationId, x.MeetingId, x.MeetingAttendeeId, x.Id });
+
+        builder.HasIndex(x => x.TenantId);
+
+        builder.HasOne(x => x.MeetingAttendee)
+            .WithMany(x => x.Functions)
+            .HasForeignKey(x => new { x.OrganizationId, x.MeetingId, x.MeetingAttendeeId })
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(x => x.Function)
+            .WithMany()
+            .HasForeignKey(x => x.MeetingFunctionId)
+            .OnDelete(DeleteBehavior.NoAction);
+
+        builder.Navigation(x => x.Function).AutoInclude();
+
+        builder.HasOne(x => x.CreatedBy)
+            .WithMany()
+            .OnDelete(DeleteBehavior.NoAction);
+
+        builder.HasOne(x => x.LastModifiedBy)
+            .WithMany()
+            .OnDelete(DeleteBehavior.NoAction);
+
+        builder.Ignore(e => e.DomainEvents);
+    }
+}

--- a/src/Executive/Meetings/Meetings/Infrastructure/Persistence/Migrations/20251023222830_AddMeetingFunctionToElections.Designer.cs
+++ b/src/Executive/Meetings/Meetings/Infrastructure/Persistence/Migrations/20251023222830_AddMeetingFunctionToElections.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using YourBrand.Meetings.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using YourBrand.Meetings.Infrastructure.Persistence;
 namespace YourBrand.Meetings.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251023222830_AddMeetingFunctionToElections")]
+    partial class AddMeetingFunctionToElections
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Executive/Meetings/Meetings/Infrastructure/Persistence/Migrations/20251023222830_AddMeetingFunctionToElections.cs
+++ b/src/Executive/Meetings/Meetings/Infrastructure/Persistence/Migrations/20251023222830_AddMeetingFunctionToElections.cs
@@ -1,0 +1,214 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace YourBrand.Meetings.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMeetingFunctionToElections : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_AgendaItemTypes_AttendeeRoles_HandledByRoleId",
+                table: "AgendaItemTypes");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Elections_MemberRoles_PositionId",
+                table: "Elections");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Meetings_AttendeeRoles_JoinAsId",
+                table: "Meetings");
+
+            migrationBuilder.RenameColumn(
+                name: "PositionId",
+                table: "Elections",
+                newName: "MeetingFunctionId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_Elections_PositionId",
+                table: "Elections",
+                newName: "IX_Elections_MeetingFunctionId");
+
+            migrationBuilder.RenameColumn(
+                name: "HandledByRoleId",
+                table: "AgendaItemTypes",
+                newName: "HandledByFunctionId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_AgendaItemTypes_HandledByRoleId",
+                table: "AgendaItemTypes",
+                newName: "IX_AgendaItemTypes_HandledByFunctionId");
+
+            migrationBuilder.CreateTable(
+                name: "MeetingFunctions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MeetingFunctions", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "MeetingAttendeeFunctions",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    OrganizationId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    MeetingId = table.Column<int>(type: "int", nullable: false),
+                    MeetingAttendeeId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    TenantId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    MeetingFunctionId = table.Column<int>(type: "int", nullable: false),
+                    AssignedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    RevokedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    CreatedById = table.Column<string>(type: "nvarchar(450)", nullable: true),
+                    Created = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    LastModifiedById = table.Column<string>(type: "nvarchar(450)", nullable: true),
+                    LastModified = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MeetingAttendeeFunctions", x => new { x.OrganizationId, x.MeetingId, x.MeetingAttendeeId, x.Id });
+                    table.ForeignKey(
+                        name: "FK_MeetingAttendeeFunctions_MeetingAttendees_OrganizationId_MeetingId_MeetingAttendeeId",
+                        columns: x => new { x.OrganizationId, x.MeetingId, x.MeetingAttendeeId },
+                        principalTable: "MeetingAttendees",
+                        principalColumns: new[] { "OrganizationId", "MeetingId", "Id" },
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_MeetingAttendeeFunctions_MeetingFunctions_MeetingFunctionId",
+                        column: x => x.MeetingFunctionId,
+                        principalTable: "MeetingFunctions",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_MeetingAttendeeFunctions_Users_CreatedById",
+                        column: x => x.CreatedById,
+                        principalTable: "Users",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_MeetingAttendeeFunctions_Users_LastModifiedById",
+                        column: x => x.LastModifiedById,
+                        principalTable: "Users",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MeetingAttendeeFunctions_CreatedById",
+                table: "MeetingAttendeeFunctions",
+                column: "CreatedById");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MeetingAttendeeFunctions_LastModifiedById",
+                table: "MeetingAttendeeFunctions",
+                column: "LastModifiedById");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MeetingAttendeeFunctions_MeetingFunctionId",
+                table: "MeetingAttendeeFunctions",
+                column: "MeetingFunctionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MeetingAttendeeFunctions_OrganizationId",
+                table: "MeetingAttendeeFunctions",
+                column: "OrganizationId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MeetingAttendeeFunctions_TenantId",
+                table: "MeetingAttendeeFunctions",
+                column: "TenantId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_AgendaItemTypes_MeetingFunctions_HandledByFunctionId",
+                table: "AgendaItemTypes",
+                column: "HandledByFunctionId",
+                principalTable: "MeetingFunctions",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Elections_MeetingFunctions_MeetingFunctionId",
+                table: "Elections",
+                column: "MeetingFunctionId",
+                principalTable: "MeetingFunctions",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Meetings_AttendeeRoles_JoinAsId",
+                table: "Meetings",
+                column: "JoinAsId",
+                principalTable: "AttendeeRoles",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_AgendaItemTypes_MeetingFunctions_HandledByFunctionId",
+                table: "AgendaItemTypes");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Elections_MeetingFunctions_MeetingFunctionId",
+                table: "Elections");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Meetings_AttendeeRoles_JoinAsId",
+                table: "Meetings");
+
+            migrationBuilder.DropTable(
+                name: "MeetingAttendeeFunctions");
+
+            migrationBuilder.DropTable(
+                name: "MeetingFunctions");
+
+            migrationBuilder.RenameColumn(
+                name: "MeetingFunctionId",
+                table: "Elections",
+                newName: "PositionId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_Elections_MeetingFunctionId",
+                table: "Elections",
+                newName: "IX_Elections_PositionId");
+
+            migrationBuilder.RenameColumn(
+                name: "HandledByFunctionId",
+                table: "AgendaItemTypes",
+                newName: "HandledByRoleId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_AgendaItemTypes_HandledByFunctionId",
+                table: "AgendaItemTypes",
+                newName: "IX_AgendaItemTypes_HandledByRoleId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_AgendaItemTypes_AttendeeRoles_HandledByRoleId",
+                table: "AgendaItemTypes",
+                column: "HandledByRoleId",
+                principalTable: "AttendeeRoles",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Elections_MemberRoles_PositionId",
+                table: "Elections",
+                column: "PositionId",
+                principalTable: "MemberRoles",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Meetings_AttendeeRoles_JoinAsId",
+                table: "Meetings",
+                column: "JoinAsId",
+                principalTable: "AttendeeRoles",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/src/Executive/Meetings/Meetings/Infrastructure/Persistence/Seed.cs
+++ b/src/Executive/Meetings/Meetings/Infrastructure/Persistence/Seed.cs
@@ -1,6 +1,8 @@
-﻿using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
+using YourBrand.Meetings.Domain.Entities;
 using YourBrand.Tenancy;
 
 namespace YourBrand.Meetings.Infrastructure.Persistence;
@@ -26,6 +28,12 @@ public static class Seed
         if (!await context.AttendeeRoles.AnyAsync())
         {
             await context.AttendeeRoles.AddRangeAsync(AttendeeRole.AllRoles);
+            await context.SaveChangesAsync();
+        }
+
+        if (!await context.MeetingFunctions.AnyAsync())
+        {
+            await context.MeetingFunctions.AddRangeAsync(MeetingFunction.AllFunctions);
             await context.SaveChangesAsync();
         }
 
@@ -130,6 +138,20 @@ public static class Seed
 
             await annualGeneralMeeting.AddAttendeesFromGroup(housingCooperative, context);
 
+            var orderedAttendees = annualGeneralMeeting.Attendees
+                .OrderBy(x => x.Order)
+                .ToList();
+
+            if (orderedAttendees.Count > 0)
+            {
+                orderedAttendees[0].SetFunctions(new[] { MeetingFunction.Chairperson });
+            }
+
+            if (orderedAttendees.Count > 1)
+            {
+                orderedAttendees[1].SetFunctions(new[] { MeetingFunction.Secretary });
+            }
+
             context.Meetings.Add(annualGeneralMeeting);
 
             await context.SaveChangesAsync();
@@ -176,7 +198,7 @@ public static class Seed
         meetingGroup.AddMember(
             name: "Alice Smith",
             email: "alice.smith@example.com",
-            role: AttendeeRole.Chairperson,
+            role: AttendeeRole.Member,
             userId: TenantConstants.UserAliceId,
             hasSpeakingRights: true,
             hasVotingRights: true
@@ -186,7 +208,7 @@ public static class Seed
         meetingGroup.AddMember(
             name: "Bob Smith",
             email: "bob.smith@example.com",
-            role: AttendeeRole.Attendee,
+            role: AttendeeRole.Member,
             userId: TenantConstants.UserBobId,
             hasSpeakingRights: true,
             hasVotingRights: true
@@ -198,7 +220,7 @@ public static class Seed
             meetingGroup.AddMember(
                 name: $"Member {i}",
                 email: $"member{i}@example.com",
-                role: AttendeeRole.Attendee,
+                role: AttendeeRole.Member,
                 userId: null,
                 hasSpeakingRights: true,
                 hasVotingRights: true
@@ -227,7 +249,7 @@ public static class Seed
         meetingGroup.AddMember(
             name: "Alice Smith",
             email: "alice.smith@example.com",
-            role: AttendeeRole.Attendee,
+            role: AttendeeRole.Member,
             userId: TenantConstants.UserAliceId,
             hasSpeakingRights: true,
             hasVotingRights: true
@@ -237,7 +259,7 @@ public static class Seed
         meetingGroup.AddMember(
             name: "Bob Smith",
             email: "bob.smith@example.com",
-            role: AttendeeRole.Attendee,
+            role: AttendeeRole.Member,
             userId: TenantConstants.UserBobId,
             hasSpeakingRights: true,
             hasVotingRights: true
@@ -249,7 +271,7 @@ public static class Seed
             meetingGroup.AddMember(
                 name: $"Member {i}",
                 email: $"member{i}@example.com",
-                role: AttendeeRole.Attendee,
+                role: AttendeeRole.Member,
                 userId: null,
                 hasSpeakingRights: true,
                 hasVotingRights: true
@@ -482,10 +504,11 @@ public static class Seed
             description: "Election of board members and officials as per organizational bylaws."
         );
 
-        var election = new Election() 
-        { 
+        var election = new Election()
+        {
             OrganizationId = TenantConstants.OrganizationId,
-            Position = MemberRole.Chairperson,
+            MeetingFunction = MeetingFunction.Chairperson,
+            MeetingFunctionId = MeetingFunction.Chairperson.Id,
             GroupId = 3
         };
 
@@ -502,7 +525,8 @@ public static class Seed
         election = new Election()
         {
             OrganizationId = TenantConstants.OrganizationId,
-            Position = MemberRole.ViceChairperson,
+            MeetingFunction = MeetingFunction.Facilitator,
+            MeetingFunctionId = MeetingFunction.Facilitator.Id,
             GroupId = 3
         };
 
@@ -518,7 +542,8 @@ public static class Seed
         election = new Election()
         {
             OrganizationId = TenantConstants.OrganizationId,
-            Position = MemberRole.Secretary,
+            MeetingFunction = MeetingFunction.Secretary,
+            MeetingFunctionId = MeetingFunction.Secretary.Id,
             GroupId = 3
         };
 
@@ -534,7 +559,8 @@ public static class Seed
         election = new Election()
         {
             OrganizationId = TenantConstants.OrganizationId,
-            Position = MemberRole.Treasurer,
+            MeetingFunction = MeetingFunction.Timekeeper,
+            MeetingFunctionId = MeetingFunction.Timekeeper.Id,
             GroupId = 3
         };
 
@@ -550,7 +576,7 @@ public static class Seed
         election = new Election()
         {
             OrganizationId = TenantConstants.OrganizationId,
-            Position = MemberRole.Member,
+            MeetingFunctionId = null,
             GroupId = 3
         };
 
@@ -566,7 +592,7 @@ public static class Seed
         election = new Election()
         {
             OrganizationId = TenantConstants.OrganizationId,
-            Position = MemberRole.Member,
+            MeetingFunctionId = null,
             GroupId = 3
         };
 
@@ -582,7 +608,7 @@ public static class Seed
         election = new Election()
         {
             OrganizationId = TenantConstants.OrganizationId,
-            Position = MemberRole.Member,
+            MeetingFunctionId = null,
             GroupId = 3
         };
 
@@ -598,7 +624,7 @@ public static class Seed
         election = new Election()
         {
             OrganizationId = TenantConstants.OrganizationId,
-            Position = MemberRole.Alternate,
+            MeetingFunctionId = null,
             GroupId = 3
         };
 
@@ -614,7 +640,7 @@ public static class Seed
         election = new Election()
         {
             OrganizationId = TenantConstants.OrganizationId,
-            Position = MemberRole.Alternate,
+            MeetingFunctionId = null,
             GroupId = 3
         };
 

--- a/src/Executive/Meetings/Meetings/Infrastructure/Persistence/ValueConverters.cs
+++ b/src/Executive/Meetings/Meetings/Infrastructure/Persistence/ValueConverters.cs
@@ -36,6 +36,14 @@ internal sealed class MeetingAttendeeIdConverter : ValueConverter<MeetingAttende
     }
 }
 
+internal sealed class MeetingAttendeeFunctionIdConverter : ValueConverter<MeetingAttendeeFunctionId, string>
+{
+    public MeetingAttendeeFunctionIdConverter()
+        : base(v => v.Value, v => new(v))
+    {
+    }
+}
+
 internal sealed class DebateIdConverter : ValueConverter<DebateId, int>
 {
     public DebateIdConverter()


### PR DESCRIPTION
## Summary
- add meeting function support to elections, agenda items, and persistence including DTO and OpenAPI updates
- allow meeting procedures to authorize facilitators or creators before a chairperson is elected and assign elected attendees to meeting functions
- seed and migrate meeting data with meeting functions to back new election capabilities

## Testing
- dotnet build YourBrand.sln

------
https://chatgpt.com/codex/tasks/task_e_68fa8e4fae0c832fb57fa5d371e11df3