### PR TITLE
Add tenant-aware database connection interceptors

### DIFF
--- a/src/Common/Tenancy.EFCore/DbContextOptionsBuilderExtensions.cs
+++ b/src/Common/Tenancy.EFCore/DbContextOptionsBuilderExtensions.cs
@@ -12,4 +12,17 @@ public static class DbContextOptionsBuilderExtensions
 
         return options;
     }
+
+    public static DbContextOptionsBuilder UseTenantDatabasePerTenant<TContext>(this DbContextOptionsBuilder options, IServiceProvider serviceProvider)
+        where TContext : DbContext
+    {
+        var interceptor = serviceProvider.GetService<TenantDbConnectionInterceptor<TContext>>();
+
+        if (interceptor is not null)
+        {
+            options.AddInterceptors(interceptor);
+        }
+
+        return options;
+    }
 }

--- a/src/Common/Tenancy.EFCore/ServiceExtensions.cs
+++ b/src/Common/Tenancy.EFCore/ServiceExtensions.cs
@@ -1,3 +1,5 @@
+using System;
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -8,6 +10,18 @@ public static class ServiceExtensions
     public static IServiceCollection AddTenancyInterceptor(this IServiceCollection services)
     {
         services.TryAddScoped<SetTenantSaveChangesInterceptor>();
+        return services;
+    }
+
+    public static IServiceCollection AddTenantDatabasePerTenant(this IServiceCollection services, Action<TenantDatabasePerTenantBuilder> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+
+        services.AddOptions<TenantDatabasePerTenantOptions>();
+
+        var builder = new TenantDatabasePerTenantBuilder(services);
+        configure(builder);
+
         return services;
     }
 }

