### PR TITLE
Refine meeting role mediation for chairperson actions

### DIFF
--- a/src/Executive/Meetings/Meetings/Domain/Entities/Meeting.cs
+++ b/src/Executive/Meetings/Meetings/Domain/Entities/Meeting.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using YourBrand.Auditability;
 using YourBrand.Domain;
 using YourBrand.Identity;
+using YourBrand.Meetings.Domain.Functions;
 using YourBrand.Meetings.Domain.ValueObjects;
 using YourBrand.Tenancy;
 
@@ -609,6 +610,9 @@ public class Meeting : AggregateRoot<MeetingId>, IAuditableEntity<MeetingId>, IH
 
         return false;
     }
+
+    public ChairpersonMeetingFunction? GetChairpersonFunction(MeetingAttendee attendee) =>
+        CanAttendeeActAsChair(attendee) ? new ChairpersonMeetingFunction(this, attendee) : null;
 
     public void AssignFunctionToAttendee(MeetingAttendee attendee, MeetingFunction function)
     {

--- a/src/Executive/Meetings/Meetings/Domain/Functions/ChairpersonMeetingFunction.cs
+++ b/src/Executive/Meetings/Meetings/Domain/Functions/ChairpersonMeetingFunction.cs
@@ -1,0 +1,117 @@
+using System;
+using YourBrand.Meetings.Domain.Entities;
+using YourBrand.Meetings.Domain.ValueObjects;
+
+namespace YourBrand.Meetings.Domain.Functions;
+
+public sealed class ChairpersonMeetingFunction
+{
+    private readonly Meeting _meeting;
+    private readonly MeetingAttendee _attendee;
+
+    internal ChairpersonMeetingFunction(Meeting meeting, MeetingAttendee attendee)
+    {
+        _meeting = meeting;
+        _attendee = attendee;
+    }
+
+    public Meeting Meeting => _meeting;
+
+    public MeetingAttendee Attendee => _attendee;
+
+    public void StartMeeting() => _meeting.StartMeeting();
+
+    public void ResumeMeeting() => _meeting.ResumeMeeting();
+
+    public void AdjournMeeting(string message) => _meeting.AdjournMeeting(message);
+
+    public void CancelMeeting() => _meeting.CancelMeeting();
+
+    public void EndMeeting() => _meeting.EndMeeting();
+
+    public void ResetMeetingProgress() => _meeting.ResetMeetingProgress();
+
+    public AgendaItem MoveToNextAgendaItem() => _meeting.MoveToNextAgendaItem();
+
+    public void CancelAgendaItem(AgendaItem agendaItem) => agendaItem.Cancel();
+
+    public void CompleteAgendaItem(AgendaItem agendaItem) => agendaItem.Complete();
+
+    public void PostponeAgendaItem(AgendaItem agendaItem) => agendaItem.Postpone();
+
+    public void StartDiscussion(AgendaItem agendaItem) => agendaItem.StartDiscussion();
+
+    public void EndDiscussion(AgendaItem agendaItem) => agendaItem.EndDiscussion();
+
+    public void StartVoting(AgendaItem agendaItem) => agendaItem.StartVoting();
+
+    public void EndVoting(AgendaItem agendaItem) => agendaItem.EndVoting();
+
+    public void StartElection(AgendaItem agendaItem) => agendaItem.StartElection();
+
+    public void EndElection(AgendaItem agendaItem) => agendaItem.EndElection();
+
+    public void SetDiscussionSpeakingTime(AgendaItem agendaItem, TimeSpan? speakingTimeLimit)
+    {
+        agendaItem.Discussion ??= new Discussion
+        {
+            OrganizationId = _meeting.OrganizationId,
+            TenantId = _meeting.TenantId,
+            AgendaItemId = agendaItem.Id
+        };
+
+        agendaItem.Discussion.SetSpeakingTimeLimit(speakingTimeLimit);
+    }
+
+    public void ExtendSpeakerTime(AgendaItem agendaItem, string speakerRequestId, TimeSpan additionalTime)
+    {
+        if (agendaItem.Discussion is null)
+        {
+            throw new InvalidOperationException("No ongoing discussion to extend speaker time for.");
+        }
+
+        agendaItem.Discussion.ExtendSpeakerTime(new SpeakerRequestId(speakerRequestId), additionalTime);
+    }
+
+    public SpeakerClockSnapshot StartSpeakerClock(AgendaItem agendaItem, DateTimeOffset now)
+    {
+        if (agendaItem.Discussion is null)
+        {
+            throw new InvalidOperationException("No ongoing discussion to start the speaker clock for.");
+        }
+
+        agendaItem.Discussion.StartCurrentSpeakerClock(now);
+        return agendaItem.Discussion.GetCurrentSpeakerClockSnapshot(now);
+    }
+
+    public SpeakerClockSnapshot StopSpeakerClock(AgendaItem agendaItem, DateTimeOffset now)
+    {
+        if (agendaItem.Discussion is null)
+        {
+            throw new InvalidOperationException("No ongoing discussion to stop the speaker clock for.");
+        }
+
+        agendaItem.Discussion.StopCurrentSpeakerClock(now);
+        return agendaItem.Discussion.GetCurrentSpeakerClockSnapshot(now);
+    }
+
+    public void ResetSpeakerClock(AgendaItem agendaItem)
+    {
+        if (agendaItem.Discussion is null)
+        {
+            throw new InvalidOperationException("No ongoing discussion to reset the speaker clock for.");
+        }
+
+        agendaItem.Discussion.ResetCurrentSpeakerClock();
+    }
+
+    public SpeakerTransition MoveToNextSpeaker(AgendaItem agendaItem)
+    {
+        if (agendaItem.Discussion is null)
+        {
+            throw new InvalidOperationException("No ongoing discussion to move to the next speaker for.");
+        }
+
+        return agendaItem.Discussion.MoveToNextSpeaker();
+    }
+}

--- a/src/Executive/Meetings/Meetings/Features/Procedure/AdjournMeeting.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/AdjournMeeting.cs
@@ -39,12 +39,14 @@ public sealed record AdjournMeeting(string OrganizationId, int Id, string Messag
                 return Errors.Meetings.YouAreNotAttendeeOfMeeting;
             }
 
-            if (!meeting.CanAttendeeActAsChair(attendee))
+            var chairFunction = meeting.GetChairpersonFunction(attendee);
+
+            if (chairFunction is null)
             {
                 return Errors.Meetings.OnlyChairpersonCanAdjournTheMeeting;
             }
 
-            meeting.AdjournMeeting(request.Message.Trim());
+            chairFunction.AdjournMeeting(request.Message.Trim());
 
             context.Meetings.Update(meeting);
 

--- a/src/Executive/Meetings/Meetings/Features/Procedure/CancelAgendaItem.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/CancelAgendaItem.cs
@@ -39,12 +39,14 @@ public sealed record CancelAgendaItem(string OrganizationId, int Id) : IRequest<
                 return Errors.Meetings.NoActiveAgendaItem;
             }
 
