### PR TITLE
Refactor meetings domain to raise events

### DIFF
--- a/src/Executive/Meetings/Meetings/Domain/Events/MeetingAgendaItemChanged.cs
+++ b/src/Executive/Meetings/Meetings/Domain/Events/MeetingAgendaItemChanged.cs
@@ -6,4 +6,8 @@ using OrganizationId = YourBrand.Domain.OrganizationId;
 
 namespace YourBrand.Meetings.Domain.Events;
 
-public sealed record MeetingUpdated(TenantId TenantId, OrganizationId OrganizationId, MeetingId MeetingId) : DomainEvent;
+public sealed record MeetingAgendaItemChanged(
+    TenantId TenantId,
+    OrganizationId OrganizationId,
+    MeetingId MeetingId,
+    string? AgendaItemId) : DomainEvent;

--- a/src/Executive/Meetings/Meetings/Domain/Events/MeetingCreated.cs
+++ b/src/Executive/Meetings/Meetings/Domain/Events/MeetingCreated.cs
@@ -1,8 +1,9 @@
-﻿using YourBrand.Meetings.Domain.ValueObjects;
+using YourBrand.Domain;
+using YourBrand.Meetings.Domain.ValueObjects;
 using YourBrand.Tenancy;
 
 using OrganizationId = YourBrand.Domain.OrganizationId;
 
 namespace YourBrand.Meetings.Domain.Events;
 
-public sealed record MeetingCreated(TenantId TenantId, OrganizationId OrganizationId, MeetingId MeetingId);
+public sealed record MeetingCreated(TenantId TenantId, OrganizationId OrganizationId, MeetingId MeetingId) : DomainEvent;

--- a/src/Executive/Meetings/Meetings/Domain/Events/MeetingDeleted.cs
+++ b/src/Executive/Meetings/Meetings/Domain/Events/MeetingDeleted.cs
@@ -1,3 +1,4 @@
+using YourBrand.Domain;
 using YourBrand.Meetings.Domain.ValueObjects;
 using YourBrand.Tenancy;
 
@@ -5,4 +6,4 @@ using OrganizationId = YourBrand.Domain.OrganizationId;
 
 namespace YourBrand.Meetings.Domain.Events;
 
-public sealed record MeetingDeleted(TenantId TenantId, OrganizationId OrganizationId, MeetingId MeetingId, string Title);
+public sealed record MeetingDeleted(TenantId TenantId, OrganizationId OrganizationId, MeetingId MeetingId, string Title) : DomainEvent;

--- a/src/Executive/Meetings/Meetings/Domain/Events/MeetingScheduledAtChanged.cs
+++ b/src/Executive/Meetings/Meetings/Domain/Events/MeetingScheduledAtChanged.cs
@@ -6,4 +6,8 @@ using OrganizationId = YourBrand.Domain.OrganizationId;
 
 namespace YourBrand.Meetings.Domain.Events;
 
-public sealed record MeetingUpdated(TenantId TenantId, OrganizationId OrganizationId, MeetingId MeetingId) : DomainEvent;
+public sealed record MeetingScheduledAtChanged(
+    TenantId TenantId,
+    OrganizationId OrganizationId,
+    MeetingId MeetingId,
+    DateTimeOffset ScheduledAt) : DomainEvent;

--- a/src/Executive/Meetings/Meetings/Domain/Events/MeetingStateChanged.cs
+++ b/src/Executive/Meetings/Meetings/Domain/Events/MeetingStateChanged.cs
@@ -1,0 +1,15 @@
+using YourBrand.Domain;
+using YourBrand.Meetings.Domain.Entities;
+using YourBrand.Meetings.Domain.ValueObjects;
+using YourBrand.Tenancy;
+
+using OrganizationId = YourBrand.Domain.OrganizationId;
+
+namespace YourBrand.Meetings.Domain.Events;
+
+public sealed record MeetingStateChanged(
+    TenantId TenantId,
+    OrganizationId OrganizationId,
+    MeetingId MeetingId,
+    MeetingState State,
+    string? AdjournmentMessage) : DomainEvent;

--- a/src/Executive/Meetings/Meetings/Features/Commands/ChangeMeetingScheduledDate.cs
+++ b/src/Executive/Meetings/Meetings/Features/Commands/ChangeMeetingScheduledDate.cs
@@ -31,7 +31,7 @@ public record ChangeMeetingScheduledDate(string OrganizationId, int Id, DateTime
                 return Errors.Meetings.MeetingNotFound;
             }
 
