### PR TITLE
Allow completing pending agenda items without required actions

### DIFF
--- a/src/Executive/Meetings/Meetings.UI/Procedure/ControlPage.razor
+++ b/src/Executive/Meetings/Meetings.UI/Procedure/ControlPage.razor
@@ -147,6 +147,10 @@ else
                             {
                                 <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="StartDiscussion" Class="me-2">Start
                                     Discussion</MudButton>
+                                @if (CanCompleteCurrentAgendaItem)
+                                {
+                                    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="CompleteAgendaItem" Class="me-2">Complete Agenda Item</MudButton>
+                                }
                                 <MudButton Variant="Variant.Filled" Color="Color.Warning" OnClick="PostponeAgendaItem" Class="me-2">Postpone
                                 </MudButton>
                                 <MudButton Variant="Variant.Filled" Color="Color.Error" OnClick="CancelAgendaItem" Class="me-2">Cancel
@@ -298,6 +302,12 @@ else
     private int? speakingTimeLimitSecondsInput;
     private string? selectedSpeakerRequestId;
     private int additionalSpeakingTimeSeconds = 60;
+
+    private bool CanCompleteCurrentAgendaItem =>
+        currentAgendaItem is not null &&
+        currentAgendaItem.State == AgendaItemState.Pending &&
+        (currentAgendaItem.DiscussionActions != DiscussionActions.Required || currentAgendaItem.IsDiscussionCompleted) &&
+        (currentAgendaItem.VoteActions != VoteActions.Required || currentAgendaItem.IsVoteCompleted);
 
     private IEnumerable<SpeakerRequest> SpeakerRequestsForExtension =>
         discussion is null


### PR DESCRIPTION
## Summary
- expose a helper to detect when the current agenda item can be finished without discussion or voting
- surface a Complete Agenda Item button for pending items that can be closed immediately

## Testing
- dotnet build src/Executive/Meetings/Meetings.UI/Meetings.UI.csproj

------
https://chatgpt.com/codex/tasks/task_e_68fb61f892f0832fa49021fe09df01f9