--- a/src/Common/Tenancy.EFCore/TenantDatabasePerTenantBuilder.cs
+++ b/src/Common/Tenancy.EFCore/TenantDatabasePerTenantBuilder.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Data.Common;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace YourBrand.Tenancy;
+
+public sealed class TenantDatabasePerTenantBuilder(IServiceCollection services)
+{
+    private readonly IServiceCollection _services = services;
+
+    public TenantDatabasePerTenantRuleBuilder ForContext<TContext>()
+        where TContext : DbContext
+    {
+        _services.TryAddScoped<TenantDbConnectionInterceptor<TContext>>();
+
+        return new TenantDatabasePerTenantRuleBuilder(_services, typeof(TContext));
+    }
+}
+
+public sealed class TenantDatabasePerTenantRuleBuilder(IServiceCollection services, Type contextType)
+{
+    private readonly IServiceCollection _services = services;
+    private readonly Type _contextType = contextType;
+
+    public TenantDatabasePerTenantRuleBuilder UseConnectionString(Func<TenantId, string, string> factory)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+
+        _services.Configure<TenantDatabasePerTenantOptions>(options =>
+        {
+            options.Configure(_contextType, rule => rule.ConnectionStringFactory = factory);
+        });
+
+        return this;
+    }
+
+    public TenantDatabasePerTenantRuleBuilder WithDatabase(Func<TenantId, string> databaseFactory)
+    {
+        ArgumentNullException.ThrowIfNull(databaseFactory);
+
+        return UseConnectionString((tenantId, connectionString) =>
+        {
+            var builder = new DbConnectionStringBuilder
+            {
+                ConnectionString = connectionString
+            };
+
+            var databaseName = databaseFactory(tenantId);
+
+            if (builder.ContainsKey("Database"))
+            {
+                builder["Database"] = databaseName;
+            }
+            else if (builder.ContainsKey("Initial Catalog"))
+            {
+                builder["Initial Catalog"] = databaseName;
+            }
+            else
+            {
+                builder["Database"] = databaseName;
+            }
+
+            return builder.ConnectionString;
+        });
+    }
+
+    public TenantDatabasePerTenantRuleBuilder WithTemplate(string template, string placeholder = "{tenantId}")
+    {
+        ArgumentNullException.ThrowIfNull(template);
+
+        if (string.IsNullOrEmpty(placeholder))
+        {
+            throw new ArgumentException("Placeholder must be provided.", nameof(placeholder));
+        }
+
+        return UseConnectionString((tenantId, _) => template.Replace(placeholder, tenantId.Value, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/src/Common/Tenancy.EFCore/TenantDatabasePerTenantOptions.cs
+++ b/src/Common/Tenancy.EFCore/TenantDatabasePerTenantOptions.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace YourBrand.Tenancy;
+
+public sealed class TenantDatabasePerTenantOptions
+{
+    private readonly Dictionary<Type, TenantDatabasePerTenantRule> _rules = new();
+
+    internal void Configure(Type contextType, Action<TenantDatabasePerTenantRule> configure)
+    {
+        ArgumentNullException.ThrowIfNull(contextType);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        if (!_rules.TryGetValue(contextType, out var rule))
+        {
+            rule = new TenantDatabasePerTenantRule();
+            _rules[contextType] = rule;
+        }
+
+        configure(rule);
+    }
+
+    internal void Configure<TContext>(Action<TenantDatabasePerTenantRule> configure)
+        where TContext : DbContext
+        => Configure(typeof(TContext), configure);
+
+    internal bool TryGetRule(Type contextType, [NotNullWhen(true)] out TenantDatabasePerTenantRule? rule)
+        => _rules.TryGetValue(contextType, out rule);
+
+    internal bool TryGetRule<TContext>([NotNullWhen(true)] out TenantDatabasePerTenantRule? rule)
+        where TContext : DbContext
+        => TryGetRule(typeof(TContext), out rule);
+}
+
+public sealed class TenantDatabasePerTenantRule
+{
+    public Func<TenantId, string, string>? ConnectionStringFactory { get; set; }
+}

--- a/src/Common/Tenancy.EFCore/TenantDbConnectionInterceptor.cs
+++ b/src/Common/Tenancy.EFCore/TenantDbConnectionInterceptor.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace YourBrand.Tenancy;
+
+public sealed class TenantDbConnectionInterceptor<TContext>(
+    ITenantContext tenantContext,
+    IOptions<TenantDatabasePerTenantOptions> options,
+    ILogger<TenantDbConnectionInterceptor<TContext>> logger) : DbConnectionInterceptor
+    where TContext : DbContext
+{
+    private readonly ITenantContext _tenantContext = tenantContext;
+    private readonly IOptions<TenantDatabasePerTenantOptions> _options = options;
+    private readonly ILogger _logger = logger;
+
+    private TenantDatabasePerTenantRule? _rule;
+
+    public override InterceptionResult ConnectionOpening(DbConnection connection, ConnectionEventData eventData, InterceptionResult result)
+    {
+        ApplyTenantConnectionString(connection, eventData.Context);
+
+        return base.ConnectionOpening(connection, eventData, result);
+    }
+
+    public override ValueTask<InterceptionResult> ConnectionOpeningAsync(DbConnection connection, ConnectionEventData eventData, InterceptionResult result, CancellationToken cancellationToken = default)
+    {
+        ApplyTenantConnectionString(connection, eventData.Context);
+
+        return base.ConnectionOpeningAsync(connection, eventData, result, cancellationToken);
+    }
+
+    private void ApplyTenantConnectionString(DbConnection connection, DbContext? dbContext)
+    {
+        if (dbContext is not TContext)
+        {
+            return;
+        }
+
+        var tenantId = _tenantContext.TenantId;
+
+        if (tenantId is null)
+        {
+            return;
+        }
+
+        var rule = _rule ??= _options.Value.TryGetRule(typeof(TContext), out var configuredRule)
+            ? configuredRule
+            : null;
+
+        if (rule?.ConnectionStringFactory is null)
+        {
+            return;
+        }
+
+        var currentConnectionString = connection.ConnectionString;
+
+        if (string.IsNullOrWhiteSpace(currentConnectionString))
+        {
+            return;
+        }
+
+        var resolvedConnectionString = rule.ConnectionStringFactory(tenantId.Value, currentConnectionString);
+
+        if (string.IsNullOrWhiteSpace(resolvedConnectionString) || string.Equals(currentConnectionString, resolvedConnectionString, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        connection.ConnectionString = resolvedConnectionString;
+
+        _logger.LogDebug("Applied tenant specific connection string for context {Context} and tenant {TenantId}.", typeof(TContext).Name, tenantId.Value.Value);
+    }
+}

--- a/src/Sales/Sales.API/Persistence/ServiceExtensions.cs
+++ b/src/Sales/Sales.API/Persistence/ServiceExtensions.cs
@@ -4,6 +4,7 @@ using YourBrand.Auditability;
 using YourBrand.Domain.Persistence;
 using YourBrand.Sales.Features.OrderManagement.Repositories;
 using YourBrand.Sales.Persistence.Repositories.Mocks;
+using YourBrand.Tenancy;
 
 namespace YourBrand.Sales.Persistence;
 
@@ -25,6 +26,7 @@ public static class ServiceExtensions
             options
                 .UseDomainInterceptors(serviceProvider)
                 .UseTenancyInterceptor(serviceProvider)
+                .UseTenantDatabasePerTenant<SalesContext>(serviceProvider)
                 .UseAuditabilityInterceptor(serviceProvider)
                 .UseSoftDeleteInterceptor(serviceProvider);
 
@@ -38,6 +40,11 @@ public static class ServiceExtensions
         services.AddScoped<ISalesContext>(sp => sp.GetRequiredService<SalesContext>());
 
         services.AddTenancyInterceptor();
+        services.AddTenantDatabasePerTenant(builder =>
+        {
+            builder.ForContext<SalesContext>()
+                .WithDatabase(tenantId => $"Orders_{tenantId.Value}");
+        });
         services.AddAuditabilityInterceptor();
         services.AddSoftDeleteInterceptor();
 


### PR DESCRIPTION
## Summary
- add infrastructure to register tenant-specific database connection interceptors
- expose options and builder extensions for configuring database-per-tenant rules
- enable tenant-based database naming for the Sales service context

## Testing
- dotnet build src/Common/Tenancy.EFCore/Tenancy.EFCore.csproj

------
https://chatgpt.com/codex/tasks/task_e_68fab69436a0832f8911edbe00a5d187