-            meeting.ScheduledAt = request.Date;
+            meeting.Reschedule(request.Date);
 
             context.Meetings.Update(meeting);
 

--- a/src/Executive/Meetings/Meetings/Features/Commands/ChangeMeetingState.cs
+++ b/src/Executive/Meetings/Meetings/Features/Commands/ChangeMeetingState.cs
@@ -31,12 +31,7 @@ public record ChangeMeetingState(string OrganizationId, int Id, MeetingState New
                 return Errors.Meetings.MeetingNotFound;
             }
 
-            meeting.State = request.NewState;
-
-            if (meeting.State != MeetingState.Adjourned)
-            {
-                meeting.ClearAdjournment();
-            }
+            meeting.ChangeState(request.NewState);
 
             context.Meetings.Update(meeting);
 

--- a/src/Executive/Meetings/Meetings/Features/Procedure/AdjournMeeting.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/AdjournMeeting.cs
@@ -3,7 +3,6 @@ using YourBrand.Meetings.Domain.Entities;
 
 using MediatR;
 
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 
 using YourBrand.Identity;
@@ -20,7 +19,7 @@ public sealed record AdjournMeeting(string OrganizationId, int Id, string Messag
         }
     }
 
-    public sealed class Handler(IApplicationDbContext context, IUserContext userContext, IHubContext<MeetingsProcedureHub, IMeetingsProcedureHubClient> hubContext) : IRequestHandler<AdjournMeeting, Result>
+    public sealed class Handler(IApplicationDbContext context, IUserContext userContext) : IRequestHandler<AdjournMeeting, Result>
     {
         public async Task<Result> Handle(AdjournMeeting request, CancellationToken cancellationToken)
         {
@@ -50,10 +49,6 @@ public sealed record AdjournMeeting(string OrganizationId, int Id, string Messag
             context.Meetings.Update(meeting);
 
             await context.SaveChangesAsync(cancellationToken);
-
-            await hubContext.Clients
-                .Group($"meeting-{meeting.Id}")
-                .OnMeetingStateChanged((Dtos.MeetingState)meeting.State, meeting.AdjournmentMessage);
 
             return Result.Success;
         }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/CancelMeeting.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/CancelMeeting.cs
@@ -1,7 +1,6 @@
 using MediatR;
 using YourBrand.Meetings.Domain.Entities;
 
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 
 using YourBrand.Identity;
@@ -10,7 +9,7 @@ namespace YourBrand.Meetings.Features.Procedure.Command;
 
 public sealed record CancelMeeting(string OrganizationId, int Id) : IRequest<Result>
 {
-    public sealed class Handler(IApplicationDbContext context, IUserContext userContext, IHubContext<MeetingsProcedureHub, IMeetingsProcedureHubClient> hubContext) : IRequestHandler<CancelMeeting, Result>
+    public sealed class Handler(IApplicationDbContext context, IUserContext userContext) : IRequestHandler<CancelMeeting, Result>
     {
         public async Task<Result> Handle(CancelMeeting request, CancellationToken cancellationToken)
         {
@@ -40,10 +39,6 @@ public sealed record CancelMeeting(string OrganizationId, int Id) : IRequest<Res
             context.Meetings.Update(meeting);
 
             await context.SaveChangesAsync(cancellationToken);
-
-            await hubContext.Clients
-                .Group($"meeting-{meeting.Id}")
-                .OnMeetingStateChanged((Dtos.MeetingState)meeting.State, meeting.AdjournmentMessage);
 
             return Result.Success;
         }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/EndMeeting.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/EndMeeting.cs
@@ -1,7 +1,6 @@
 using MediatR;
 using YourBrand.Meetings.Domain.Entities;
 
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 
 using YourBrand.Identity;
@@ -10,7 +9,7 @@ namespace YourBrand.Meetings.Features.Procedure.Command;
 
 public sealed record EndMeeting(string OrganizationId, int Id) : IRequest<Result>
 {
-    public sealed class Handler(IApplicationDbContext context, IUserContext userContext, IHubContext<MeetingsProcedureHub, IMeetingsProcedureHubClient> hubContext) : IRequestHandler<EndMeeting, Result>
+    public sealed class Handler(IApplicationDbContext context, IUserContext userContext) : IRequestHandler<EndMeeting, Result>
     {
         public async Task<Result> Handle(EndMeeting request, CancellationToken cancellationToken)
         {
@@ -58,10 +57,6 @@ public sealed record EndMeeting(string OrganizationId, int Id) : IRequest<Result
             context.Meetings.Update(meeting);
 
             await context.SaveChangesAsync(cancellationToken);
-
-            await hubContext.Clients
-                .Group($"meeting-{meeting.Id}")
-                .OnMeetingStateChanged((Dtos.MeetingState)meeting.State, meeting.AdjournmentMessage);
 
             return Result.Success;
         }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/EventHandlers/MeetingAgendaItemChangedEventHandler.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/EventHandlers/MeetingAgendaItemChangedEventHandler.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.SignalR;
+
+using YourBrand.Domain;
+using YourBrand.Meetings.Domain.Events;
+
+namespace YourBrand.Meetings.Features.Procedure.EventHandlers;
+
+public sealed class MeetingAgendaItemChangedEventHandler(
+    IHubContext<MeetingsProcedureHub, IMeetingsProcedureHubClient> hubContext) : IDomainEventHandler<MeetingAgendaItemChanged>
+{
+    private readonly IHubContext<MeetingsProcedureHub, IMeetingsProcedureHubClient> _hubContext = hubContext;
+
+    public async Task Handle(MeetingAgendaItemChanged notification, CancellationToken cancellationToken)
+    {
+        if (notification.AgendaItemId is null)
+        {
+            return;
+        }
+
+        await _hubContext.Clients
+            .Group($"meeting-{notification.MeetingId.Value}")
+            .OnAgendaItemChanged(notification.AgendaItemId);
+    }
+}

--- a/src/Executive/Meetings/Meetings/Features/Procedure/EventHandlers/MeetingStateChangedEventHandler.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/EventHandlers/MeetingStateChangedEventHandler.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.SignalR;
+
+using YourBrand.Domain;
+using YourBrand.Meetings.Domain.Events;
+using Dtos = YourBrand.Meetings.Dtos;
+
+namespace YourBrand.Meetings.Features.Procedure.EventHandlers;
+
+public sealed class MeetingStateChangedEventHandler(
+    IHubContext<MeetingsProcedureHub, IMeetingsProcedureHubClient> hubContext) : IDomainEventHandler<MeetingStateChanged>
+{
+    private readonly IHubContext<MeetingsProcedureHub, IMeetingsProcedureHubClient> _hubContext = hubContext;
+
+    public async Task Handle(MeetingStateChanged notification, CancellationToken cancellationToken)
+    {
+        await _hubContext.Clients
+            .Group($"meeting-{notification.MeetingId.Value}")
+            .OnMeetingStateChanged((Dtos.MeetingState)notification.State, notification.AdjournmentMessage);
+    }
+}

--- a/src/Executive/Meetings/Meetings/Features/Procedure/MoveToNextAgendaItem.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/MoveToNextAgendaItem.cs
@@ -1,7 +1,6 @@
 using MediatR;
 using YourBrand.Meetings.Domain.Entities;
 
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 
 using YourBrand.Identity;
@@ -11,7 +10,7 @@ namespace YourBrand.Meetings.Features.Procedure.Command;
 
 public sealed record MoveToNextAgendaItem(string OrganizationId, int Id) : IRequest<Result<AgendaItemDto>>
 {
-    public sealed class Handler(IApplicationDbContext context, IUserContext userContext, IHubContext<MeetingsProcedureHub, IMeetingsProcedureHubClient> hubContext) : IRequestHandler<MoveToNextAgendaItem, Result<AgendaItemDto>>
+    public sealed class Handler(IApplicationDbContext context, IUserContext userContext) : IRequestHandler<MoveToNextAgendaItem, Result<AgendaItemDto>>
     {
         public async Task<Result<AgendaItemDto>> Handle(MoveToNextAgendaItem request, CancellationToken cancellationToken)
         {
@@ -44,10 +43,6 @@ public sealed record MoveToNextAgendaItem(string OrganizationId, int Id) : IRequ
             context.Meetings.Update(meeting);
 
             await context.SaveChangesAsync(cancellationToken);
-
-            await hubContext.Clients
-                .Group($"meeting-{meeting.Id}")
-                .OnAgendaItemChanged((string)nextItem.Id);
 
             return nextItem.ToDto();
         }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/ResetMeetingProcedure.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/ResetMeetingProcedure.cs
@@ -3,7 +3,6 @@ using YourBrand.Meetings.Domain.Entities;
 
 using MediatR;
 
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 
 using YourBrand.Identity;
@@ -20,7 +19,7 @@ public record ResetMeetingProcedure(string OrganizationId, int Id) : IRequest<Re
         }
     }
 
-    public class Handler(IApplicationDbContext context, IUserContext userContext, IHubContext<MeetingsProcedureHub, IMeetingsProcedureHubClient> hubContext) : IRequestHandler<ResetMeetingProcedure, Result<MeetingDto>>
+    public class Handler(IApplicationDbContext context, IUserContext userContext) : IRequestHandler<ResetMeetingProcedure, Result<MeetingDto>>
     {
         public async Task<Result<MeetingDto>> Handle(ResetMeetingProcedure request, CancellationToken cancellationToken)
         {
@@ -52,10 +51,6 @@ public record ResetMeetingProcedure(string OrganizationId, int Id) : IRequest<Re
             context.Meetings.Update(meeting);
 
             await context.SaveChangesAsync(cancellationToken);
-
-            await hubContext.Clients
-                .Group($"meeting-{meeting.Id}")
-                .OnMeetingStateChanged((Dtos.MeetingState)meeting.State, meeting.AdjournmentMessage);
 
             return meeting.ToDto();
         }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/ResumeMeeting.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/ResumeMeeting.cs
@@ -1,7 +1,6 @@
 using MediatR;
 using YourBrand.Meetings.Domain.Entities;
 
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 
 using YourBrand.Identity;
@@ -10,7 +9,7 @@ namespace YourBrand.Meetings.Features.Procedure.Command;
 
 public sealed record ResumeMeeting(string OrganizationId, int Id) : IRequest<Result>
 {
-    public sealed class Handler(IApplicationDbContext context, IUserContext userContext, IHubContext<MeetingsProcedureHub, IMeetingsProcedureHubClient> hubContext) : IRequestHandler<ResumeMeeting, Result>
+    public sealed class Handler(IApplicationDbContext context, IUserContext userContext) : IRequestHandler<ResumeMeeting, Result>
     {
         public async Task<Result> Handle(ResumeMeeting request, CancellationToken cancellationToken)
         {
@@ -40,10 +39,6 @@ public sealed record ResumeMeeting(string OrganizationId, int Id) : IRequest<Res
             context.Meetings.Update(meeting);
 
             await context.SaveChangesAsync(cancellationToken);
-
-            await hubContext.Clients
-                .Group($"meeting-{meeting.Id}")
-                .OnMeetingStateChanged((Dtos.MeetingState)meeting.State, meeting.AdjournmentMessage);
 
             return Result.Success;
         }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/StartMeeting.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/StartMeeting.cs
@@ -1,7 +1,6 @@
 using MediatR;
 using YourBrand.Meetings.Domain.Entities;
 
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 
 using YourBrand.Identity;
@@ -10,7 +9,7 @@ namespace YourBrand.Meetings.Features.Procedure.Command;
 
 public sealed record StartMeeting(string OrganizationId, int Id) : IRequest<Result>
 {
-    public sealed class Handler(IApplicationDbContext context, IUserContext userContext, IHubContext<MeetingsProcedureHub, IMeetingsProcedureHubClient> hubContext) : IRequestHandler<StartMeeting, Result>
+    public sealed class Handler(IApplicationDbContext context, IUserContext userContext) : IRequestHandler<StartMeeting, Result>
     {
         public async Task<Result> Handle(StartMeeting request, CancellationToken cancellationToken)
         {
@@ -40,14 +39,6 @@ public sealed record StartMeeting(string OrganizationId, int Id) : IRequest<Resu
             context.Meetings.Update(meeting);
 
             await context.SaveChangesAsync(cancellationToken);
-
-            await hubContext.Clients
-                .Group($"meeting-{meeting.Id}")
-                .OnMeetingStateChanged((Dtos.MeetingState)meeting.State, meeting.AdjournmentMessage);
-
-            await hubContext.Clients
-                .Group($"meeting-{meeting.Id}")
-                .OnAgendaItemChanged(meeting.GetCurrentAgendaItem().Id);
 
             return Result.Success;
         }


### PR DESCRIPTION
## Summary
- add explicit meeting domain events for schedule changes, state changes, and agenda progression
- raise new events within the Meeting aggregate and simplify command handlers to rely on aggregate behavior
- broadcast meeting state and agenda changes through new domain event handlers instead of command-side hub calls

## Testing
- dotnet build src/Executive/Meetings/Meetings/Meetings.csproj

------
https://chatgpt.com/codex/tasks/task_e_68fb42513cf8832fa86ed3b051bbbe22