### PR TITLE
Add discussion procedure domain tests

### DIFF
--- a/src/Executive/Meetings/Meetings.Domain.Tests/DiscussionProcedureTests.cs
+++ b/src/Executive/Meetings/Meetings.Domain.Tests/DiscussionProcedureTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Linq;
+using Shouldly;
+using YourBrand.Meetings.Domain.Entities;
+using Xunit;
+
+namespace YourBrand.Meetings.Domain.Tests;
+
+public sealed class DiscussionProcedureTests
+{
+    [Fact]
+    public void StartDiscussion_WhenAgendaItemActiveInitializesDiscussion()
+    {
+        var meeting = MeetingTestFactory.CreateMeetingWithAgenda(AgendaItemType.NewBusiness);
+
+        meeting.StartMeeting();
+        var agendaItem = meeting.GetCurrentAgendaItem();
+
+        agendaItem.ShouldNotBeNull();
+        agendaItem!.Activate();
+
+        agendaItem.StartDiscussion();
+
+        agendaItem.Phase.ShouldBe(AgendaItemPhase.Discussion);
+        agendaItem.Discussion.ShouldNotBeNull();
+        agendaItem.Discussion!.State.ShouldBe(DiscussionState.InProgress);
+        agendaItem.DiscussionStartedAt.ShouldNotBeNull();
+        agendaItem.Discussion!.SpeakerQueue.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void RequestSpeakerSlot_WhenPendingInitializesDiscussionAndAddsSpeaker()
+    {
+        var meeting = MeetingTestFactory.CreateMeetingWithAgenda(AgendaItemType.NewBusiness);
+        var agendaItem = meeting.Agenda!.Items.First();
+        var attendee = meeting.Attendees.First();
+
+        agendaItem.RequestSpeakerSlot(attendee);
+
+        agendaItem.Discussion.ShouldNotBeNull();
+        var speakerRequest = agendaItem.Discussion!.SpeakerQueue.ShouldHaveSingleItem();
+        speakerRequest.AttendeeId.ShouldBe(attendee.Id);
+        speakerRequest.Status.ShouldBe(SpeakerRequestStatus.Pending);
+    }
+
+    [Fact]
+    public void EndDiscussion_CompletesDiscussionAndMarksSpeakersCompleted()
+    {
+        var meeting = MeetingTestFactory.CreateMeetingWithAgenda(AgendaItemType.NewBusiness);
+
+        meeting.StartMeeting();
+        var agendaItem = meeting.GetCurrentAgendaItem();
+        agendaItem.ShouldNotBeNull();
+        var attendee = meeting.Attendees.First();
+
+        agendaItem!.RequestSpeakerSlot(attendee);
+        agendaItem.Activate();
+        agendaItem.StartDiscussion();
+        agendaItem.Discussion!.MoveToNextSpeaker();
+
+        agendaItem.EndDiscussion();
+
+        agendaItem.IsDiscussionCompleted.ShouldBeTrue();
+        agendaItem.Phase.ShouldBe(AgendaItemPhase.Default);
+        agendaItem.DiscussionEndedAt.ShouldNotBeNull();
+        agendaItem.Discussion!.State.ShouldBe(DiscussionState.Completed);
+
+        foreach (var speaker in agendaItem.Discussion!.SpeakerQueue)
+        {
+            speaker.Status.ShouldBe(SpeakerRequestStatus.Completed);
+        }
+    }
+
+    [Fact]
+    public void StartDiscussion_WhenAgendaItemNotActive_Throws()
+    {
+        var meeting = MeetingTestFactory.CreateMeetingWithAgenda(AgendaItemType.NewBusiness);
+
+        meeting.StartMeeting();
+        var agendaItem = meeting.GetCurrentAgendaItem();
+        agendaItem.ShouldNotBeNull();
+
+        Should.Throw<InvalidOperationException>(() => agendaItem!.StartDiscussion());
+    }
+}

--- a/src/Executive/Meetings/Meetings.Domain.Tests/MeetingProcedureTests.cs
+++ b/src/Executive/Meetings/Meetings.Domain.Tests/MeetingProcedureTests.cs
@@ -15,7 +15,7 @@ public sealed class MeetingProcedureTests
     public void MeetingProcedure_FullLifecycle_TransitionsStatesAndPhases()
     {
         // Arrange
-        var meeting = CreateMeetingWithAgenda(
+        var meeting = MeetingTestFactory.CreateMeetingWithAgenda(
             AgendaItemType.PublicComment,
             AgendaItemType.Motion);
 
@@ -85,7 +85,7 @@ public sealed class MeetingProcedureTests
     public void MoveToNextAgendaItem_ReactivatesPostponedItems()
     {
         // Arrange
-        var meeting = CreateMeetingWithAgenda(
+        var meeting = MeetingTestFactory.CreateMeetingWithAgenda(
             AgendaItemType.ChairpersonRemarks,
             AgendaItemType.Reports,
             AgendaItemType.Announcements);
@@ -122,47 +122,5 @@ public sealed class MeetingProcedureTests
         activatedThird.ShouldBe(third);
         activatedThird.State.ShouldBe(AgendaItemState.Active);
         activatedThird.Phase.ShouldBe(AgendaItemPhase.Default);
-    }
-
-    private static Meeting CreateMeetingWithAgenda(params AgendaItemType[] itemTypes)
-    {
-        var tenantId = new TenantId("tenant");
-        var organizationId = new OrganizationId("org");
-        var meetingId = new MeetingId(1);
-
-        var meeting = new Meeting(meetingId, "Test meeting")
-        {
-            TenantId = tenantId,
-            OrganizationId = organizationId,
-            State = MeetingState.Scheduled
-        };
-
-        meeting.Agenda = CreateAgenda(itemTypes, tenantId, organizationId, meeting.Id);
-
-        meeting.AddAttendee("Chair", "chair-user", "chair@example.com", AttendeeRole.Member, hasSpeakingRights: true, hasVotingRights: true);
-
-        return meeting;
-    }
-
-    private static Agenda CreateAgenda(AgendaItemType[] itemTypes, TenantId tenantId, OrganizationId organizationId, MeetingId meetingId)
-    {
-        var agenda = new Agenda(new AgendaId(1))
-        {
-            TenantId = tenantId,
-            OrganizationId = organizationId,
-            MeetingId = meetingId
-        };
-
-        for (int index = 0; index < itemTypes.Length; index++)
-        {
-            var type = itemTypes[index];
-            var item = agenda.AddItem(type, $"Item {index + 1}", $"Description {index + 1}");
-
-            item.IsMandatory = type.IsMandatory;
-            item.DiscussionActions = type.RequiresDiscussion ? DiscussionActions.Required : DiscussionActions.Optional;
-            item.VoteActions = type.RequiresVoting ? VoteActions.Required : VoteActions.Optional;
-        }
-
-        return agenda;
     }
 }

--- a/src/Executive/Meetings/Meetings.Domain.Tests/MeetingTestFactory.cs
+++ b/src/Executive/Meetings/Meetings.Domain.Tests/MeetingTestFactory.cs
@@ -1,0 +1,51 @@
+using YourBrand.Domain;
+using YourBrand.Meetings.Domain.Entities;
+using YourBrand.Meetings.Domain.ValueObjects;
+using YourBrand.Tenancy;
+
+namespace YourBrand.Meetings.Domain.Tests;
+
+internal static class MeetingTestFactory
+{
+    public static Meeting CreateMeetingWithAgenda(params AgendaItemType[] itemTypes)
+    {
+        var tenantId = new TenantId("tenant");
+        var organizationId = new OrganizationId("org");
+        var meetingId = new MeetingId(1);
+
+        var meeting = new Meeting(meetingId, "Test meeting")
+        {
+            TenantId = tenantId,
+            OrganizationId = organizationId,
+            State = MeetingState.Scheduled
+        };
+
+        meeting.Agenda = CreateAgenda(itemTypes, tenantId, organizationId, meeting.Id);
+
+        meeting.AddAttendee("Chair", "chair-user", "chair@example.com", AttendeeRole.Member, hasSpeakingRights: true, hasVotingRights: true);
+
+        return meeting;
+    }
+
+    private static Agenda CreateAgenda(AgendaItemType[] itemTypes, TenantId tenantId, OrganizationId organizationId, MeetingId meetingId)
+    {
+        var agenda = new Agenda(new AgendaId(1))
+        {
+            TenantId = tenantId,
+            OrganizationId = organizationId,
+            MeetingId = meetingId
+        };
+
+        for (int index = 0; index < itemTypes.Length; index++)
+        {
+            var type = itemTypes[index];
+            var item = agenda.AddItem(type, $"Item {index + 1}", $"Description {index + 1}");
+
+            item.IsMandatory = type.IsMandatory;
+            item.DiscussionActions = type.RequiresDiscussion ? DiscussionActions.Required : DiscussionActions.Optional;
+            item.VoteActions = type.RequiresVoting ? VoteActions.Required : VoteActions.Optional;
+        }
+
+        return agenda;
+    }
+}


### PR DESCRIPTION
## Summary
- add coverage for agenda item discussion lifecycle and speaker queue behavior
- extract a reusable meeting factory for domain tests
- update existing meeting procedure tests to consume the shared factory

## Testing
- dotnet test src/Executive/Meetings/Meetings.Domain.Tests/Meetings.Domain.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68fc9680961c832f8210e01ac581208a