### PR TITLE
Show completion button when agenda actions are optional

### DIFF
--- a/src/Executive/Meetings/Meetings.UI/Procedure/ControlPage.razor
+++ b/src/Executive/Meetings/Meetings.UI/Procedure/ControlPage.razor
@@ -143,10 +143,18 @@ else
                     <MudCardActions>
                         @if (currentAgendaItem is not null)
                         {
+                            var requiresDiscussion = currentAgendaItem.DiscussionActions == DiscussionActions.Required;
+                            var requiresVoting = currentAgendaItem.VoteActions == VoteActions.Required;
+                            var canCompleteImmediately = !requiresDiscussion && !requiresVoting;
+
                             if (currentAgendaItem.State == AgendaItemState.Pending)
                             {
                                 <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="StartDiscussion" Class="me-2">Start
                                     Discussion</MudButton>
+                                @if (canCompleteImmediately)
+                                {
+                                    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="CompleteAgendaItem" Class="me-2">Complete Agenda Item</MudButton>
+                                }
                                 <MudButton Variant="Variant.Filled" Color="Color.Warning" OnClick="PostponeAgendaItem" Class="me-2">Postpone
                                 </MudButton>
                                 <MudButton Variant="Variant.Filled" Color="Color.Error" OnClick="CancelAgendaItem" Class="me-2">Cancel


### PR DESCRIPTION
## Summary
- use the agenda item's discussion and vote actions to decide when it can be completed immediately
- remove the unused agenda item type extension helper

## Testing
- `dotnet build src/Executive/Meetings/Meetings.UI/Meetings.UI.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68fb5cbb9f7c832f93df6718764dfdb9