### PR TITLE
Use domain events for discussion and voting updates

### DIFF
--- a/src/Executive/Meetings/Meetings/Domain/Entities/Meeting.cs
+++ b/src/Executive/Meetings/Meetings/Domain/Entities/Meeting.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using YourBrand.Auditability;
 using YourBrand.Domain;
 using YourBrand.Identity;
+using YourBrand.Meetings.Domain.Events;
 using YourBrand.Meetings.Domain.Functions;
 using YourBrand.Meetings.Domain.ValueObjects;
 using YourBrand.Tenancy;
@@ -533,6 +534,11 @@ public class Meeting : AggregateRoot<MeetingId>, IAuditableEntity<MeetingId>, IH
     private void RaiseAgendaItemChanged(string? agendaItemId)
     {
         AddDomainEvent(new MeetingAgendaItemChanged(TenantId, OrganizationId, Id, agendaItemId));
+    }
+
+    internal void NotifyAgendaItemStateChanged(AgendaItem agendaItem)
+    {
+        AddDomainEvent(new MeetingAgendaItemStateChanged(TenantId, OrganizationId, Id, agendaItem.Id, agendaItem.State, agendaItem.Phase));
     }
 
     public bool IsAttendeeAllowedToSpeak(MeetingAttendee attendee)

--- a/src/Executive/Meetings/Meetings/Domain/Events/MeetingAgendaItemStateChanged.cs
+++ b/src/Executive/Meetings/Meetings/Domain/Events/MeetingAgendaItemStateChanged.cs
@@ -1,0 +1,16 @@
+using YourBrand.Domain;
+using YourBrand.Meetings.Domain.Entities;
+using YourBrand.Meetings.Domain.ValueObjects;
+using YourBrand.Tenancy;
+
+using OrganizationId = YourBrand.Domain.OrganizationId;
+
+namespace YourBrand.Meetings.Domain.Events;
+
+public sealed record MeetingAgendaItemStateChanged(
+    TenantId TenantId,
+    OrganizationId OrganizationId,
+    MeetingId MeetingId,
+    AgendaItemId AgendaItemId,
+    AgendaItemState State,
+    AgendaItemPhase Phase) : DomainEvent;

--- a/src/Executive/Meetings/Meetings/Domain/Functions/ChairpersonMeetingFunction.cs
+++ b/src/Executive/Meetings/Meetings/Domain/Functions/ChairpersonMeetingFunction.cs
@@ -63,9 +63,17 @@ public sealed class ChairpersonMeetingFunction
         _meeting.NotifyAgendaItemStateChanged(agendaItem);
     }
 
-    public void StartElection(AgendaItem agendaItem) => agendaItem.StartElection();
+    public void StartElection(AgendaItem agendaItem)
+    {
+        agendaItem.StartElection();
+        _meeting.NotifyAgendaItemStateChanged(agendaItem);
+    }
 