-            if (!meeting.CanAttendeeActAsChair(attendee))
+            var chairFunction = meeting.GetChairpersonFunction(attendee);
+
+            if (chairFunction is null)
             {
                 return Errors.Meetings.OnlyChairpersonCanCancelAgendaItem;
             }
 
-            agendaItem.Cancel();
+            chairFunction.CancelAgendaItem(agendaItem);
 
             context.Meetings.Update(meeting);
 

--- a/src/Executive/Meetings/Meetings/Features/Procedure/CancelMeeting.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/CancelMeeting.cs
@@ -29,12 +29,14 @@ public sealed record CancelMeeting(string OrganizationId, int Id) : IRequest<Res
                 return Errors.Meetings.YouAreNotAttendeeOfMeeting;
             }
 
-            if (!meeting.CanAttendeeActAsChair(attendee))
+            var chairFunction = meeting.GetChairpersonFunction(attendee);
+
+            if (chairFunction is null)
             {
                 return Errors.Meetings.OnlyChairpersonCanEndTheMeeting;
             }
 
-            meeting.CancelMeeting();
+            chairFunction.CancelMeeting();
 
             context.Meetings.Update(meeting);
 

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/EndDiscussions.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/EndDiscussions.cs
@@ -40,12 +40,14 @@ public sealed record EndDiscussions(string OrganizationId, int Id) : IRequest<Re
                 return Errors.Meetings.NoActiveAgendaItem;
             }
 
