### PR TITLE
Ensure seeded agendas assign meeting functions to elections

### DIFF
--- a/src/Executive/Meetings/Meetings/Infrastructure/Persistence/Seed.cs
+++ b/src/Executive/Meetings/Meetings/Infrastructure/Persistence/Seed.cs
@@ -294,11 +294,14 @@ public static class Seed
         };
 
         // Opening and formalities
-        agenda.AddItem(
+        var callToOrder = agenda.AddItem(
             type: AgendaItemType.CallToOrder,
             title: "Call to Order",
             description: "Chairperson calls the meeting to order."
         );
+        callToOrder.IsMandatory = AgendaItemType.CallToOrder.IsMandatory;
+        callToOrder.DiscussionActions = DiscussionActions.None;
+        callToOrder.VoteActions = VoteActions.None;
 
         var secretaryElection = new Election()
         {
@@ -444,11 +447,14 @@ public static class Seed
         };
 
         // Opening of the AGM
-        agenda.AddItem(
+        var callToOrder = agenda.AddItem(
             type: AgendaItemType.CallToOrder,
             title: "Call to Order",
             description: "Temporary chairperson calls the meeting to order."
         );
+        callToOrder.IsMandatory = AgendaItemType.CallToOrder.IsMandatory;
+        callToOrder.DiscussionActions = DiscussionActions.None;
+        callToOrder.VoteActions = VoteActions.None;
 
         // Election of AGM roles
         var defaultGroupId = meeting.Attendees

--- a/src/Executive/Meetings/Meetings/Infrastructure/Persistence/Seed.cs
+++ b/src/Executive/Meetings/Meetings/Infrastructure/Persistence/Seed.cs
@@ -300,16 +300,32 @@ public static class Seed
             description: "Chairperson calls the meeting to order."
         );
 
+        var secretaryElection = new Election()
+        {
+            OrganizationId = TenantConstants.OrganizationId,
+            MeetingFunction = MeetingFunction.Secretary,
+            MeetingFunctionId = MeetingFunction.Secretary.Id
+        };
+
         agenda.AddItem(
             type: AgendaItemType.Election,
             title: "Election of Secretary",
-            description: "Election to appoint the Secretary for the meeting."
+            description: "Election to appoint the Secretary for the meeting.",
+            election: secretaryElection
         );
+
+        var adjusterElection = new Election()
+        {
+            OrganizationId = TenantConstants.OrganizationId,
+            MeetingFunction = MeetingFunction.MinuteAdjuster,
+            MeetingFunctionId = MeetingFunction.MinuteAdjuster.Id
+        };
 
         agenda.AddItem(
             type: AgendaItemType.Election,
             title: "Election of Adjuster of Minutes",
-            description: "Election to appoint an Adjuster of Minutes for this meeting."
+            description: "Election to appoint an Adjuster of Minutes for this meeting.",
+            election: adjusterElection
         );
 
         agenda.AddItem(
@@ -435,22 +451,54 @@ public static class Seed
         );
 
         // Election of AGM roles
+        var defaultGroupId = meeting.Attendees
+            .OrderBy(x => x.Order)
+            .Select(x => x.MeetingGroupId)
+            .FirstOrDefault(x => x is not null);
+
+        var chairpersonElection = new Election()
+        {
+            OrganizationId = TenantConstants.OrganizationId,
+            MeetingFunction = MeetingFunction.Chairperson,
+            MeetingFunctionId = MeetingFunction.Chairperson.Id,
+            GroupId = defaultGroupId
+        };
+
         agenda.AddItem(
             type: AgendaItemType.Election,
             title: "Election of Chairperson",
-            description: "Election to appoint the Chairperson for the meeting."
+            description: "Election to appoint the Chairperson for the meeting.",
+            election: chairpersonElection
         );
+
+        var secretaryElectionAgm = new Election()
+        {
+            OrganizationId = TenantConstants.OrganizationId,
+            MeetingFunction = MeetingFunction.Secretary,
+            MeetingFunctionId = MeetingFunction.Secretary.Id,
+            GroupId = defaultGroupId
+        };
 
         agenda.AddItem(
             type: AgendaItemType.Election,
             title: "Election of Secretary",
-            description: "Election to appoint the Secretary for the meeting."
+            description: "Election to appoint the Secretary for the meeting.",
+            election: secretaryElectionAgm
         );
+
+        var minuteAdjusterElection = new Election()
+        {
+            OrganizationId = TenantConstants.OrganizationId,
+            MeetingFunction = MeetingFunction.MinuteAdjuster,
+            MeetingFunctionId = MeetingFunction.MinuteAdjuster.Id,
+            GroupId = defaultGroupId
+        };
 
         agenda.AddItem(
             type: AgendaItemType.Election,
             title: "Election of Adjuster of Minutes",
-            description: "Election to appoint an Adjuster of Minutes for this meeting."
+            description: "Election to appoint an Adjuster of Minutes for this meeting.",
+            election: minuteAdjusterElection
         );
 
         // Formalities and approvals


### PR DESCRIPTION
## Summary
- attach meeting functions to the seeded secretary and minute adjuster elections for the board meeting
- assign meeting functions and meeting group context to the AGM elections so agenda logic is not blocked

## Testing
- dotnet build src/Executive/Meetings/Meetings/Meetings.csproj

------
https://chatgpt.com/codex/tasks/task_e_68fb558bdb78832f9f56b1627c015078