### PR TITLE
Add minutes task workflow to meetings service

### DIFF
--- a/src/Executive/Meetings/Meetings.Client/OpenAPIs/swagger.yaml
+++ b/src/Executive/Meetings/Meetings.Client/OpenAPIs/swagger.yaml
@@ -3142,6 +3142,109 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProblemDetails'
+  /v1/Minutes/{minutesId}/tasks:
+    get:
+      tags:
+      - Minutes
+      operationId: Minutes_GetMinutesTasks
+      parameters:
+      - name: organizationId
+        in: query
+        schema:
+          type: string
+        x-position: 1
+      - name: minutesId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+        x-position: 2
+      responses:
+        200:
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MinutesTask'
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+  /v1/Minutes/tasks/my:
+    get:
+      tags:
+      - Minutes
+      operationId: Minutes_GetMyMinutesTasks
+      parameters:
+      - name: organizationId
+        in: query
+        schema:
+          type: string
+        x-position: 1
+      - name: status
+        in: query
+        schema:
+          oneOf:
+          - nullable: true
+            oneOf:
+            - $ref: '#/components/schemas/MinutesTaskStatus'
+        x-position: 2
+      responses:
+        200:
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MinutesTask'
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+      security:
+      - JWT: []
+  /v1/Minutes/tasks/{taskId}/complete:
+    post:
+      tags:
+      - Minutes
+      operationId: Minutes_CompleteMinutesTask
+      parameters:
+      - name: organizationId
+        in: query
+        schema:
+          type: string
+        x-position: 1
+      - name: taskId
+        in: path
+        required: true
+        schema:
+          type: string
+        x-position: 2
+      responses:
+        200:
+          description: ''
+        404:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+      security:
+      - JWT: []
   /v1/MeetingGroups:
     get:
       tags:
@@ -5004,6 +5107,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/MinutesItem'
+        tasks:
+          type: array
+          items:
+            $ref: '#/components/schemas/MinutesTask'
     MinutesState:
       type: integer
       description: ''
@@ -5041,6 +5148,61 @@ components:
           type: integer
           format: int32
           nullable: true
+    MinutesTask:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+        type:
+          $ref: '#/components/schemas/MinutesTaskType'
+        status:
+          $ref: '#/components/schemas/MinutesTaskStatus'
+        title:
+          type: string
+        description:
+          type: string
+          nullable: true
+        assignedAt:
+          type: string
+          format: date-time
+        dueAt:
+          type: string
+          format: date-time
+          nullable: true
+        assignedToId:
+          type: string
+          nullable: true
+        assignedToName:
+          type: string
+          nullable: true
+        assignedToEmail:
+          type: string
+          nullable: true
+        completedAt:
+          type: string
+          format: date-time
+          nullable: true
+    MinutesTaskType:
+      type: integer
+      description: ''
+      x-enumNames:
+      - AdjustMinutes
+      - ApproveMinutes
+      enum:
+      - 0
+      - 1
+    MinutesTaskStatus:
+      type: integer
+      description: ''
+      x-enumNames:
+      - Pending
+      - Completed
+      - Cancelled
+      enum:
+      - 0
+      - 1
+      - 2
     MinutesItemState:
       type: integer
       description: ''

--- a/src/Executive/Meetings/Meetings.Shared/OpenAPIs/swagger.yaml
+++ b/src/Executive/Meetings/Meetings.Shared/OpenAPIs/swagger.yaml
@@ -3142,6 +3142,109 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProblemDetails'
+  /v1/Minutes/{minutesId}/tasks:
+    get:
+      tags:
+      - Minutes
+      operationId: Minutes_GetMinutesTasks
+      parameters:
+      - name: organizationId
+        in: query
+        schema:
+          type: string
+        x-position: 1
+      - name: minutesId
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+        x-position: 2
+      responses:
+        200:
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MinutesTask'
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+  /v1/Minutes/tasks/my:
+    get:
+      tags:
+      - Minutes
+      operationId: Minutes_GetMyMinutesTasks
+      parameters:
+      - name: organizationId
+        in: query
+        schema:
+          type: string
+        x-position: 1
+      - name: status
+        in: query
+        schema:
+          oneOf:
+          - nullable: true
+            oneOf:
+            - $ref: '#/components/schemas/MinutesTaskStatus'
+        x-position: 2
+      responses:
+        200:
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MinutesTask'
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+      security:
+      - JWT: []
+  /v1/Minutes/tasks/{taskId}/complete:
+    post:
+      tags:
+      - Minutes
+      operationId: Minutes_CompleteMinutesTask
+      parameters:
+      - name: organizationId
+        in: query
+        schema:
+          type: string
+        x-position: 1
+      - name: taskId
+        in: path
+        required: true
+        schema:
+          type: string
+        x-position: 2
+      responses:
+        200:
+          description: ''
+        404:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+        default:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+      security:
+      - JWT: []
   /v1/MeetingGroups:
     get:
       tags:
@@ -5004,6 +5107,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/MinutesItem'
+        tasks:
+          type: array
+          items:
+            $ref: '#/components/schemas/MinutesTask'
     MinutesState:
       type: integer
       description: ''
@@ -5041,6 +5148,61 @@ components:
           type: integer
           format: int32
           nullable: true