-            if (!meeting.CanAttendeeActAsChair(attendee))
+            var chairFunction = meeting.GetChairpersonFunction(attendee);
+
+            if (chairFunction is null)
             {
                 return Errors.Meetings.OnlyChairpersonCanEndDiscussion;
             }
 
-            agendaItem.EndDiscussion();
+            chairFunction.EndDiscussion(agendaItem);
 
             context.Meetings.Update(meeting);
 

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/EndElection.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/EndElection.cs
@@ -44,12 +44,14 @@ public sealed record EndElection(string OrganizationId, int Id) : IRequest<Resul
                 return Errors.Meetings.NoActiveAgendaItem;
             }
 
-            if (!meeting.CanAttendeeActAsChair(attendee))
+            var chairFunction = meeting.GetChairpersonFunction(attendee);
+
+            if (chairFunction is null)
             {
                 return Errors.Meetings.OnlyChairpersonCanEndVoting;
             }
 
-            agendaItem.EndElection();
+            chairFunction.EndElection(agendaItem);
 
             var election = agendaItem.Election;
 

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/EndVoting.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/EndVoting.cs
@@ -40,12 +40,14 @@ public sealed record EndVoting(string OrganizationId, int Id) : IRequest<Result>
                 return Errors.Meetings.NoActiveAgendaItem;
             }
 
-            if (!meeting.CanAttendeeActAsChair(attendee))
+            var chairFunction = meeting.GetChairpersonFunction(attendee);
+
+            if (chairFunction is null)
             {
                 return Errors.Meetings.OnlyChairpersonCanEndVoting;
             }
 
-            agendaItem.EndVoting();
+            chairFunction.EndVoting(agendaItem);
 
             context.Meetings.Update(meeting);
 

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/ExtendSpeakerTime.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/ExtendSpeakerTime.cs
@@ -43,7 +43,9 @@ public sealed record ExtendSpeakerTime(string OrganizationId, int Id, string Age
                 return Errors.Meetings.YouAreNotAttendeeOfMeeting;
             }
 
-            if (!meeting.CanAttendeeActAsChair(attendee))
+            var chairFunction = meeting.GetChairpersonFunction(attendee);
+
+            if (chairFunction is null)
             {
                 return Errors.Meetings.OnlyChairpersonCanManageSpeakerQueue;
             }
@@ -62,7 +64,7 @@ public sealed record ExtendSpeakerTime(string OrganizationId, int Id, string Age
 
             try
             {
-                agendaItem.Discussion.ExtendSpeakerTime(request.SpeakerRequestId, TimeSpan.FromSeconds(request.AdditionalSeconds));
+                chairFunction.ExtendSpeakerTime(agendaItem, request.SpeakerRequestId, TimeSpan.FromSeconds(request.AdditionalSeconds));
             }
             catch (InvalidOperationException)
             {

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/MoveToNextSpeaker.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/MoveToNextSpeaker.cs
@@ -37,7 +37,9 @@ public sealed record MoveToNextSpeaker(string OrganizationId, int Id) : IRequest
                 return Errors.Meetings.YouAreNotAttendeeOfMeeting;
             }
 
-            if (!meeting.CanAttendeeActAsChair(attendee))
+            var chairFunction = meeting.GetChairpersonFunction(attendee);
+
+            if (chairFunction is null)
             {
                 return Errors.Meetings.OnlyChairpersonCanManageSpeakerQueue;
             }
@@ -54,7 +56,7 @@ public sealed record MoveToNextSpeaker(string OrganizationId, int Id) : IRequest
                 return Errors.Meetings.NoOngoingDiscussionSession;
             }
 
-            var transition = agendaItem.Discussion!.MoveToNextSpeaker();
+            var transition = chairFunction.MoveToNextSpeaker(agendaItem);
 
             var nextSpeakerId = transition.CurrentSpeaker is null ? null : transition.CurrentSpeaker.Id.Value;
             var previousSpeakerId = transition.PreviousSpeaker is null ? null : transition.PreviousSpeaker.Id.Value;

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/ResetSpeakerClock.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/ResetSpeakerClock.cs
@@ -40,7 +40,9 @@ public sealed record ResetSpeakerClock(string OrganizationId, int Id, string Age
                 return Errors.Meetings.YouAreNotAttendeeOfMeeting;
             }
 