-    public void EndElection(AgendaItem agendaItem) => agendaItem.EndElection();
+    public void EndElection(AgendaItem agendaItem)
+    {
+        agendaItem.EndElection();
+        _meeting.NotifyAgendaItemStateChanged(agendaItem);
+    }
 
     public void SetDiscussionSpeakingTime(AgendaItem agendaItem, TimeSpan? speakingTimeLimit)
     {

--- a/src/Executive/Meetings/Meetings/Domain/Functions/ChairpersonMeetingFunction.cs
+++ b/src/Executive/Meetings/Meetings/Domain/Functions/ChairpersonMeetingFunction.cs
@@ -39,13 +39,29 @@ public sealed class ChairpersonMeetingFunction
 
     public void PostponeAgendaItem(AgendaItem agendaItem) => agendaItem.Postpone();
 
-    public void StartDiscussion(AgendaItem agendaItem) => agendaItem.StartDiscussion();
+    public void StartDiscussion(AgendaItem agendaItem)
+    {
+        agendaItem.StartDiscussion();
+        _meeting.NotifyAgendaItemStateChanged(agendaItem);
+    }
 
-    public void EndDiscussion(AgendaItem agendaItem) => agendaItem.EndDiscussion();
+    public void EndDiscussion(AgendaItem agendaItem)
+    {
+        agendaItem.EndDiscussion();
+        _meeting.NotifyAgendaItemStateChanged(agendaItem);
+    }
 
-    public void StartVoting(AgendaItem agendaItem) => agendaItem.StartVoting();
+    public void StartVoting(AgendaItem agendaItem)
+    {
+        agendaItem.StartVoting();
+        _meeting.NotifyAgendaItemStateChanged(agendaItem);
+    }
 
-    public void EndVoting(AgendaItem agendaItem) => agendaItem.EndVoting();
+    public void EndVoting(AgendaItem agendaItem)
+    {
+        agendaItem.EndVoting();
+        _meeting.NotifyAgendaItemStateChanged(agendaItem);
+    }
 
     public void StartElection(AgendaItem agendaItem) => agendaItem.StartElection();
 

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/EndDiscussions.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/EndDiscussions.cs
@@ -1,7 +1,6 @@
 using MediatR;
 using YourBrand.Meetings.Domain.Entities;
 
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 
 using YourBrand.Identity;
@@ -11,7 +10,7 @@ namespace YourBrand.Meetings.Features.Procedure.Chairman;
 
 public sealed record EndDiscussions(string OrganizationId, int Id) : IRequest<Result>
 {
-    public sealed class Handler(IApplicationDbContext context, IUserContext userContext, IHubContext<MeetingsProcedureHub, IMeetingsProcedureHubClient> hubContext) : IRequestHandler<EndDiscussions, Result>
+    public sealed class Handler(IApplicationDbContext context, IUserContext userContext) : IRequestHandler<EndDiscussions, Result>
     {
         public async Task<Result> Handle(EndDiscussions request, CancellationToken cancellationToken)
         {
@@ -52,10 +51,6 @@ public sealed record EndDiscussions(string OrganizationId, int Id) : IRequest<Re
             context.Meetings.Update(meeting);
 
             await context.SaveChangesAsync(cancellationToken);
-
-            await hubContext.Clients
-                .Group($"meeting-{meeting.Id}")
-               .OnAgendaItemStateChanged(agendaItem.Id, (Dtos.AgendaItemState)agendaItem.State, (Dtos.AgendaItemPhase)agendaItem.Phase);
 
             return Result.Success;
         }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/EndElection.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/EndElection.cs
@@ -2,7 +2,6 @@ using System.Linq;
 using MediatR;
 using YourBrand.Meetings.Domain.Entities;
 
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 
 using YourBrand.Identity;
@@ -12,7 +11,7 @@ namespace YourBrand.Meetings.Features.Procedure.Chairman;
 
 public sealed record EndElection(string OrganizationId, int Id) : IRequest<Result>
 {
-    public sealed class Handler(IApplicationDbContext context, IUserContext userContext, IHubContext<MeetingsProcedureHub, IMeetingsProcedureHubClient> hubContext) : IRequestHandler<EndElection, Result>
+    public sealed class Handler(IApplicationDbContext context, IUserContext userContext) : IRequestHandler<EndElection, Result>
     {
         public async Task<Result> Handle(EndElection request, CancellationToken cancellationToken)
         {
@@ -76,10 +75,6 @@ public sealed record EndElection(string OrganizationId, int Id) : IRequest<Resul
             context.Meetings.Update(meeting);
 
             await context.SaveChangesAsync(cancellationToken);
-
-            await hubContext.Clients
-                .Group($"meeting-{meeting.Id}")
-               .OnAgendaItemStateChanged(agendaItem.Id, (Dtos.AgendaItemState)agendaItem.State, (Dtos.AgendaItemPhase)agendaItem.Phase);
 
             return Result.Success;
         }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/EndVoting.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/EndVoting.cs
@@ -1,7 +1,6 @@
 using MediatR;
 using YourBrand.Meetings.Domain.Entities;
 
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 
 using YourBrand.Identity;
@@ -11,7 +10,7 @@ namespace YourBrand.Meetings.Features.Procedure.Chairman;
 
 public sealed record EndVoting(string OrganizationId, int Id) : IRequest<Result>
 {
-    public sealed class Handler(IApplicationDbContext context, IUserContext userContext, IHubContext<MeetingsProcedureHub, IMeetingsProcedureHubClient> hubContext) : IRequestHandler<EndVoting, Result>
+    public sealed class Handler(IApplicationDbContext context, IUserContext userContext) : IRequestHandler<EndVoting, Result>
     {
         public async Task<Result> Handle(EndVoting request, CancellationToken cancellationToken)
         {
@@ -52,10 +51,6 @@ public sealed record EndVoting(string OrganizationId, int Id) : IRequest<Result>
             context.Meetings.Update(meeting);
 
             await context.SaveChangesAsync(cancellationToken);
-
-            await hubContext.Clients
-                .Group($"meeting-{meeting.Id}")
-               .OnAgendaItemStateChanged(agendaItem.Id, (Dtos.AgendaItemState)agendaItem.State, (Dtos.AgendaItemPhase)agendaItem.Phase);
 
             return Result.Success;
         }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/StartDiscussions.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/StartDiscussions.cs
@@ -1,7 +1,6 @@
 using MediatR;
 using YourBrand.Meetings.Domain.Entities;
 
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 
 using YourBrand.Identity;
@@ -11,7 +10,7 @@ namespace YourBrand.Meetings.Features.Procedure.Chairman;
 
 public sealed record StartDiscussions(string OrganizationId, int Id) : IRequest<Result>
 {
-    public sealed class Handler(IApplicationDbContext context, IUserContext userContext, IHubContext<MeetingsProcedureHub, IMeetingsProcedureHubClient> hubContext) : IRequestHandler<StartDiscussions, Result>
+    public sealed class Handler(IApplicationDbContext context, IUserContext userContext) : IRequestHandler<StartDiscussions, Result>
     {
         public async Task<Result> Handle(StartDiscussions request, CancellationToken cancellationToken)
         {
@@ -52,10 +51,6 @@ public sealed record StartDiscussions(string OrganizationId, int Id) : IRequest<
             context.Meetings.Update(meeting);
 
             await context.SaveChangesAsync(cancellationToken);
-
-            await hubContext.Clients
-                .Group($"meeting-{meeting.Id}")
-               .OnAgendaItemStateChanged(agendaItem.Id, (Dtos.AgendaItemState)agendaItem.State, (Dtos.AgendaItemPhase)agendaItem.Phase);
 
             return Result.Success;
         }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/StartElection.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/StartElection.cs
@@ -1,7 +1,6 @@
 using MediatR;
 using YourBrand.Meetings.Domain.Entities;
 
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 
 using YourBrand.Identity;
@@ -12,7 +11,7 @@ namespace YourBrand.Meetings.Features.Procedure.Chairman;
 
 public sealed record StartElection(string OrganizationId, int Id) : IRequest<Result>
 {
-    public sealed class Handler(IApplicationDbContext context, IUserContext userContext, IHubContext<MeetingsProcedureHub, IMeetingsProcedureHubClient> hubContext) : IRequestHandler<StartElection, Result>
+    public sealed class Handler(IApplicationDbContext context, IUserContext userContext) : IRequestHandler<StartElection, Result>
     {
         public async Task<Result> Handle(StartElection request, CancellationToken cancellationToken)
         {
@@ -53,10 +52,6 @@ public sealed record StartElection(string OrganizationId, int Id) : IRequest<Res
             context.Meetings.Update(meeting);
 
             await context.SaveChangesAsync(cancellationToken);
-
-            await hubContext.Clients
-                .Group($"meeting-{meeting.Id}")
-               .OnAgendaItemStateChanged(agendaItem.Id, (Dtos.AgendaItemState)agendaItem.State, (Dtos.AgendaItemPhase)agendaItem.Phase);
 
             return Result.Success;
         }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/StartVoting.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/StartVoting.cs
@@ -1,7 +1,6 @@
 using MediatR;
 using YourBrand.Meetings.Domain.Entities;
 
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 
 using YourBrand.Identity;
@@ -12,7 +11,7 @@ namespace YourBrand.Meetings.Features.Procedure.Chairman;
 
 public sealed record StartVoting(string OrganizationId, int Id) : IRequest<Result>
 {
-    public sealed class Handler(IApplicationDbContext context, IUserContext userContext, IHubContext<MeetingsProcedureHub, IMeetingsProcedureHubClient> hubContext) : IRequestHandler<StartVoting, Result>
+    public sealed class Handler(IApplicationDbContext context, IUserContext userContext) : IRequestHandler<StartVoting, Result>
     {
         public async Task<Result> Handle(StartVoting request, CancellationToken cancellationToken)
         {
@@ -53,10 +52,6 @@ public sealed record StartVoting(string OrganizationId, int Id) : IRequest<Resul
             context.Meetings.Update(meeting);
 
             await context.SaveChangesAsync(cancellationToken);
-
-            await hubContext.Clients
-                .Group($"meeting-{meeting.Id}")
-               .OnAgendaItemStateChanged(agendaItem.Id, (Dtos.AgendaItemState)agendaItem.State, (Dtos.AgendaItemPhase)agendaItem.Phase);
 
             return Result.Success;
         }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/EventHandlers/MeetingAgendaItemStateChangedEventHandler.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/EventHandlers/MeetingAgendaItemStateChangedEventHandler.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.SignalR;
+
+using YourBrand.Domain;
+using YourBrand.Meetings.Domain.Events;
+using Dtos = YourBrand.Meetings.Dtos;
+
+namespace YourBrand.Meetings.Features.Procedure.EventHandlers;
+
+public sealed class MeetingAgendaItemStateChangedEventHandler(
+    IHubContext<MeetingsProcedureHub, IMeetingsProcedureHubClient> hubContext) : IDomainEventHandler<MeetingAgendaItemStateChanged>
+{
+    private readonly IHubContext<MeetingsProcedureHub, IMeetingsProcedureHubClient> _hubContext = hubContext;
+
+    public async Task Handle(MeetingAgendaItemStateChanged notification, CancellationToken cancellationToken)
+    {
+        await _hubContext.Clients
+            .Group($"meeting-{notification.MeetingId.Value}")
+            .OnAgendaItemStateChanged(notification.AgendaItemId.Value, (Dtos.AgendaItemState)notification.State, (Dtos.AgendaItemPhase)notification.Phase);
+    }
+}


### PR DESCRIPTION
## Summary
- add a MeetingAgendaItemStateChanged domain event and SignalR handler to broadcast agenda item phase transitions
- raise agenda item state events from the chairperson meeting function when starting or ending discussions and voting
- simplify chairman procedure handlers to rely on domain events instead of publishing directly to hubs

## Testing
- dotnet test src/Executive/Meetings/Meetings.Domain.Tests/Meetings.Domain.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_68fca00c3be8832f8df1b2f05fbbb431