+    MinutesTask:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+        type:
+          $ref: '#/components/schemas/MinutesTaskType'
+        status:
+          $ref: '#/components/schemas/MinutesTaskStatus'
+        title:
+          type: string
+        description:
+          type: string
+          nullable: true
+        assignedAt:
+          type: string
+          format: date-time
+        dueAt:
+          type: string
+          format: date-time
+          nullable: true
+        assignedToId:
+          type: string
+          nullable: true
+        assignedToName:
+          type: string
+          nullable: true
+        assignedToEmail:
+          type: string
+          nullable: true
+        completedAt:
+          type: string
+          format: date-time
+          nullable: true
+    MinutesTaskType:
+      type: integer
+      description: ''
+      x-enumNames:
+      - AdjustMinutes
+      - ApproveMinutes
+      enum:
+      - 0
+      - 1
+    MinutesTaskStatus:
+      type: integer
+      description: ''
+      x-enumNames:
+      - Pending
+      - Completed
+      - Cancelled
+      enum:
+      - 0
+      - 1
+      - 2
     MinutesItemState:
       type: integer
       description: ''

--- a/src/Executive/Meetings/Meetings/Domain/Entities/Meeting.cs
+++ b/src/Executive/Meetings/Meetings/Domain/Entities/Meeting.cs
@@ -423,6 +423,11 @@ public class Meeting : AggregateRoot<MeetingId>, IAuditableEntity<MeetingId>, IH
         return Attendees.FirstOrDefault(x => x.UserId == userId);
     }
 
+    public IEnumerable<MeetingAttendee> GetAttendeesByFunction(MeetingFunction function)
+    {
+        return Attendees.Where(x => x.HasFunction(function));
+    }
+
     public void SetOpenAccess(bool canAnyoneJoin, AttendeeRole joinAs)
     {
         if (canAnyoneJoin && joinAs != AttendeeRole.Member && joinAs != AttendeeRole.Observer)

--- a/src/Executive/Meetings/Meetings/Domain/Entities/MinutesTask.cs
+++ b/src/Executive/Meetings/Meetings/Domain/Entities/MinutesTask.cs
@@ -1,0 +1,98 @@
+using YourBrand.Auditability;
+using YourBrand.Domain;
+using YourBrand.Identity;
+using YourBrand.Meetings.Domain.ValueObjects;
+using YourBrand.Tenancy;
+
+namespace YourBrand.Meetings.Domain.Entities;
+
+public enum MinutesTaskType
+{
+    AdjustMinutes,
+    ApproveMinutes
+}
+
+public enum MinutesTaskStatus
+{
+    Pending,
+    Completed,
+    Cancelled
+}
+
+public sealed class MinutesTask : Entity<MinutesTaskId>, IAuditableEntity<MinutesTaskId>, IHasTenant, IHasOrganization
+{
+    public MinutesTask()
+        : base(new MinutesTaskId())
+    {
+    }
+
+    public TenantId TenantId { get; set; }
+
+    public OrganizationId OrganizationId { get; set; }
+
+    public MinutesId MinutesId { get; set; }
+
+    public Minutes? Minutes { get; set; }
+
+    public MinutesTaskType Type { get; set; }
+
+    public MinutesTaskStatus Status { get; private set; } = MinutesTaskStatus.Pending;
+
+    public string Title { get; set; } = null!;
+
+    public string? Description { get; set; }
+
+    public UserId? AssignedToId { get; set; }
+
+    public User? AssignedTo { get; set; }
+
+    public string? AssignedToName { get; set; }
+
+    public string? AssignedToEmail { get; set; }
+
+    public DateTimeOffset AssignedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    public DateTimeOffset? DueAt { get; set; }
+
+    public DateTimeOffset? CompletedAt { get; private set; }
+
+    public UserId? CompletedById { get; private set; }
+
+    public User? CompletedBy { get; set; }
+
+    public void Complete(UserId completedBy, DateTimeOffset completedAt)
+    {
+        if (Status == MinutesTaskStatus.Completed)
+        {
+            return;
+        }
+
+        Status = MinutesTaskStatus.Completed;
+        CompletedById = completedBy;
+        CompletedAt = completedAt;
+    }
+
+    public void Reopen()
+    {
+        Status = MinutesTaskStatus.Pending;
+        CompletedAt = null;
+        CompletedById = null;
+    }
+
+    public void Cancel()
+    {
+        Status = MinutesTaskStatus.Cancelled;
+    }
+
+    public User? CreatedBy { get; set; } = null!;
+
+    public UserId? CreatedById { get; set; } = null!;
+
+    public DateTimeOffset Created { get; set; }
+
+    public User? LastModifiedBy { get; set; }
+
+    public UserId? LastModifiedById { get; set; }
+
+    public DateTimeOffset? LastModified { get; set; }
+}

--- a/src/Executive/Meetings/Meetings/Domain/Errors/Errors.cs
+++ b/src/Executive/Meetings/Meetings/Domain/Errors/Errors.cs
@@ -88,6 +88,10 @@ public static partial class Errors
         public static readonly Error MinuteNotFound = new Error(nameof(MinuteNotFound), "Minutes not found", string.Empty);
 
         public static readonly Error MinutesItemNotFound = new Error(nameof(MinutesItemNotFound), "Minutes item not found", string.Empty);
+
+        public static readonly Error MinutesTaskNotFound = new Error(nameof(MinutesTaskNotFound), "Minutes task not found", string.Empty);
+
+        public static readonly Error YouAreNotAssignedToThisTask = new Error(nameof(YouAreNotAssignedToThisTask), "You are not assigned to this task.", string.Empty);
     }
 
     public static class Motions