-            if (!meeting.CanAttendeeActAsChair(attendee))
+            var chairFunction = meeting.GetChairpersonFunction(attendee);
+
+            if (chairFunction is null)
             {
                 return Errors.Meetings.OnlyChairpersonCanManageSpeakerQueue;
             }
@@ -62,7 +64,7 @@ public sealed record ResetSpeakerClock(string OrganizationId, int Id, string Age
                 return Errors.Meetings.NoCurrentSpeaker;
             }
 
-            agendaItem.Discussion.ResetCurrentSpeakerClock();
+            chairFunction.ResetSpeakerClock(agendaItem);
 
             context.Meetings.Update(meeting);
 

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/StartDiscussions.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/StartDiscussions.cs
@@ -40,12 +40,14 @@ public sealed record StartDiscussions(string OrganizationId, int Id) : IRequest<
                 return Errors.Meetings.NoActiveAgendaItem;
             }
 
-            if (!meeting.CanAttendeeActAsChair(attendee))
+            var chairFunction = meeting.GetChairpersonFunction(attendee);
+
+            if (chairFunction is null)
             {
                 return Errors.Meetings.OnlyChairpersonCanStartDiscussion;
             }
 
-            agendaItem.StartDiscussion();
+            chairFunction.StartDiscussion(agendaItem);
 
             context.Meetings.Update(meeting);
 

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/StartElection.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/StartElection.cs
@@ -41,12 +41,14 @@ public sealed record StartElection(string OrganizationId, int Id) : IRequest<Res
                 return Errors.Meetings.NoActiveAgendaItem;
             }
 
-            if (!meeting.CanAttendeeActAsChair(attendee))
+            var chairFunction = meeting.GetChairpersonFunction(attendee);
+
+            if (chairFunction is null)
             {
                 return Errors.Meetings.OnlyChairpersonCanStartVoting;
             }
 
-            agendaItem.StartElection();
+            chairFunction.StartElection(agendaItem);
 
             context.Meetings.Update(meeting);
 

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/StartVoting.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/StartVoting.cs
@@ -41,12 +41,14 @@ public sealed record StartVoting(string OrganizationId, int Id) : IRequest<Resul
                 return Errors.Meetings.NoActiveAgendaItem;
             }
 
-            if (!meeting.CanAttendeeActAsChair(attendee))
+            var chairFunction = meeting.GetChairpersonFunction(attendee);
+
+            if (chairFunction is null)
             {
                 return Errors.Meetings.OnlyChairpersonCanStartVoting;
             }
 
-            agendaItem.StartVoting();
+            chairFunction.StartVoting(agendaItem);
 
             context.Meetings.Update(meeting);
 

--- a/src/Executive/Meetings/Meetings/Features/Procedure/CompleteAgendaItem.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/CompleteAgendaItem.cs
@@ -39,12 +39,14 @@ public sealed record CompleteAgendaItem(string OrganizationId, int Id) : IReques
                 return Errors.Meetings.NoActiveAgendaItem;
             }
 
-            if (!meeting.CanAttendeeActAsChair(attendee))
+            var chairFunction = meeting.GetChairpersonFunction(attendee);
+
+            if (chairFunction is null)
             {
                 return Errors.Meetings.OnlyChairpersonCanCompleteAgendaItem;
             }
 
-            agendaItem.Complete();
+            chairFunction.CompleteAgendaItem(agendaItem);
 
             context.Meetings.Update(meeting);
 

--- a/src/Executive/Meetings/Meetings/Features/Procedure/EndMeeting.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/EndMeeting.cs
@@ -29,12 +29,14 @@ public sealed record EndMeeting(string OrganizationId, int Id) : IRequest<Result
                 return Errors.Meetings.YouAreNotAttendeeOfMeeting;
             }
 
-            if (!meeting.CanAttendeeActAsChair(attendee))
+            var chairFunction = meeting.GetChairpersonFunction(attendee);
+
+            if (chairFunction is null)
             {
                 return Errors.Meetings.OnlyChairpersonCanEndTheMeeting;
             }
 
-            meeting.EndMeeting();
+            chairFunction.EndMeeting();
 
             var minutes = meeting.Minutes;
 

