### PR TITLE
Allow completing pending agenda items without extra actions

### DIFF
--- a/src/Executive/Meetings/Meetings.UI/Procedure/ControlPage.razor
+++ b/src/Executive/Meetings/Meetings.UI/Procedure/ControlPage.razor
@@ -151,6 +151,12 @@ else
                                 </MudButton>
                                 <MudButton Variant="Variant.Filled" Color="Color.Error" OnClick="CancelAgendaItem" Class="me-2">Cancel
                                 </MudButton>
+
+                                @if (CanCompleteCurrentAgendaItem)
+                                {
+                                    <MudButton Variant="Variant.Filled" Color="Color.Success" OnClick="CompleteAgendaItem">Complete
+                                        Agenda Item</MudButton>
+                                }
                             }
                             else if (currentAgendaItem.State == AgendaItemState.UnderDiscussion)
                             {
@@ -316,6 +322,14 @@ else
 
     private bool CanResetSpeakerClock =>
         discussion?.CurrentSpeaker is not null && discussion.CurrentSpeakerClock is not null;
+
+    private bool CanCompleteCurrentAgendaItem =>
+        currentAgendaItem is not null &&
+        currentAgendaItem.State != AgendaItemState.Completed &&
+        currentAgendaItem.State != AgendaItemState.Canceled &&
+        currentAgendaItem.State != AgendaItemState.Skipped &&
+        (currentAgendaItem.DiscussionActions != DiscussionActions.Required || currentAgendaItem.IsDiscussionCompleted) &&
+        (currentAgendaItem.VoteActions != VoteActions.Required || currentAgendaItem.IsVoteCompleted);
 
     private static string FormatTime(TimeSpan? timeSpan) => timeSpan is null ? "-" : timeSpan.Value.ToString(@"hh\:mm");
 


### PR DESCRIPTION
## Summary
- add a "Complete agenda item" action to pending agenda items on the control page when they can be closed without discussion or voting
- mirror the server-side completion rules in the UI so the button only appears when the item is eligible

## Testing
- dotnet build src/Executive/Meetings/Meetings.UI/Meetings.UI.csproj

------
https://chatgpt.com/codex/tasks/task_e_68fb660eede0832f9bb69d5724470402