--- a/src/Executive/Meetings/Meetings/Domain/IApplicationDbContext.cs
+++ b/src/Executive/Meetings/Meetings/Domain/IApplicationDbContext.cs
@@ -22,6 +22,8 @@ public interface IApplicationDbContext
 
     DbSet<Entities.Minutes> Minutes { get; }
 
+    DbSet<MinutesTask> MinutesTasks { get; }
+
     DbSet<Motion> Motions { get; }
 
     DbSet<MeetingGroup> MeetingGroups { get; }

--- a/src/Executive/Meetings/Meetings/Domain/ValueObjects/MinutesTaskId.cs
+++ b/src/Executive/Meetings/Meetings/Domain/ValueObjects/MinutesTaskId.cs
@@ -1,0 +1,46 @@
+using System;
+
+namespace YourBrand.Meetings.Domain.ValueObjects;
+
+public readonly struct MinutesTaskId : IEquatable<MinutesTaskId>
+{
+    public MinutesTaskId(string value)
+    {
+        Value = value;
+    }
+
+    public MinutesTaskId()
+        : this(Guid.NewGuid().ToString())
+    {
+    }
+
+    public string Value { get; }
+
+    public bool Equals(MinutesTaskId other) => Value == other.Value;
+
+    public override bool Equals(object? obj) => obj is MinutesTaskId other && Equals(other);
+
+    public override int GetHashCode() => Value.GetHashCode(StringComparison.Ordinal);
+
+    public override string ToString() => Value;
+
+    public static bool operator ==(MinutesTaskId lhs, MinutesTaskId rhs) => lhs.Equals(rhs);
+
+    public static bool operator !=(MinutesTaskId lhs, MinutesTaskId rhs) => !lhs.Equals(rhs);
+
+    public static implicit operator MinutesTaskId(string id) => new(id);
+
+    public static implicit operator string(MinutesTaskId id) => id.Value;
+
+    public static bool TryParse(string? value, out MinutesTaskId minutesTaskId)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            minutesTaskId = default;
+            return false;
+        }
+
+        minutesTaskId = new MinutesTaskId(value);
+        return true;
+    }
+}

--- a/src/Executive/Meetings/Meetings/Features/Minutes/Mapper.cs
+++ b/src/Executive/Meetings/Meetings/Features/Minutes/Mapper.cs
@@ -1,4 +1,7 @@
-﻿using YourBrand.Meetings.Features.Agendas;
+using System.Linq;
+
+using YourBrand.Meetings.Domain.Entities;
+using YourBrand.Meetings.Features.Agendas;
 using YourBrand.Meetings.Features.Organizations;
 using YourBrand.Meetings.Features.Users;
 
@@ -6,6 +9,23 @@ namespace YourBrand.Meetings.Features.Minutes;
 
 public static partial class Mappings
 {
-    public static MinutesDto ToDto(this Domain.Entities.Minutes minute) => new(minute.Id, minute.MeetingId, minute.State, minute.Items.Select(x => x.ToDto()));
+    public static MinutesDto ToDto(this Domain.Entities.Minutes minute) => new(minute.Id, minute.MeetingId, minute.State, minute.Items.Select(x => x.ToDto()))
+    {
+        Tasks = minute.Tasks.Select(x => x.ToDto()).ToArray()
+    };
+
     public static MinutesItemDto ToDto(this MinutesItem item) => new(item.Id, item.Order, item.Type.ToDto(), item.AgendaId, item.AgendaItemId, item.Heading!, item.State, item.Details, item.MotionId);
+
+    public static MinutesTaskDto ToDto(this MinutesTask task) => new(
+        task.Id,
+        task.Type,
+        task.Status,
+        task.Title,
+        task.Description,
+        task.AssignedAt,
+        task.DueAt,
+        task.AssignedToId,
+        task.AssignedToName,
+        task.AssignedToEmail,
+        task.CompletedAt);
 }

--- a/src/Executive/Meetings/Meetings/Features/Minutes/MinutesDto.cs
+++ b/src/Executive/Meetings/Meetings/Features/Minutes/MinutesDto.cs
@@ -1,6 +1,24 @@
+using System;
+
 using YourBrand.Meetings.Features.Agendas;
 
 namespace YourBrand.Meetings.Features.Minutes;
 
-public sealed record MinutesDto(int Id, int MeetingId, MinutesState State, IEnumerable<MinutesItemDto> Items);
+public sealed record MinutesDto(int Id, int MeetingId, MinutesState State, IEnumerable<MinutesItemDto> Items)
+{
+    public IEnumerable<MinutesTaskDto> Tasks { get; init; } = Array.Empty<MinutesTaskDto>();
+}
+
 public sealed record MinutesItemDto(string Id, int Order, AgendaItemTypeDto Type, int AgendaId, string AgendaItemId, string Title, MinutesItemState State, string Description, int? MotionId);
