### PR TITLE
Allow immediate completion of simple agenda items

### DIFF
--- a/src/Executive/Meetings/Meetings.UI/AgendaItemTypeExtensions.cs
+++ b/src/Executive/Meetings/Meetings.UI/AgendaItemTypeExtensions.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+
+namespace YourBrand.Meetings;
+
+public static class AgendaItemTypeExtensions
+{
+    private static readonly HashSet<AgendaItemTypeEnum> DiscussionTypes = new()
+    {
+        AgendaItemTypeEnum.PublicComment,
+        AgendaItemTypeEnum.SpecialPresentations,
+        AgendaItemTypeEnum.OldBusiness,
+        AgendaItemTypeEnum.UnfinishedBusiness,
+        AgendaItemTypeEnum.NewBusiness,
+        AgendaItemTypeEnum.Discussion,
+        AgendaItemTypeEnum.StrategicDiscussion,
+        AgendaItemTypeEnum.ExecutiveSession,
+        AgendaItemTypeEnum.ActionItemsReview,
+        AgendaItemTypeEnum.GuestSpeakers,
+        AgendaItemTypeEnum.FollowUpItems
+    };
+
+    private static readonly HashSet<AgendaItemTypeEnum> VotingTypes = new()
+    {
+        AgendaItemTypeEnum.ApprovalOfMinutes,
+        AgendaItemTypeEnum.ApprovalOfAgenda,
+        AgendaItemTypeEnum.ConsentAgenda,
+        AgendaItemTypeEnum.Motion,
+        AgendaItemTypeEnum.Voting,
+        AgendaItemTypeEnum.Election
+    };
+
+    public static bool RequiresDiscussion(this AgendaItemTypeEnum type) => DiscussionTypes.Contains(type);
+
+    public static bool RequiresVoting(this AgendaItemTypeEnum type) => VotingTypes.Contains(type);
+}

--- a/src/Executive/Meetings/Meetings.UI/Procedure/ControlPage.razor
+++ b/src/Executive/Meetings/Meetings.UI/Procedure/ControlPage.razor
@@ -143,10 +143,17 @@ else
                     <MudCardActions>
                         @if (currentAgendaItem is not null)
                         {
+                            var itemType = (AgendaItemTypeEnum)currentAgendaItem.Type.Id;
+                            var canCompleteImmediately = !itemType.RequiresDiscussion() && !itemType.RequiresVoting();
+
                             if (currentAgendaItem.State == AgendaItemState.Pending)
                             {
                                 <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="StartDiscussion" Class="me-2">Start
                                     Discussion</MudButton>
+                                @if (canCompleteImmediately)
+                                {
+                                    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="CompleteAgendaItem" Class="me-2">Complete Agenda Item</MudButton>
+                                }
                                 <MudButton Variant="Variant.Filled" Color="Color.Warning" OnClick="PostponeAgendaItem" Class="me-2">Postpone
                                 </MudButton>
                                 <MudButton Variant="Variant.Filled" Color="Color.Error" OnClick="CancelAgendaItem" Class="me-2">Cancel


### PR DESCRIPTION
## Summary
- add agenda item type extensions to describe discussion and voting requirements
- show the Complete button for agenda items that require neither discussion nor voting

## Testing
- `dotnet build src/Executive/Meetings/Meetings.UI/Meetings.UI.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68fb5cbb9f7c832f93df6718764dfdb9