--- a/src/Executive/Meetings/Meetings/Features/Procedure/MoveToNextAgendaItem.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/MoveToNextAgendaItem.cs
@@ -33,12 +33,14 @@ public sealed record MoveToNextAgendaItem(string OrganizationId, int Id) : IRequ
                 return Errors.Meetings.YouAreNotAttendeeOfMeeting;
             }
 
-            if (!meeting.CanAttendeeActAsChair(attendee))
+            var chairFunction = meeting.GetChairpersonFunction(attendee);
+
+            if (chairFunction is null)
             {
                 return Errors.Meetings.OnlyChairpersonCanMoveToNextAgendaItem;
             }
 
-            var nextItem = meeting.MoveToNextAgendaItem();
+            var nextItem = chairFunction.MoveToNextAgendaItem();
 
             context.Meetings.Update(meeting);
 

--- a/src/Executive/Meetings/Meetings/Features/Procedure/PostponeAgendaItem.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/PostponeAgendaItem.cs
@@ -39,12 +39,14 @@ public sealed record PostponeAgendaItem(string OrganizationId, int Id) : IReques
                 return Errors.Meetings.NoActiveAgendaItem;
             }
 
-            if (!meeting.CanAttendeeActAsChair(attendee))
+            var chairFunction = meeting.GetChairpersonFunction(attendee);
+
+            if (chairFunction is null)
             {
                 return Errors.Meetings.OnlyChairpersonCanPostponeAgendaItem;
             }
 
-            agendaItem.Postpone();
+            chairFunction.PostponeAgendaItem(agendaItem);
 
             context.Meetings.Update(meeting);
 

--- a/src/Executive/Meetings/Meetings/Features/Procedure/ResetMeetingProcedure.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/ResetMeetingProcedure.cs
@@ -41,12 +41,14 @@ public record ResetMeetingProcedure(string OrganizationId, int Id) : IRequest<Re
                 return Errors.Meetings.YouAreNotAttendeeOfMeeting;
             }
 
-            if (!meeting.CanAttendeeActAsChair(attendee))
+            var chairFunction = meeting.GetChairpersonFunction(attendee);
+
+            if (chairFunction is null)
             {
                 return Errors.Meetings.OnlyChairpersonCanResetTheMeetingProcedure;
             }
 
-            meeting.ResetMeetingProgress();
+            chairFunction.ResetMeetingProgress();
 
             context.Meetings.Update(meeting);
 

--- a/src/Executive/Meetings/Meetings/Features/Procedure/ResumeMeeting.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/ResumeMeeting.cs
@@ -29,12 +29,14 @@ public sealed record ResumeMeeting(string OrganizationId, int Id) : IRequest<Res
                 return Errors.Meetings.YouAreNotAttendeeOfMeeting;
             }
 
-            if (!meeting.CanAttendeeActAsChair(attendee))
+            var chairFunction = meeting.GetChairpersonFunction(attendee);
+
+            if (chairFunction is null)
             {
                 return Errors.Meetings.OnlyChairpersonCanResumeTheMeeting;
             }
 
-            meeting.ResumeMeeting();
+            chairFunction.ResumeMeeting();
 
             context.Meetings.Update(meeting);
 

--- a/src/Executive/Meetings/Meetings/Features/Procedure/StartMeeting.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/StartMeeting.cs
@@ -29,12 +29,14 @@ public sealed record StartMeeting(string OrganizationId, int Id) : IRequest<Resu
                 return Errors.Meetings.YouAreNotAttendeeOfMeeting;
             }
 
-            if (!meeting.CanAttendeeActAsChair(attendee))
+            var chairFunction = meeting.GetChairpersonFunction(attendee);
+
+            if (chairFunction is null)
             {
                 return Errors.Meetings.OnlyChairpersonCanStartTheMeeting;
             }
 
-            meeting.StartMeeting();
+            chairFunction.StartMeeting();
 
             context.Meetings.Update(meeting);
 


### PR DESCRIPTION
## Summary
- add a chairperson meeting function mediator so only assigned attendees can invoke chair-specific state changes
- expose the mediator from the Meeting aggregate and switch procedure handlers to call its APIs instead of raw domain methods
- ensure speaker management helpers (clock control, extensions, etc.) run through the mediator for consistency

## Testing
- dotnet build src/Executive/Meetings/Meetings/Meetings.csproj


------
https://chatgpt.com/codex/tasks/task_e_68fc9bbbba80832f9a0e0befa4dea50f