+public sealed record MinutesTaskDto(
+    string Id,
+    MinutesTaskType Type,
+    MinutesTaskStatus Status,
+    string Title,
+    string? Description,
+    DateTimeOffset AssignedAt,
+    DateTimeOffset? DueAt,
+    string? AssignedToId,
+    string? AssignedToName,
+    string? AssignedToEmail,
+    DateTimeOffset? CompletedAt);

--- a/src/Executive/Meetings/Meetings/Features/Minutes/Tasks/CompleteMinutesTask.cs
+++ b/src/Executive/Meetings/Meetings/Features/Minutes/Tasks/CompleteMinutesTask.cs
@@ -1,0 +1,51 @@
+using System;
+
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Identity;
+using YourBrand.Meetings.Features.Minutes;
+
+namespace YourBrand.Meetings.Features.Minutes.Tasks;
+
+public sealed record CompleteMinutesTask(string OrganizationId, string TaskId) : IRequest<Result>;
+
+public sealed class CompleteMinutesTaskHandler(IApplicationDbContext context, IUserContext userContext) : IRequestHandler<CompleteMinutesTask, Result>
+{
+    public async Task<Result> Handle(CompleteMinutesTask request, CancellationToken cancellationToken)
+    {
+        if (userContext.UserId is null || string.IsNullOrWhiteSpace(userContext.UserId.Value))
+        {
+            return Errors.Users.UserNotFound;
+        }
+
+        var currentUserId = userContext.UserId.Value;
+
+        var task = await context.MinutesTasks
+            .InOrganization(request.OrganizationId)
+            .Include(x => x.Minutes)
+                .ThenInclude(x => x.Tasks)
+            .FirstOrDefaultAsync(x => x.Id == request.TaskId, cancellationToken);
+
+        if (task is null)
+        {
+            return Errors.Minutes.MinutesTaskNotFound;
+        }
+
+        if (task.AssignedToId != currentUserId)
+        {
+            return Errors.Minutes.YouAreNotAssignedToThisTask;
+        }
+
+        task.Complete(currentUserId, DateTimeOffset.UtcNow);
+
+        task.Minutes?.UpdateStateFromTasks();
+
+        context.MinutesTasks.Update(task);
+
+        await context.SaveChangesAsync(cancellationToken);
+
+        return Result.Success;
+    }
+}

--- a/src/Executive/Meetings/Meetings/Features/Minutes/Tasks/GetMinutesTasks.cs
+++ b/src/Executive/Meetings/Meetings/Features/Minutes/Tasks/GetMinutesTasks.cs
@@ -1,0 +1,26 @@
+using System.Linq;
+
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Meetings.Features.Minutes;
+
+namespace YourBrand.Meetings.Features.Minutes.Tasks;
+
+public sealed record GetMinutesTasks(string OrganizationId, int MinutesId) : IRequest<IEnumerable<MinutesTaskDto>>;
+
+public sealed class GetMinutesTasksHandler(IApplicationDbContext context) : IRequestHandler<GetMinutesTasks, IEnumerable<MinutesTaskDto>>
+{
+    public async Task<IEnumerable<MinutesTaskDto>> Handle(GetMinutesTasks request, CancellationToken cancellationToken)
+    {
+        var tasks = await context.MinutesTasks
+            .InOrganization(request.OrganizationId)
+            .Where(x => x.MinutesId == request.MinutesId)
+            .OrderBy(x => x.Type)
+            .ThenBy(x => x.DueAt)
+            .ToListAsync(cancellationToken);
+
+        return tasks.Select(x => x.ToDto());
+    }
+}

--- a/src/Executive/Meetings/Meetings/Features/Minutes/Tasks/GetMyMinutesTasks.cs
+++ b/src/Executive/Meetings/Meetings/Features/Minutes/Tasks/GetMyMinutesTasks.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Linq;
+
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Identity;
+using YourBrand.Meetings.Features.Minutes;
+
+namespace YourBrand.Meetings.Features.Minutes.Tasks;
+
+public sealed record GetMyMinutesTasks(string OrganizationId, MinutesTaskStatus? Status = null) : IRequest<IEnumerable<MinutesTaskDto>>;
+
+public sealed class GetMyMinutesTasksHandler(IApplicationDbContext context, IUserContext userContext) : IRequestHandler<GetMyMinutesTasks, IEnumerable<MinutesTaskDto>>
+{
+    public async Task<IEnumerable<MinutesTaskDto>> Handle(GetMyMinutesTasks request, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(userContext.UserId))
+        {
+            return Enumerable.Empty<MinutesTaskDto>();
+        }
+
+        var query = context.MinutesTasks
+            .InOrganization(request.OrganizationId)
+            .Where(x => x.AssignedToId == userContext.UserId);
+
+        if (request.Status.HasValue)
+        {
+            query = query.Where(x => x.Status == request.Status);
+        }
+
+        var tasks = await query
+            .OrderBy(x => x.DueAt ?? DateTimeOffset.MaxValue)
+            .ThenBy(x => x.Type)
+            .ToListAsync(cancellationToken);
+
+        return tasks.Select(x => x.ToDto());
+    }
+}

--- a/src/Executive/Meetings/Meetings/Features/Minutes/Tasks/MinutesTasksController.cs
+++ b/src/Executive/Meetings/Meetings/Features/Minutes/Tasks/MinutesTasksController.cs
@@ -1,0 +1,40 @@
+using Asp.Versioning;
+
+using MediatR;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+using YourBrand.Meetings.Features.Minutes;
+
+namespace YourBrand.Meetings.Features.Minutes.Tasks;
+
+[ApiController]
+[ApiVersion("1")]
+[Route("v{version:apiVersion}/Minutes")]
+public sealed class MinutesTasksController(IMediator mediator) : ControllerBase
+{
+    [HttpGet("{minutesId}/tasks")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<MinutesTaskDto>))]
+    [ProducesDefaultResponseType]
+    public async Task<IEnumerable<MinutesTaskDto>> GetMinutesTasks(string organizationId, int minutesId, CancellationToken cancellationToken)
+        => await mediator.Send(new GetMinutesTasks(organizationId, minutesId), cancellationToken);
+
+    [HttpGet("tasks/my")]
+    [Authorize]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<MinutesTaskDto>))]
+    [ProducesDefaultResponseType]
+    public async Task<IEnumerable<MinutesTaskDto>> GetMyMinutesTasks(string organizationId, [FromQuery] MinutesTaskStatus? status, CancellationToken cancellationToken)
+        => await mediator.Send(new GetMyMinutesTasks(organizationId, status), cancellationToken);
+
+    [HttpPost("tasks/{taskId}/complete")]
+    [Authorize]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound, Type = typeof(ProblemDetails))]
+    [ProducesDefaultResponseType]
+    public async Task<ActionResult> CompleteTask(string organizationId, string taskId, CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new CompleteMinutesTask(organizationId, taskId), cancellationToken);
+        return this.HandleResult(result);
+    }
+}

--- a/src/Executive/Meetings/Meetings/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/src/Executive/Meetings/Meetings/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -59,6 +59,7 @@ public sealed class ApplicationDbContext(
         configurationBuilder.Properties<MinutesId>().HaveConversion<MinutesIdConverter>();
         configurationBuilder.Properties<MinutesAttendeeId>().HaveConversion<MinutesAttendeeIdConverter>();
         configurationBuilder.Properties<MinutesItemId>().HaveConversion<MinutesItemIdConverter>();
+        configurationBuilder.Properties<MinutesTaskId>().HaveConversion<MinutesTaskIdConverter>();
         
         configurationBuilder.Properties<MeetingGroupId>().HaveConversion<MeetingGroupIdConverter>();
         configurationBuilder.Properties<MeetingGroupMemberId>().HaveConversion<MeetingGroupMemberIdConverter>();
@@ -85,6 +86,8 @@ public sealed class ApplicationDbContext(
     public DbSet<AgendaItemType> AgendaItemTypes { get; set; }
 
     public DbSet<Domain.Entities.Minutes> Minutes { get; set; }
+
+    public DbSet<MinutesTask> MinutesTasks { get; set; }
 
     public DbSet<Motion> Motions { get; set; }
 

--- a/src/Executive/Meetings/Meetings/Infrastructure/Persistence/Configurations/MinuteConfiguration.cs
+++ b/src/Executive/Meetings/Meetings/Infrastructure/Persistence/Configurations/MinuteConfiguration.cs
@@ -1,7 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
-namespace YourBrand.Minutes.Infrastructure.Persistence.Configurations;
+namespace YourBrand.Meetings.Infrastructure.Persistence.Configurations;
 
 public sealed class MinuteConfiguration : IEntityTypeConfiguration<Meetings.Domain.Entities.Minutes>
 {
@@ -30,6 +30,12 @@ public sealed class MinuteConfiguration : IEntityTypeConfiguration<Meetings.Doma
             .HasForeignKey(x => new { x.OrganizationId, x.MinutesId });
 
         builder.Navigation(x => x.Items).AutoInclude();
+
+        builder.HasMany(x => x.Tasks)
+            .WithOne()
+            .HasForeignKey(x => new { x.OrganizationId, x.MinutesId });
+
+        builder.Navigation(x => x.Tasks).AutoInclude();
 
         builder.HasOne(x => x.CreatedBy)
             .WithMany()

--- a/src/Executive/Meetings/Meetings/Infrastructure/Persistence/Configurations/MinutesTaskConfiguration.cs
+++ b/src/Executive/Meetings/Meetings/Infrastructure/Persistence/Configurations/MinutesTaskConfiguration.cs
@@ -1,0 +1,52 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using YourBrand.Meetings.Domain.Entities;
+
+namespace YourBrand.Meetings.Infrastructure.Persistence.Configurations;
+
+public sealed class MinutesTaskConfiguration : IEntityTypeConfiguration<MinutesTask>
+{
+    public void Configure(EntityTypeBuilder<MinutesTask> builder)
+    {
+        builder.ToTable("MinutesTasks");
+
+        builder.HasKey(x => new { x.OrganizationId, x.MinutesId, x.Id });
+
+        builder.HasIndex(x => x.OrganizationId);
+        builder.HasIndex(x => x.TenantId);
+
+        builder.HasOne(x => x.Minutes)
+            .WithMany(x => x.Tasks)
+            .HasForeignKey(x => new { x.OrganizationId, x.MinutesId })
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Property(x => x.Title)
+            .HasMaxLength(200)
+            .IsRequired();
+
+        builder.Property(x => x.AssignedToName)
+            .HasMaxLength(200);
+
+        builder.Property(x => x.AssignedToEmail)
+            .HasMaxLength(200);
+
+        builder.HasOne(x => x.AssignedTo)
+            .WithMany()
+            .OnDelete(DeleteBehavior.NoAction);
+
+        builder.HasOne(x => x.CompletedBy)
+            .WithMany()
+            .OnDelete(DeleteBehavior.NoAction);
+
+        builder.HasOne(x => x.CreatedBy)
+            .WithMany()
+            .OnDelete(DeleteBehavior.NoAction);
+
+        builder.HasOne(x => x.LastModifiedBy)
+            .WithMany()
+            .OnDelete(DeleteBehavior.NoAction);
+
+        builder.Ignore(x => x.DomainEvents);
+    }
+}

--- a/src/Executive/Meetings/Meetings/Infrastructure/Persistence/Migrations/20251023222830_AddMeetingFunctionToElections.Designer.cs
+++ b/src/Executive/Meetings/Meetings/Infrastructure/Persistence/Migrations/20251023222830_AddMeetingFunctionToElections.Designer.cs
@@ -1119,6 +1119,87 @@ namespace YourBrand.Meetings.Infrastructure.Persistence.Migrations
                     b.ToTable("MinutesItems", (string)null);
                 });
 
+            modelBuilder.Entity("YourBrand.Meetings.Domain.Entities.MinutesTask", b =>
+                {
+                    b.Property<string>("OrganizationId")
+                        .HasColumnType("nvarchar(450)");
+
+                    b.Property<int>("MinutesId")
+                        .HasColumnType("int");
+
+                    b.Property<string>("Id")
+                        .HasColumnType("nvarchar(450)");
+
+                    b.Property<DateTimeOffset>("AssignedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<string>("AssignedToEmail")
+                        .HasMaxLength(200)
+                        .HasColumnType("nvarchar(200)");
+
+                    b.Property<string>("AssignedToId")
+                        .HasColumnType("nvarchar(450)");
+
+                    b.Property<string>("AssignedToName")
+                        .HasMaxLength(200)
+                        .HasColumnType("nvarchar(200)");
+
+                    b.Property<DateTimeOffset?>("CompletedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<string>("CompletedById")
+                        .HasColumnType("nvarchar(450)");
+
+                    b.Property<DateTimeOffset>("Created")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<string>("CreatedById")
+                        .HasColumnType("nvarchar(450)");
+
+                    b.Property<string>("Description")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<DateTimeOffset?>("DueAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<DateTimeOffset?>("LastModified")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<string>("LastModifiedById")
+                        .HasColumnType("nvarchar(450)");
+
+                    b.Property<int>("Status")
+                        .HasColumnType("int");
+
+                    b.Property<string>("TenantId")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(450)");
+
+                    b.Property<string>("Title")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("nvarchar(200)");
+
+                    b.Property<int>("Type")
+                        .HasColumnType("int");
+
+                    b.HasKey("OrganizationId", "MinutesId", "Id");
+
+                    b.HasIndex("AssignedToId");
+
+                    b.HasIndex("CompletedById");
+
+                    b.HasIndex("CreatedById");
+
+                    b.HasIndex("LastModifiedById");
+
+                    b.HasIndex("OrganizationId");
+
+                    b.HasIndex("TenantId");
+
+                    b.ToTable("MinutesTasks", (string)null);
+                });
+
             modelBuilder.Entity("YourBrand.Meetings.Domain.Entities.Motion", b =>
                 {
                     b.Property<string>("OrganizationId")
@@ -2040,6 +2121,43 @@ namespace YourBrand.Meetings.Infrastructure.Persistence.Migrations
                     b.Navigation("Type");
                 });
 
+            modelBuilder.Entity("YourBrand.Meetings.Domain.Entities.MinutesTask", b =>
+                {
+                    b.HasOne("YourBrand.Meetings.Domain.Entities.User", "AssignedTo")
+                        .WithMany()
+                        .HasForeignKey("AssignedToId")
+                        .OnDelete(DeleteBehavior.NoAction);
+
+                    b.HasOne("YourBrand.Meetings.Domain.Entities.User", "CompletedBy")
+                        .WithMany()
+                        .HasForeignKey("CompletedById")
+                        .OnDelete(DeleteBehavior.NoAction);
+
+                    b.HasOne("YourBrand.Meetings.Domain.Entities.User", "CreatedBy")
+                        .WithMany()
+                        .HasForeignKey("CreatedById")
+                        .OnDelete(DeleteBehavior.NoAction);
+
+                    b.HasOne("YourBrand.Meetings.Domain.Entities.User", "LastModifiedBy")
+                        .WithMany()
+                        .HasForeignKey("LastModifiedById")
+                        .OnDelete(DeleteBehavior.NoAction);
+
+                    b.HasOne("YourBrand.Meetings.Domain.Entities.Minutes", null)
+                        .WithMany("Tasks")
+                        .HasForeignKey("OrganizationId", "MinutesId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("AssignedTo");
+
+                    b.Navigation("CompletedBy");
+
+                    b.Navigation("CreatedBy");
+
+                    b.Navigation("LastModifiedBy");
+                });
+
             modelBuilder.Entity("YourBrand.Meetings.Domain.Entities.Motion", b =>
                 {
                     b.HasOne("YourBrand.Meetings.Domain.Entities.User", "CreatedBy")
@@ -2268,6 +2386,8 @@ namespace YourBrand.Meetings.Infrastructure.Persistence.Migrations
                     b.Navigation("Attendees");
 
                     b.Navigation("Items");
+
+                    b.Navigation("Tasks");
                 });
 
             modelBuilder.Entity("YourBrand.Meetings.Domain.Entities.Motion", b =>

--- a/src/Executive/Meetings/Meetings/Infrastructure/Persistence/Migrations/20251023222830_AddMeetingFunctionToElections.cs
+++ b/src/Executive/Meetings/Meetings/Infrastructure/Persistence/Migrations/20251023222830_AddMeetingFunctionToElections.cs
@@ -125,6 +125,86 @@ namespace YourBrand.Meetings.Infrastructure.Persistence.Migrations
                 table: "MeetingAttendeeFunctions",
                 column: "TenantId");
 
+            migrationBuilder.CreateTable(
+                name: "MinutesTasks",
+                columns: table => new
+                {
+                    OrganizationId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    MinutesId = table.Column<int>(type: "int", nullable: false),
+                    Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    TenantId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    Type = table.Column<int>(type: "int", nullable: false),
+                    Status = table.Column<int>(type: "int", nullable: false),
+                    Title = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    AssignedToId = table.Column<string>(type: "nvarchar(450)", nullable: true),
+                    AssignedToName = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    AssignedToEmail = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: true),
+                    AssignedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    DueAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    CompletedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    CompletedById = table.Column<string>(type: "nvarchar(450)", nullable: true),
+                    Created = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    CreatedById = table.Column<string>(type: "nvarchar(450)", nullable: true),
+                    LastModified = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    LastModifiedById = table.Column<string>(type: "nvarchar(450)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MinutesTasks", x => new { x.OrganizationId, x.MinutesId, x.Id });
+                    table.ForeignKey(
+                        name: "FK_MinutesTasks_Minutes_OrganizationId_MinutesId",
+                        columns: x => new { x.OrganizationId, x.MinutesId },
+                        principalTable: "Minutes",
+                        principalColumns: new[] { "OrganizationId", "Id" },
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_MinutesTasks_Users_AssignedToId",
+                        column: x => x.AssignedToId,
+                        principalTable: "Users",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_MinutesTasks_Users_CompletedById",
+                        column: x => x.CompletedById,
+                        principalTable: "Users",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_MinutesTasks_Users_CreatedById",
+                        column: x => x.CreatedById,
+                        principalTable: "Users",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_MinutesTasks_Users_LastModifiedById",
+                        column: x => x.LastModifiedById,
+                        principalTable: "Users",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MinutesTasks_AssignedToId",
+                table: "MinutesTasks",
+                column: "AssignedToId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MinutesTasks_CompletedById",
+                table: "MinutesTasks",
+                column: "CompletedById");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MinutesTasks_CreatedById",
+                table: "MinutesTasks",
+                column: "CreatedById");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MinutesTasks_LastModifiedById",
+                table: "MinutesTasks",
+                column: "LastModifiedById");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MinutesTasks_TenantId",
+                table: "MinutesTasks",
+                column: "TenantId");
+
             migrationBuilder.AddForeignKey(
                 name: "FK_AgendaItemTypes_MeetingFunctions_HandledByFunctionId",
                 table: "AgendaItemTypes",
@@ -161,6 +241,9 @@ namespace YourBrand.Meetings.Infrastructure.Persistence.Migrations
             migrationBuilder.DropForeignKey(
                 name: "FK_Meetings_AttendeeRoles_JoinAsId",
                 table: "Meetings");
+
+            migrationBuilder.DropTable(
+                name: "MinutesTasks");
 
             migrationBuilder.DropTable(
                 name: "MeetingAttendeeFunctions");

--- a/src/Executive/Meetings/Meetings/Infrastructure/Persistence/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/src/Executive/Meetings/Meetings/Infrastructure/Persistence/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -1116,6 +1116,87 @@ namespace YourBrand.Meetings.Infrastructure.Persistence.Migrations
                     b.ToTable("MinutesItems", (string)null);
                 });
 
+            modelBuilder.Entity("YourBrand.Meetings.Domain.Entities.MinutesTask", b =>
+                {
+                    b.Property<string>("OrganizationId")
+                        .HasColumnType("nvarchar(450)");
+
+                    b.Property<int>("MinutesId")
+                        .HasColumnType("int");
+
+                    b.Property<string>("Id")
+                        .HasColumnType("nvarchar(450)");
+
+                    b.Property<DateTimeOffset>("AssignedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<string>("AssignedToEmail")
+                        .HasMaxLength(200)
+                        .HasColumnType("nvarchar(200)");
+
+                    b.Property<string>("AssignedToId")
+                        .HasColumnType("nvarchar(450)");
+
+                    b.Property<string>("AssignedToName")
+                        .HasMaxLength(200)
+                        .HasColumnType("nvarchar(200)");
+
+                    b.Property<DateTimeOffset?>("CompletedAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<string>("CompletedById")
+                        .HasColumnType("nvarchar(450)");
+
+                    b.Property<DateTimeOffset>("Created")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<string>("CreatedById")
+                        .HasColumnType("nvarchar(450)");
+
+                    b.Property<string>("Description")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<DateTimeOffset?>("DueAt")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<DateTimeOffset?>("LastModified")
+                        .HasColumnType("datetimeoffset");
+
+                    b.Property<string>("LastModifiedById")
+                        .HasColumnType("nvarchar(450)");
+
+                    b.Property<int>("Status")
+                        .HasColumnType("int");
+
+                    b.Property<string>("TenantId")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(450)");
+
+                    b.Property<string>("Title")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("nvarchar(200)");
+
+                    b.Property<int>("Type")
+                        .HasColumnType("int");
+
+                    b.HasKey("OrganizationId", "MinutesId", "Id");
+
+                    b.HasIndex("AssignedToId");
+
+                    b.HasIndex("CompletedById");
+
+                    b.HasIndex("CreatedById");
+
+                    b.HasIndex("LastModifiedById");
+
+                    b.HasIndex("OrganizationId");
+
+                    b.HasIndex("TenantId");
+
+                    b.ToTable("MinutesTasks", (string)null);
+                });
+
             modelBuilder.Entity("YourBrand.Meetings.Domain.Entities.Motion", b =>
                 {
                     b.Property<string>("OrganizationId")
@@ -2037,6 +2118,43 @@ namespace YourBrand.Meetings.Infrastructure.Persistence.Migrations
                     b.Navigation("Type");
                 });
 
+            modelBuilder.Entity("YourBrand.Meetings.Domain.Entities.MinutesTask", b =>
+                {
+                    b.HasOne("YourBrand.Meetings.Domain.Entities.User", "AssignedTo")
+                        .WithMany()
+                        .HasForeignKey("AssignedToId")
+                        .OnDelete(DeleteBehavior.NoAction);
+
+                    b.HasOne("YourBrand.Meetings.Domain.Entities.User", "CompletedBy")
+                        .WithMany()
+                        .HasForeignKey("CompletedById")
+                        .OnDelete(DeleteBehavior.NoAction);
+
+                    b.HasOne("YourBrand.Meetings.Domain.Entities.User", "CreatedBy")
+                        .WithMany()
+                        .HasForeignKey("CreatedById")
+                        .OnDelete(DeleteBehavior.NoAction);
+
+                    b.HasOne("YourBrand.Meetings.Domain.Entities.User", "LastModifiedBy")
+                        .WithMany()
+                        .HasForeignKey("LastModifiedById")
+                        .OnDelete(DeleteBehavior.NoAction);
+
+                    b.HasOne("YourBrand.Meetings.Domain.Entities.Minutes", null)
+                        .WithMany("Tasks")
+                        .HasForeignKey("OrganizationId", "MinutesId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("AssignedTo");
+
+                    b.Navigation("CompletedBy");
+
+                    b.Navigation("CreatedBy");
+
+                    b.Navigation("LastModifiedBy");
+                });
+
             modelBuilder.Entity("YourBrand.Meetings.Domain.Entities.Motion", b =>
                 {
                     b.HasOne("YourBrand.Meetings.Domain.Entities.User", "CreatedBy")
@@ -2265,6 +2383,8 @@ namespace YourBrand.Meetings.Infrastructure.Persistence.Migrations
                     b.Navigation("Attendees");
 
                     b.Navigation("Items");
+
+                    b.Navigation("Tasks");
                 });
 
             modelBuilder.Entity("YourBrand.Meetings.Domain.Entities.Motion", b =>

--- a/src/Executive/Meetings/Meetings/Infrastructure/Persistence/ValueConverters.cs
+++ b/src/Executive/Meetings/Meetings/Infrastructure/Persistence/ValueConverters.cs
@@ -158,6 +158,14 @@ internal sealed class MinutesItemIdConverter : ValueConverter<MinutesItemId, str
     }
 }
 
+internal sealed class MinutesTaskIdConverter : ValueConverter<MinutesTaskId, string>
+{
+    public MinutesTaskIdConverter()
+        : base(v => v.Value, v => new(v))
+    {
+    }
+}
+
 internal sealed class MeetingGroupIdConverter : ValueConverter<MeetingGroupId, int>
 {
     public MeetingGroupIdConverter()


### PR DESCRIPTION
## Summary
- add minutes task entities, value objects, and EF configuration so minutes tasks can be persisted
- generate post-meeting adjustment and approval tasks, expose them on minutes DTOs, and add API endpoints for listing and completing tasks
- update OpenAPI specifications to describe the new minutes task operations and schema

## Testing
- dotnet build src/Executive/Meetings/Meetings/Meetings.csproj

------
https://chatgpt.com/codex/tasks/task_e_68fab9b1d498832f92672222ecb54167