### PR TITLE
Display vote and election results across meeting views

### DIFF
--- a/src/Executive/Meetings/Meetings.Client/OpenAPIs/swagger.yaml
+++ b/src/Executive/Meetings/Meetings.Client/OpenAPIs/swagger.yaml
@@ -4731,6 +4731,26 @@ components:
           $ref: '#/components/schemas/VotingState'
         hasPassed:
           type: boolean
+        breakdown:
+          nullable: true
+          $ref: '#/components/schemas/VoteBreakdown'
+    VoteBreakdown:
+      type: object
+      additionalProperties: false
+      properties:
+        forVotes:
+          type: integer
+          format: int32
+        againstVotes:
+          type: integer
+          format: int32
+        abstainVotes:
+          type: integer
+          format: int32
+      required:
+      - forVotes
+      - againstVotes
+      - abstainVotes
     VotingState:
       type: integer
       description: ''
@@ -4765,6 +4785,10 @@ components:
         meetingFunction:
           nullable: true
           $ref: '#/components/schemas/MeetingFunction'
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ElectionResult'
     ElectionState:
       type: integer
       description: ''
@@ -4794,6 +4818,21 @@ components:
         statement:
           type: string
           nullable: true
+    ElectionResult:
+      type: object
+      additionalProperties: false
+      properties:
+        candidateId:
+          type: string
+        candidateName:
+          type: string
+        votes:
+          type: integer
+          format: int32
+      required:
+      - candidateId
+      - candidateName
+      - votes
     PagedResultOfMemberRole:
       type: object
       additionalProperties: false

--- a/src/Executive/Meetings/Meetings.Shared/IElectionsHub.cs
+++ b/src/Executive/Meetings/Meetings.Shared/IElectionsHub.cs
@@ -1,5 +1,8 @@
+using System.Threading.Tasks;
+
 namespace YourBrand.Meetings;
 
 public interface IElectionsHub
 {
+    Task PresentElectionResults(ElectionResultsPresentationOptions options);
 }

--- a/src/Executive/Meetings/Meetings.Shared/IElectionsHubClient.cs
+++ b/src/Executive/Meetings/Meetings.Shared/IElectionsHubClient.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using YourBrand.Meetings.Dtos;
 
 namespace YourBrand.Meetings;
@@ -5,4 +6,6 @@ namespace YourBrand.Meetings;
 public interface IElectionsHubClient
 {
     Task OnElectionStatusChanged(ElectionState state);
+
+    Task OnElectionResultsPresented(string agendaItemId, ElectionResultsPresentationOptions options);
 }

--- a/src/Executive/Meetings/Meetings.Shared/IVotingHub.cs
+++ b/src/Executive/Meetings/Meetings.Shared/IVotingHub.cs
@@ -1,6 +1,8 @@
+using System.Threading.Tasks;
+
 namespace YourBrand.Meetings;
 
 public interface IVotingHub
 {
-
+    Task PresentVotingResults(VotingResultsPresentationOptions options);
 }

--- a/src/Executive/Meetings/Meetings.Shared/IVotingHubClient.cs
+++ b/src/Executive/Meetings/Meetings.Shared/IVotingHubClient.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using YourBrand.Meetings.Dtos;
 
 namespace YourBrand.Meetings;
@@ -5,4 +6,6 @@ namespace YourBrand.Meetings;
 public interface IVotingHubClient
 {
     Task OnVotingStatusChanged(VotingState state);
+
+    Task OnVotingResultsPresented(string agendaItemId, VotingResultsPresentationOptions options);
 }

--- a/src/Executive/Meetings/Meetings.Shared/OpenAPIs/swagger.yaml
+++ b/src/Executive/Meetings/Meetings.Shared/OpenAPIs/swagger.yaml
@@ -4731,6 +4731,26 @@ components:
           $ref: '#/components/schemas/VotingState'
         hasPassed:
           type: boolean
+        breakdown:
+          nullable: true
+          $ref: '#/components/schemas/VoteBreakdown'
+    VoteBreakdown:
+      type: object
+      additionalProperties: false
+      properties:
+        forVotes:
+          type: integer
+          format: int32
+        againstVotes:
+          type: integer
+          format: int32
+        abstainVotes:
+          type: integer
+          format: int32
+      required:
+      - forVotes
+      - againstVotes
+      - abstainVotes
     VotingState:
       type: integer
       description: ''
@@ -4765,6 +4785,10 @@ components:
         meetingFunction:
           nullable: true
           $ref: '#/components/schemas/MeetingFunction'
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ElectionResult'
     ElectionState:
       type: integer
       description: ''
@@ -4794,6 +4818,21 @@ components:
         statement:
           type: string
           nullable: true
+    ElectionResult:
+      type: object
+      additionalProperties: false
+      properties:
+        candidateId:
+          type: string
+        candidateName:
+          type: string
+        votes:
+          type: integer
+          format: int32
+      required:
+      - candidateId
+      - candidateName
+      - votes
     PagedResultOfMemberRole:
       type: object
       additionalProperties: false

--- a/src/Executive/Meetings/Meetings.Shared/ResultsPresentationOptions.cs
+++ b/src/Executive/Meetings/Meetings.Shared/ResultsPresentationOptions.cs
@@ -1,0 +1,17 @@
+namespace YourBrand.Meetings;
+
+public enum ResultsDisplayMode
+{
+    Diagram,
+    Numbers
+}
+
+public enum ResultsValueMode
+{
+    Votes,
+    Percent
+}
+
+public sealed record VotingResultsPresentationOptions(ResultsDisplayMode DisplayMode, ResultsValueMode ValueMode);
+
+public sealed record ElectionResultsPresentationOptions(ResultsDisplayMode DisplayMode, ResultsValueMode ValueMode);

--- a/src/Executive/Meetings/Meetings.UI/Procedure/AttendeePage.razor
+++ b/src/Executive/Meetings/Meetings.UI/Procedure/AttendeePage.razor
@@ -130,16 +130,59 @@ else
             </MudPaper>
         }
 
-        @if (currentAgendaItem?.Type.Id == (int)AgendaItemTypeEnum.Election 
-        && currentAgendaItem?.State == AgendaItemState.Completed)
+        @if (currentAgendaItem?.Type.Id == (int)AgendaItemTypeEnum.Voting
+            && (currentAgendaItem?.IsVoteCompleted == true || currentAgendaItem?.State == AgendaItemState.Completed))
         {
-            <MudPaper Elevation="25" Class="pa-6 mb-4">
-                
-                <MudText Typo="@Typo.h4" GutterBottom="true">Elected </MudText>
+            var voteResult = voting ?? currentAgendaItem?.Voting;
 
-                @* <CandidatesSelector OrganizationId="@organization?.Id" Meeting="meeting" AgendaItem="currentAgendaItem" /> *@
+            if (voteResult is not null)
+            {
+                <MudPaper Elevation="25" Class="pa-6 mb-4">
+                    <MudText Typo="@Typo.h4" GutterBottom="true">Vote result</MudText>
 
-            </MudPaper>
+                    <MudAlert Severity="@(voteResult.HasPassed ? Severity.Success : Severity.Error)" Variant="Variant.Filled">
+                        @(voteResult.HasPassed ? "The motion passed." : "The motion did not pass.")
+                    </MudAlert>
+                </MudPaper>
+            }
+        }
+
+        @if (currentAgendaItem?.Type.Id == (int)AgendaItemTypeEnum.Election
+            && (currentAgendaItem?.State == AgendaItemState.Completed
+                || currentAgendaItem?.Election?.ElectedCandidate is not null))
+        {
+            var electionResult = election ?? currentAgendaItem?.Election;
+
+            if (electionResult is not null)
+            {
+                <MudPaper Elevation="25" Class="pa-6 mb-4">
+
+                    <MudText Typo="@Typo.h4" GutterBottom="true">Election result</MudText>
+
+                    @if (electionResult.MeetingFunction?.Name is { } functionName)
+                    {
+                        <MudText Typo="@Typo.subtitle1" Class="mb-2">Position: @functionName</MudText>
+                    }
+
+                    @if (electionResult.ElectedCandidate is { } electedCandidate)
+                    {
+                        <MudAlert Severity="Severity.Success" Variant="Variant.Filled" Class="mb-2">
+                            <MudText Typo="@Typo.h6" Class="mb-0">@electedCandidate.Name</MudText>
+                        </MudAlert>
+
+                        @if (!string.IsNullOrWhiteSpace(electedCandidate.Statement))
+                        {
+                            <MudText Typo="@Typo.body1">@electedCandidate.Statement</MudText>
+                        }
+                    }
+                    else
+                    {
+                        <MudAlert Severity="Severity.Warning" Variant="Variant.Filled">
+                            No candidate was elected.
+                        </MudAlert>
+                    }
+                </MudPaper>
+            }
         }
 
         </MudItem>

--- a/src/Executive/Meetings/Meetings.UI/Procedure/AttendeePage.razor
+++ b/src/Executive/Meetings/Meetings.UI/Procedure/AttendeePage.razor
@@ -1,9 +1,12 @@
 @page "/meetings/{MeetingId:int}/attendee"
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.SignalR.Client
+@using System.Collections.Generic
+@using System.Linq
 @using YourBrand.Meetings.Procedure.Elections
 @using YourBrand.Portal.Services
 @using YourBrand.Meetings
+@using YourBrand.Meetings.Procedure
 @attribute [Authorize]
 @inject IStringLocalizer<DisplayPage> T
 @inject IMeetingsClient MeetingsClient
@@ -138,11 +141,58 @@ else
             if (voteResult is not null)
             {
                 <MudPaper Elevation="25" Class="pa-6 mb-4">
-                    <MudText Typo="@Typo.h4" GutterBottom="true">Vote result</MudText>
+                    <MudStack Spacing="2">
+                        <MudText Typo="@Typo.h4" GutterBottom="true">Vote result</MudText>
 
-                    <MudAlert Severity="@(voteResult.HasPassed ? Severity.Success : Severity.Error)" Variant="Variant.Filled">
-                        @(voteResult.HasPassed ? "The motion passed." : "The motion did not pass.")
-                    </MudAlert>
+                        <MudAlert Severity="@(voteResult.HasPassed ? Severity.Success : Severity.Error)" Variant="Variant.Filled">
+                            @(voteResult.HasPassed ? "The motion passed." : "The motion did not pass.")
+                        </MudAlert>
+
+                          @if (voteResult.Breakdown is not null && votingPresentation is not null)
+                          {
+                              var valueLabel = ResultsPresentationHelper.ValueLabel(votingPresentation.ValueMode);
+                              var voteChartSeries = ResultsPresentationHelper.BuildVoteSeries(voteResult.Breakdown, votingPresentation.ValueMode);
+
+                              if (votingPresentation.DisplayMode == ResultsDisplayMode.Diagram)
+                              {
+                                  <MudChart ChartType="ChartType.Pie"
+                                            Class="mt-4"
+                                            ChartSeries="@voteChartSeries"
+                                            XAxisLabels="@VoteLabels" />
+                              }
+                              else
+                              {
+                                  <MudSimpleTable Dense="true" Class="mt-4">
+                                      <thead>
+                                          <tr>
+                                              <th>Option</th>
+                                              <th class="text-end">@valueLabel</th>
+                                          </tr>
+                                      </thead>
+                                      <tbody>
+                                          <tr>
+                                              <td>For</td>
+                                              <td class="text-end">@ResultsPresentationHelper.FormatVoteValue(voteResult.Breakdown.ForVotes, voteResult.Breakdown, votingPresentation.ValueMode)</td>
+                                          </tr>
+                                          <tr>
+                                              <td>Against</td>
+                                              <td class="text-end">@ResultsPresentationHelper.FormatVoteValue(voteResult.Breakdown.AgainstVotes, voteResult.Breakdown, votingPresentation.ValueMode)</td>
+                                          </tr>
+                                          <tr>
+                                              <td>Abstain</td>
+                                              <td class="text-end">@ResultsPresentationHelper.FormatVoteValue(voteResult.Breakdown.AbstainVotes, voteResult.Breakdown, votingPresentation.ValueMode)</td>
+                                          </tr>
+                                      </tbody>
+                                  </MudSimpleTable>
+                              }
+                          }
+                        else
+                        {
+                            <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Class="mt-4">
+                                Waiting for the chairperson to present the detailed results.
+                            </MudAlert>
+                        }
+                    </MudStack>
                 </MudPaper>
             }
         }
@@ -179,6 +229,50 @@ else
                     {
                         <MudAlert Severity="Severity.Warning" Variant="Variant.Filled">
                             No candidate was elected.
+                        </MudAlert>
+                    }
+
+                    @{ var electionResults = electionResult.Results?.ToList() ?? new List<ElectionResult>(); }
+
+                    @if (electionResults.Count > 0 && electionPresentation is not null)
+                    {
+                        var totalVotes = electionResults.Sum(r => r.Votes);
+                        var labels = electionResults.Select(r => r.CandidateName).ToArray();
+                        var electionChartSeries = ResultsPresentationHelper.BuildElectionSeries(electionResults, electionPresentation.ValueMode);
+                        var valueLabel = ResultsPresentationHelper.ValueLabel(electionPresentation.ValueMode);
+
+                        if (electionPresentation.DisplayMode == ResultsDisplayMode.Diagram)
+                        {
+                            <MudChart ChartType="ChartType.Pie"
+                                      Class="mt-4"
+                                      ChartSeries="@electionChartSeries"
+                                      XAxisLabels="@labels" />
+                        }
+                        else
+                        {
+                            <MudSimpleTable Dense="true" Class="mt-4">
+                                <thead>
+                                    <tr>
+                                        <th>Candidate</th>
+                                        <th class="text-end">@valueLabel</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach (var candidateResult in electionResults)
+                                    {
+                                        <tr>
+                                            <td>@candidateResult.CandidateName</td>
+                                            <td class="text-end">@ResultsPresentationHelper.FormatElectionValue(candidateResult.Votes, totalVotes, electionPresentation.ValueMode)</td>
+                                        </tr>
+                                    }
+                                </tbody>
+                            </MudSimpleTable>
+                        }
+                    }
+                    else
+                    {
+                        <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Class="mt-4">
+                            Waiting for the chairperson to present the detailed results.
                         </MudAlert>
                     }
                 </MudPaper>

--- a/src/Executive/Meetings/Meetings.UI/Procedure/AttendeePage.razor.cs
+++ b/src/Executive/Meetings/Meetings.UI/Procedure/AttendeePage.razor.cs
@@ -24,6 +24,11 @@ public partial class AttendeePage : IMeetingsProcedureHubClient
     private Voting? voting;
     private Election? election;
 
+    private VotingResultsPresentationOptions? votingPresentation;
+    private ElectionResultsPresentationOptions? electionPresentation;
+
+    private static readonly string[] VoteLabels = new[] { "For", "Against", "Abstain" };
+
     HubConnection procedureHub = null!;
     IDiscussionsHub hubProxy = default!;
 
@@ -140,6 +145,8 @@ public partial class AttendeePage : IMeetingsProcedureHubClient
         currentMotion = null;
         voting = null;
         election = null;
+        votingPresentation = null;
+        electionPresentation = null;
 
         if (currentAgendaItem is null)
         {
@@ -182,6 +189,28 @@ public partial class AttendeePage : IMeetingsProcedureHubClient
                 election = currentAgendaItem.Election ?? await ElectionsClient.GetElectionAsync(organization.Id, MeetingId);
             }
         }
+    }
+
+    public Task OnVotingResultsPresented(string agendaItemId, VotingResultsPresentationOptions options)
+    {
+        if (currentAgendaItem?.Id == agendaItemId)
+        {
+            votingPresentation = options;
+            InvokeAsync(StateHasChanged);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnElectionResultsPresented(string agendaItemId, ElectionResultsPresentationOptions options)
+    {
+        if (currentAgendaItem?.Id == agendaItemId)
+        {
+            electionPresentation = options;
+            InvokeAsync(StateHasChanged);
+        }
+
+        return Task.CompletedTask;
     }
 
     private async Task PromptToJoinIfNeeded()

--- a/src/Executive/Meetings/Meetings.UI/Procedure/ControlPage.razor
+++ b/src/Executive/Meetings/Meetings.UI/Procedure/ControlPage.razor
@@ -1,8 +1,10 @@
 @page "/meetings/{MeetingId:int}/control"
+@using Microsoft.AspNetCore.SignalR
 @using Microsoft.AspNetCore.SignalR.Client
 @using System
 @using System.Linq
 @using YourBrand.Portal.Services
+@using YourBrand.Meetings.Procedure
 @inject IStringLocalizer<DisplayPage> T
 @inject IMeetingsClient MeetingsClient
 @inject IChairmanClient ChairmanClient
@@ -141,11 +143,80 @@ else
 
                                 if (voteResult is not null)
                                 {
-                                    <MudAlert Severity="@(voteResult.HasPassed ? Severity.Success : Severity.Error)" Variant="Variant.Filled" Class="mt-4">
-                                        <MudText Typo="Typo.subtitle1" Class="mb-0">
-                                            @(voteResult.HasPassed ? "The motion passed." : "The motion did not pass.")
-                                        </MudText>
-                                    </MudAlert>
+                                    var canPresentVote = voteResult.Breakdown is not null;
+
+                                    <MudPaper Class="pa-4 mt-4" Elevation="1">
+                                        <MudStack Spacing="2">
+                                            <MudText Typo="Typo.subtitle1" Class="mb-0">Vote result</MudText>
+
+                                            <MudAlert Severity="@(voteResult.HasPassed ? Severity.Success : Severity.Error)" Variant="Variant.Filled">
+                                                <MudText Typo="Typo.subtitle1" Class="mb-0">
+                                                    @(voteResult.HasPassed ? "The motion passed." : "The motion did not pass.")
+                                                </MudText>
+                                            </MudAlert>
+
+                                            <MudStack Direction="Row" Spacing="1" AlignItems="AlignItems.Center">
+                                                <MudRadioGroup T="ResultsDisplayMode" Orientation="Orientation.Horizontal" @bind-SelectedOption="votingDisplayMode">
+                                                    <MudRadio T="ResultsDisplayMode" Option="ResultsDisplayMode.Diagram">Diagram</MudRadio>
+                                                    <MudRadio T="ResultsDisplayMode" Option="ResultsDisplayMode.Numbers">Numbers</MudRadio>
+                                                </MudRadioGroup>
+
+                                                <MudRadioGroup T="ResultsValueMode" Orientation="Orientation.Horizontal" @bind-SelectedOption="votingValueMode">
+                                                    <MudRadio T="ResultsValueMode" Option="ResultsValueMode.Votes">Votes</MudRadio>
+                                                    <MudRadio T="ResultsValueMode" Option="ResultsValueMode.Percent">Percent</MudRadio>
+                                                </MudRadioGroup>
+                                            </MudStack>
+
+                                            @if (canPresentVote)
+                                            {
+                                                var valueLabel = ResultsPresentationHelper.ValueLabel(votingValueMode);
+                                                var voteChartSeries = ResultsPresentationHelper.BuildVoteSeries(voteResult.Breakdown, votingValueMode);
+
+                                                @if (votingDisplayMode == ResultsDisplayMode.Diagram)
+                                                {
+                                                    <MudChart ChartType="ChartType.Pie"
+                                                              Class="mt-2"
+                                                              ChartSeries="@voteChartSeries"
+                                                              XAxisLabels="@VoteLabels" />
+                                                }
+                                                else
+                                                {
+                                                    <MudSimpleTable Dense="true" Class="mt-2">
+                                                        <thead>
+                                                            <tr>
+                                                                <th>Option</th>
+                                                                <th class="text-end">@valueLabel</th>
+                                                            </tr>
+                                                        </thead>
+                                                        <tbody>
+                                                            <tr>
+                                                                <td>For</td>
+                                                                <td class="text-end">@ResultsPresentationHelper.FormatVoteValue(voteResult.Breakdown.ForVotes, voteResult.Breakdown, votingValueMode)</td>
+                                                            </tr>
+                                                            <tr>
+                                                                <td>Against</td>
+                                                                <td class="text-end">@ResultsPresentationHelper.FormatVoteValue(voteResult.Breakdown.AgainstVotes, voteResult.Breakdown, votingValueMode)</td>
+                                                            </tr>
+                                                            <tr>
+                                                                <td>Abstain</td>
+                                                                <td class="text-end">@ResultsPresentationHelper.FormatVoteValue(voteResult.Breakdown.AbstainVotes, voteResult.Breakdown, votingValueMode)</td>
+                                                            </tr>
+                                                        </tbody>
+                                                    </MudSimpleTable>
+                                                }
+                                            }
+                                            else
+                                            {
+                                                <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">
+                                                    Results are not yet tallied.
+                                                </MudAlert>
+                                            }
+
+                                            <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!canPresentVote)" OnClick="PresentVotingResultsAsync">
+                                                Present results
+                                            </MudButton>
+                                        </MudStack>
+                                    </MudPaper>
                                 }
                             }
 
@@ -157,31 +228,95 @@ else
                                 if (electionResult is not null)
                                 {
                                     var hasWinner = electionResult.ElectedCandidate is not null;
+                                    var electionResults = electionResult.Results?.ToList() ?? new List<ElectionResult>();
+                                    var canPresentElection = electionResults.Count > 0;
 
-                                    <MudAlert Severity="@(hasWinner ? Severity.Success : Severity.Warning)" Variant="Variant.Filled" Class="mt-4">
-                                        <MudStack Spacing="1">
+                                    <MudPaper Class="pa-4 mt-4" Elevation="1">
+                                        <MudStack Spacing="2">
                                             <MudText Typo="Typo.subtitle1" Class="mb-0">Election result</MudText>
 
-                                            @if (electionResult.MeetingFunction?.Name is { } functionName)
-                                            {
-                                                <MudText Typo="Typo.body2" Class="mb-0">Position: @functionName</MudText>
-                                            }
+                                            <MudAlert Severity="@(hasWinner ? Severity.Success : Severity.Warning)" Variant="Variant.Filled">
+                                                <MudStack Spacing="1">
+                                                    @if (electionResult.MeetingFunction?.Name is { } functionName)
+                                                    {
+                                                        <MudText Typo="Typo.body2" Class="mb-0">Position: @functionName</MudText>
+                                                    }
 
-                                            @if (hasWinner)
-                                            {
-                                                <MudText Typo="Typo.h6" Class="mb-0">@electionResult.ElectedCandidate!.Name</MudText>
+                                                    @if (hasWinner)
+                                                    {
+                                                        <MudText Typo="Typo.h6" Class="mb-0">@electionResult.ElectedCandidate!.Name</MudText>
 
-                                                @if (!string.IsNullOrWhiteSpace(electionResult.ElectedCandidate!.Statement))
+                                                        @if (!string.IsNullOrWhiteSpace(electionResult.ElectedCandidate!.Statement))
+                                                        {
+                                                            <MudText Typo="Typo.body2">@electionResult.ElectedCandidate!.Statement</MudText>
+                                                        }
+                                                    }
+                                                    else
+                                                    {
+                                                        <MudText Typo="Typo.body2" Class="mb-0">No candidate was elected.</MudText>
+                                                    }
+                                                </MudStack>
+                                            </MudAlert>
+
+                                            <MudStack Direction="Row" Spacing="1" AlignItems="AlignItems.Center">
+                                                <MudRadioGroup T="ResultsDisplayMode" Orientation="Orientation.Horizontal" @bind-SelectedOption="electionDisplayMode">
+                                                    <MudRadio T="ResultsDisplayMode" Option="ResultsDisplayMode.Diagram">Diagram</MudRadio>
+                                                    <MudRadio T="ResultsDisplayMode" Option="ResultsDisplayMode.Numbers">Numbers</MudRadio>
+                                                </MudRadioGroup>
+
+                                                <MudRadioGroup T="ResultsValueMode" Orientation="Orientation.Horizontal" @bind-SelectedOption="electionValueMode">
+                                                    <MudRadio T="ResultsValueMode" Option="ResultsValueMode.Votes">Votes</MudRadio>
+                                                    <MudRadio T="ResultsValueMode" Option="ResultsValueMode.Percent">Percent</MudRadio>
+                                                </MudRadioGroup>
+                                            </MudStack>
+
+                                            @if (canPresentElection)
+                                            {
+                                                var totalVotes = electionResults.Sum(r => r.Votes);
+                                                var labels = electionResults.Select(r => r.CandidateName).ToArray();
+                                                var electionChartSeries = ResultsPresentationHelper.BuildElectionSeries(electionResults, electionValueMode);
+                                                var valueLabel = ResultsPresentationHelper.ValueLabel(electionValueMode);
+
+                                                @if (electionDisplayMode == ResultsDisplayMode.Diagram)
                                                 {
-                                                    <MudText Typo="Typo.body2">@electionResult.ElectedCandidate!.Statement</MudText>
+                                                    <MudChart ChartType="ChartType.Pie"
+                                                              Class="mt-2"
+                                                              ChartSeries="@electionChartSeries"
+                                                              XAxisLabels="@labels" />
+                                                }
+                                                else
+                                                {
+                                                    <MudSimpleTable Dense="true" Class="mt-2">
+                                                        <thead>
+                                                            <tr>
+                                                                <th>Candidate</th>
+                                                                <th class="text-end">@valueLabel</th>
+                                                            </tr>
+                                                        </thead>
+                                                        <tbody>
+                                                            @foreach (var candidateResult in electionResults)
+                                                            {
+                                                                <tr>
+                                                                    <td>@candidateResult.CandidateName</td>
+                                                                    <td class="text-end">@ResultsPresentationHelper.FormatElectionValue(candidateResult.Votes, totalVotes, electionValueMode)</td>
+                                                                </tr>
+                                                            }
+                                                        </tbody>
+                                                    </MudSimpleTable>
                                                 }
                                             }
                                             else
                                             {
-                                                <MudText Typo="Typo.body2" Class="mb-0">No candidate was elected.</MudText>
+                                                <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">
+                                                    Results are not yet tallied.
+                                                </MudAlert>
                                             }
+
+                                            <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!canPresentElection)" OnClick="PresentElectionResultsAsync">
+                                                Present results
+                                            </MudButton>
                                         </MudStack>
-                                    </MudAlert>
+                                    </MudPaper>
                                 }
                             }
                         }
@@ -400,6 +535,13 @@ else
 
     HubConnection procedureHub = null!;
     IDiscussionsHub hubProxy = default!;
+    IMeetingsProcedureHub meetingsHubProxy = default!;
+
+    private ResultsDisplayMode votingDisplayMode = ResultsDisplayMode.Diagram;
+    private ResultsValueMode votingValueMode = ResultsValueMode.Votes;
+    private ResultsDisplayMode electionDisplayMode = ResultsDisplayMode.Diagram;
+    private ResultsValueMode electionValueMode = ResultsValueMode.Votes;
+    private static readonly string[] VoteLabels = new[] { "For", "Against", "Abstain" };
 
 
     protected override async Task OnInitializedAsync()
@@ -424,6 +566,7 @@ else
         }).WithAutomaticReconnect().Build();
 
         hubProxy = procedureHub.ServerProxy<IDiscussionsHub>();
+        meetingsHubProxy = procedureHub.ServerProxy<IMeetingsProcedureHub>();
         _ = procedureHub.ClientRegistration<IDiscussionsHubClient>(this);
 
         procedureHub.Closed += (error) =>
@@ -465,6 +608,46 @@ else
         };
 
         await procedureHub.StartAsync();
+    }
+
+    private async Task PresentVotingResultsAsync()
+    {
+        if (meetingsHubProxy is null)
+        {
+            return;
+        }
+
+        var options = new VotingResultsPresentationOptions(votingDisplayMode, votingValueMode);
+
+        try
+        {
+            await meetingsHubProxy.PresentVotingResults(options);
+            Snackbar.Add("Vote results presented.", Severity.Success);
+        }
+        catch (HubException ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+    private async Task PresentElectionResultsAsync()
+    {
+        if (meetingsHubProxy is null)
+        {
+            return;
+        }
+
+        var options = new ElectionResultsPresentationOptions(electionDisplayMode, electionValueMode);
+
+        try
+        {
+            await meetingsHubProxy.PresentElectionResults(options);
+            Snackbar.Add("Election results presented.", Severity.Success);
+        }
+        catch (HubException ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
     }
 
     private async Task RefreshDiscussionAsync()

--- a/src/Executive/Meetings/Meetings.UI/Procedure/ControlPage.razor
+++ b/src/Executive/Meetings/Meetings.UI/Procedure/ControlPage.razor
@@ -133,6 +133,57 @@ else
                             </MudGrid>
 
                             <MudDivider Class="mt-4" />
+
+                            @if (currentAgendaItem?.Type.Id == (int)AgendaItemTypeEnum.Voting
+                                && (currentAgendaItem?.IsVoteCompleted == true || currentAgendaItem?.State == AgendaItemState.Completed))
+                            {
+                                var voteResult = voting ?? currentAgendaItem?.Voting;
+
+                                if (voteResult is not null)
+                                {
+                                    <MudAlert Severity="@(voteResult.HasPassed ? Severity.Success : Severity.Error)" Variant="Variant.Filled" Class="mt-4">
+                                        <MudText Typo="Typo.subtitle1" Class="mb-0">
+                                            @(voteResult.HasPassed ? "The motion passed." : "The motion did not pass.")
+                                        </MudText>
+                                    </MudAlert>
+                                }
+                            }
+
+                            @if (currentAgendaItem?.Type.Id == (int)AgendaItemTypeEnum.Election
+                                && (currentAgendaItem?.State == AgendaItemState.Completed || currentAgendaItem?.Election?.ElectedCandidate is not null))
+                            {
+                                var electionResult = election ?? currentAgendaItem?.Election;
+
+                                if (electionResult is not null)
+                                {
+                                    var hasWinner = electionResult.ElectedCandidate is not null;
+
+                                    <MudAlert Severity="@(hasWinner ? Severity.Success : Severity.Warning)" Variant="Variant.Filled" Class="mt-4">
+                                        <MudStack Spacing="1">
+                                            <MudText Typo="Typo.subtitle1" Class="mb-0">Election result</MudText>
+
+                                            @if (electionResult.MeetingFunction?.Name is { } functionName)
+                                            {
+                                                <MudText Typo="Typo.body2" Class="mb-0">Position: @functionName</MudText>
+                                            }
+
+                                            @if (hasWinner)
+                                            {
+                                                <MudText Typo="Typo.h6" Class="mb-0">@electionResult.ElectedCandidate!.Name</MudText>
+
+                                                @if (!string.IsNullOrWhiteSpace(electionResult.ElectedCandidate!.Statement))
+                                                {
+                                                    <MudText Typo="Typo.body2">@electionResult.ElectedCandidate!.Statement</MudText>
+                                                }
+                                            }
+                                            else
+                                            {
+                                                <MudText Typo="Typo.body2" Class="mb-0">No candidate was elected.</MudText>
+                                            }
+                                        </MudStack>
+                                    </MudAlert>
+                                }
+                            }
                         }
                         else
                         {
@@ -567,6 +618,8 @@ else
         lastItem = agenda.Items.OrderBy(ai => ai.Order).LastOrDefault()?.Id == currentAgendaItem?.Id;
 
         currentMotion = null;
+        voting = null;
+        election = null;
 
         if (currentAgendaItem is not null)
         {
@@ -584,15 +637,30 @@ else
             {
                 await RefreshDiscussionAsync();
             }
-            else if(currentAgendaItem.State == AgendaItemState.Active && currentAgendaItem.Phase == AgendaItemPhase.Voting)
+            
+            var isVotingItem = currentAgendaItem.Type.Id == (int)AgendaItemTypeEnum.Voting;
+            var isElectionItem = currentAgendaItem.Type.Id == (int)AgendaItemTypeEnum.Election;
+
+            if(currentAgendaItem.State == AgendaItemState.Active && currentAgendaItem.Phase == AgendaItemPhase.Voting)
             {
-                if(currentAgendaItem.Type.Id == (int)AgendaItemTypeEnum.Voting)
+                if(isVotingItem)
                 {
                     voting = await VotingClient.GetVotingAsync(organization.Id, MeetingId);
                 }
-                else if(currentAgendaItem.Type.Id == (int)AgendaItemTypeEnum.Election) 
+                else if(isElectionItem)
                 {
                     election = await ElectionsClient.GetElectionAsync(organization.Id, MeetingId);
+                }
+            }
+            else
+            {
+                if(isVotingItem && (currentAgendaItem.IsVoteCompleted || currentAgendaItem.State == AgendaItemState.Completed))
+                {
+                    voting = currentAgendaItem.Voting ?? await VotingClient.GetVotingAsync(organization.Id, MeetingId);
+                }
+                else if(isElectionItem && (currentAgendaItem.State == AgendaItemState.Completed || currentAgendaItem.Election?.ElectedCandidate is not null))
+                {
+                    election = currentAgendaItem.Election ?? await ElectionsClient.GetElectionAsync(organization.Id, MeetingId);
                 }
             }
         }

--- a/src/Executive/Meetings/Meetings.UI/Procedure/DisplayPage.razor
+++ b/src/Executive/Meetings/Meetings.UI/Procedure/DisplayPage.razor
@@ -1,8 +1,11 @@
 @page "/meetings/{MeetingId:int}/procedure"
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.SignalR.Client
+@using System.Collections.Generic
+@using System.Linq
 @using YourBrand.Portal.Services
 @using YourBrand.Meetings
+@using YourBrand.Meetings.Procedure
 @attribute [Authorize]
 @inject IStringLocalizer<DisplayPage> T
 @inject IMeetingsClient MeetingsClient
@@ -133,11 +136,58 @@ else
         if (voteResult is not null)
         {
             <MudPaper Class="pa-8 mb-4" Elevation="25">
-                <MudText Typo="@Typo.h4" GutterBottom="true">Vote result</MudText>
+                <MudStack Spacing="2">
+                    <MudText Typo="@Typo.h4" GutterBottom="true">Vote result</MudText>
 
-                <MudAlert Severity="@(voteResult.HasPassed ? Severity.Success : Severity.Error)" Variant="Variant.Filled">
-                    @(voteResult.HasPassed ? "The motion passed." : "The motion did not pass.")
-                </MudAlert>
+                    <MudAlert Severity="@(voteResult.HasPassed ? Severity.Success : Severity.Error)" Variant="Variant.Filled">
+                        @(voteResult.HasPassed ? "The motion passed." : "The motion did not pass.")
+                    </MudAlert>
+
+                @if (voteResult.Breakdown is not null && votingPresentation is not null)
+                {
+                    var valueLabel = ResultsPresentationHelper.ValueLabel(votingPresentation.ValueMode);
+                    var voteChartSeries = ResultsPresentationHelper.BuildVoteSeries(voteResult.Breakdown, votingPresentation.ValueMode);
+
+                    if (votingPresentation.DisplayMode == ResultsDisplayMode.Diagram)
+                    {
+                        <MudChart ChartType="ChartType.Pie"
+                                  Class="mt-4"
+                                  ChartSeries="@voteChartSeries"
+                                  XAxisLabels="@VoteLabels" />
+                    }
+                    else
+                    {
+                        <MudSimpleTable Dense="true" Class="mt-4">
+                            <thead>
+                                <tr>
+                                    <th>Option</th>
+                                    <th class="text-end">@valueLabel</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>For</td>
+                                    <td class="text-end">@ResultsPresentationHelper.FormatVoteValue(voteResult.Breakdown.ForVotes, voteResult.Breakdown, votingPresentation.ValueMode)</td>
+                                </tr>
+                                <tr>
+                                    <td>Against</td>
+                                    <td class="text-end">@ResultsPresentationHelper.FormatVoteValue(voteResult.Breakdown.AgainstVotes, voteResult.Breakdown, votingPresentation.ValueMode)</td>
+                                </tr>
+                                <tr>
+                                    <td>Abstain</td>
+                                    <td class="text-end">@ResultsPresentationHelper.FormatVoteValue(voteResult.Breakdown.AbstainVotes, voteResult.Breakdown, votingPresentation.ValueMode)</td>
+                                </tr>
+                            </tbody>
+                        </MudSimpleTable>
+                    }
+                }
+                    else
+                    {
+                        <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Class="mt-4">
+                            Waiting for the chairperson to present the detailed results.
+                        </MudAlert>
+                    }
+                </MudStack>
             </MudPaper>
         }
     }
@@ -172,6 +222,50 @@ else
                 {
                     <MudAlert Severity="Severity.Warning" Variant="Variant.Filled">
                         No candidate was elected.
+                    </MudAlert>
+                }
+
+                @{ var electionResults = electionResult.Results?.ToList() ?? new List<ElectionResult>(); }
+
+                @if (electionResults.Count > 0 && electionPresentation is not null)
+                {
+                    var totalVotes = electionResults.Sum(r => r.Votes);
+                    var labels = electionResults.Select(r => r.CandidateName).ToArray();
+                    var electionChartSeries = ResultsPresentationHelper.BuildElectionSeries(electionResults, electionPresentation.ValueMode);
+                    var valueLabel = ResultsPresentationHelper.ValueLabel(electionPresentation.ValueMode);
+
+                    if (electionPresentation.DisplayMode == ResultsDisplayMode.Diagram)
+                    {
+                        <MudChart ChartType="ChartType.Pie"
+                                  Class="mt-4"
+                                  ChartSeries="@electionChartSeries"
+                                  XAxisLabels="@labels" />
+                    }
+                    else
+                    {
+                        <MudSimpleTable Dense="true" Class="mt-4">
+                            <thead>
+                                <tr>
+                                    <th>Candidate</th>
+                                    <th class="text-end">@valueLabel</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var candidateResult in electionResults)
+                                {
+                                    <tr>
+                                        <td>@candidateResult.CandidateName</td>
+                                        <td class="text-end">@ResultsPresentationHelper.FormatElectionValue(candidateResult.Votes, totalVotes, electionPresentation.ValueMode)</td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </MudSimpleTable>
+                    }
+                }
+                else
+                {
+                    <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Class="mt-4">
+                        Waiting for the chairperson to present the detailed results.
                     </MudAlert>
                 }
             </MudPaper>

--- a/src/Executive/Meetings/Meetings.UI/Procedure/DisplayPage.razor
+++ b/src/Executive/Meetings/Meetings.UI/Procedure/DisplayPage.razor
@@ -8,6 +8,8 @@
 @inject IMeetingsClient MeetingsClient
 @inject IAgendasClient AgendasClient
 @inject IMotionsClient MotionsClient
+@inject IVotingClient VotingClient
+@inject IElectionsClient ElectionsClient
 @inject NavigationManager NavigationManager
 @inject IOrganizationProvider OrganizationProvider
 @inject YourBrand.Portal.Services.IAccessTokenProvider AccessTokenProvider
@@ -121,6 +123,59 @@ else
 
 
         </MudPaper>
+    }
+
+    @if (agendaItem?.Type.Id == (int)AgendaItemTypeEnum.Voting
+        && (agendaItem?.IsVoteCompleted == true || agendaItem?.State == AgendaItemState.Completed))
+    {
+        var voteResult = voting ?? agendaItem?.Voting;
+
+        if (voteResult is not null)
+        {
+            <MudPaper Class="pa-8 mb-4" Elevation="25">
+                <MudText Typo="@Typo.h4" GutterBottom="true">Vote result</MudText>
+
+                <MudAlert Severity="@(voteResult.HasPassed ? Severity.Success : Severity.Error)" Variant="Variant.Filled">
+                    @(voteResult.HasPassed ? "The motion passed." : "The motion did not pass.")
+                </MudAlert>
+            </MudPaper>
+        }
+    }
+
+    @if (agendaItem?.Type.Id == (int)AgendaItemTypeEnum.Election
+        && (agendaItem?.State == AgendaItemState.Completed || agendaItem?.Election?.ElectedCandidate is not null))
+    {
+        var electionResult = election ?? agendaItem?.Election;
+
+        if (electionResult is not null)
+        {
+            <MudPaper Class="pa-8 mb-4" Elevation="25">
+                <MudText Typo="@Typo.h4" GutterBottom="true">Election result</MudText>
+
+                @if (electionResult.MeetingFunction?.Name is { } functionName)
+                {
+                    <MudText Typo="@Typo.subtitle1" Class="mb-2">Position: @functionName</MudText>
+                }
+
+                @if (electionResult.ElectedCandidate is { } electedCandidate)
+                {
+                    <MudAlert Severity="Severity.Success" Variant="Variant.Filled" Class="mb-2">
+                        <MudText Typo="@Typo.h6" Class="mb-0">@electedCandidate.Name</MudText>
+                    </MudAlert>
+
+                    @if (!string.IsNullOrWhiteSpace(electedCandidate.Statement))
+                    {
+                        <MudText Typo="@Typo.body1">@electedCandidate.Statement</MudText>
+                    }
+                }
+                else
+                {
+                    <MudAlert Severity="Severity.Warning" Variant="Variant.Filled">
+                        No candidate was elected.
+                    </MudAlert>
+                }
+            </MudPaper>
+        }
     }
 
 }

--- a/src/Executive/Meetings/Meetings.UI/Procedure/DisplayPage.razor.cs
+++ b/src/Executive/Meetings/Meetings.UI/Procedure/DisplayPage.razor.cs
@@ -16,6 +16,8 @@ public partial class DisplayPage : IMeetingsProcedureHubClient
     Agenda? agenda;
     AgendaItem? agendaItem;
     Motion? currentMotion;
+    Voting? voting;
+    Election? election;
 
     HubConnection hubConnection = null!;
     IMeetingsProcedureHub hubProxy = default!;
@@ -146,10 +148,43 @@ public partial class DisplayPage : IMeetingsProcedureHubClient
         agendaItem = await MeetingsClient.GetCurrentAgendaItemAsync(organization.Id, MeetingId);
 
         currentMotion = null;
+        voting = null;
+        election = null;
+
+        if (agendaItem is null)
+        {
+            return;
+        }
 
         if (agendaItem.MotionId is not null)
         {
             currentMotion = await MotionsClient.GetMotionByIdAsync(organization.Id, agendaItem.MotionId.GetValueOrDefault());
+        }
+
+        var isVotingItem = agendaItem.Type.Id == (int)AgendaItemTypeEnum.Voting;
+        var isElectionItem = agendaItem.Type.Id == (int)AgendaItemTypeEnum.Election;
+
+        if (agendaItem.State == AgendaItemState.Active && agendaItem.Phase == AgendaItemPhase.Voting)
+        {
+            if (isVotingItem)
+            {
+                voting = await VotingClient.GetVotingAsync(organization.Id, MeetingId);
+            }
+            else if (isElectionItem)
+            {
+                election = await ElectionsClient.GetElectionAsync(organization.Id, MeetingId);
+            }
+        }
+        else
+        {
+            if (isVotingItem && (agendaItem.IsVoteCompleted || agendaItem.State == AgendaItemState.Completed))
+            {
+                voting = agendaItem.Voting ?? await VotingClient.GetVotingAsync(organization.Id, MeetingId);
+            }
+            else if (isElectionItem && (agendaItem.State == AgendaItemState.Completed || agendaItem.Election?.ElectedCandidate is not null))
+            {
+                election = agendaItem.Election ?? await ElectionsClient.GetElectionAsync(organization.Id, MeetingId);
+            }
         }
     }
 
@@ -165,6 +200,8 @@ public partial class DisplayPage : IMeetingsProcedureHubClient
         if (state == MeetingState.Scheduled || state == MeetingState.Canceled || state == MeetingState.Completed)
         {
             agendaItem = null;
+            voting = null;
+            election = null;
         }
         else if (meeting?.CurrentAgendaItemIndex is not null)
         {
@@ -206,48 +243,18 @@ public partial class DisplayPage : IMeetingsProcedureHubClient
         StateHasChanged();
     }
 
-    public Task OnVotingStatusChanged(VotingState state)
+    public async Task OnVotingStatusChanged(VotingState state)
     {
-        if (state == VotingState.Voting)
-        {
-            Console.WriteLine("Voting");
-        }
-        else if (state == VotingState.RedoRequired)
-        {
-            Console.WriteLine("Voting redo required");
-        }
-        else if (state == VotingState.ResultReady)
-        {
-            Console.WriteLine("Voting result ready");
-        }
-        else if (state == VotingState.Completed)
-        {
-            Console.WriteLine("Voting completed");
-        }
+        await LoadAgendaItem();
 
-        return Task.CompletedTask;
+        await InvokeAsync(StateHasChanged);
     }
 
-    public Task OnElectionStatusChanged(ElectionState state)
+    public async Task OnElectionStatusChanged(ElectionState state)
     {
-        if (state == ElectionState.Voting)
-        {
-            Console.WriteLine("Election");
-        }
-        else if (state == ElectionState.RedoRequired)
-        {
-            Console.WriteLine("Election redo required");
-        }
-        else if (state == ElectionState.ResultReady)
-        {
-            Console.WriteLine("Election result ready");
-        }
-        else if (state == ElectionState.Completed)
-        {
-            Console.WriteLine("Election completed");
-        }
+        await LoadAgendaItem();
 
-        return Task.CompletedTask;
+        await InvokeAsync(StateHasChanged);
     }
 
     public Task OnDiscussionStatusChanged(int status)

--- a/src/Executive/Meetings/Meetings.UI/Procedure/DisplayPage.razor.cs
+++ b/src/Executive/Meetings/Meetings.UI/Procedure/DisplayPage.razor.cs
@@ -19,6 +19,11 @@ public partial class DisplayPage : IMeetingsProcedureHubClient
     Voting? voting;
     Election? election;
 
+    private VotingResultsPresentationOptions? votingPresentation;
+    private ElectionResultsPresentationOptions? electionPresentation;
+
+    private static readonly string[] VoteLabels = new[] { "For", "Against", "Abstain" };
+
     HubConnection hubConnection = null!;
     IMeetingsProcedureHub hubProxy = default!;
 
@@ -150,6 +155,8 @@ public partial class DisplayPage : IMeetingsProcedureHubClient
         currentMotion = null;
         voting = null;
         election = null;
+        votingPresentation = null;
+        electionPresentation = null;
 
         if (agendaItem is null)
         {
@@ -248,6 +255,28 @@ public partial class DisplayPage : IMeetingsProcedureHubClient
         await LoadAgendaItem();
 
         await InvokeAsync(StateHasChanged);
+    }
+
+    public Task OnVotingResultsPresented(string agendaItemId, VotingResultsPresentationOptions options)
+    {
+        if (this.agendaItem?.Id == agendaItemId)
+        {
+            votingPresentation = options;
+            InvokeAsync(StateHasChanged);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task OnElectionResultsPresented(string agendaItemId, ElectionResultsPresentationOptions options)
+    {
+        if (this.agendaItem?.Id == agendaItemId)
+        {
+            electionPresentation = options;
+            InvokeAsync(StateHasChanged);
+        }
+
+        return Task.CompletedTask;
     }
 
     public async Task OnElectionStatusChanged(ElectionState state)

--- a/src/Executive/Meetings/Meetings.UI/Procedure/ResultsPresentationHelper.cs
+++ b/src/Executive/Meetings/Meetings.UI/Procedure/ResultsPresentationHelper.cs
@@ -1,0 +1,117 @@
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using MudBlazor;
+using YourBrand.Meetings;
+
+namespace YourBrand.Meetings.Procedure;
+
+internal static class ResultsPresentationHelper
+{
+    public static List<ChartSeries> BuildVoteSeries(VoteBreakdown? breakdown, ResultsValueMode valueMode)
+    {
+        var data = BuildVoteData(breakdown, valueMode);
+
+        return new List<ChartSeries>
+        {
+            new()
+            {
+                Name = ValueLabel(valueMode),
+                Data = data
+            }
+        };
+    }
+
+    public static string FormatVoteValue(int count, VoteBreakdown? breakdown, ResultsValueMode valueMode)
+    {
+        if (breakdown is null)
+        {
+            return valueMode == ResultsValueMode.Percent ? "0%" : "0";
+        }
+
+        return valueMode == ResultsValueMode.Percent
+            ? FormatPercent(count, TotalVotes(breakdown))
+            : FormatVotes(count);
+    }
+
+    public static List<ChartSeries> BuildElectionSeries(IEnumerable<ElectionResult> results, ResultsValueMode valueMode)
+    {
+        var resultList = results.ToList();
+        var data = BuildElectionData(resultList, valueMode);
+
+        return new List<ChartSeries>
+        {
+            new()
+            {
+                Name = ValueLabel(valueMode),
+                Data = data
+            }
+        };
+    }
+
+    public static string FormatElectionValue(int votes, int totalVotes, ResultsValueMode valueMode)
+        => valueMode == ResultsValueMode.Percent ? FormatPercent(votes, totalVotes) : FormatVotes(votes);
+
+    public static string ValueLabel(ResultsValueMode valueMode) => valueMode == ResultsValueMode.Percent ? "Percent" : "Votes";
+
+    private static double[] BuildVoteData(VoteBreakdown? breakdown, ResultsValueMode valueMode)
+    {
+        if (breakdown is null)
+        {
+            return new double[] { 0d, 0d, 0d };
+        }
+
+        var totals = TotalVotes(breakdown);
+
+        if (totals == 0)
+        {
+            return new double[] { 0d, 0d, 0d };
+        }
+
+        return valueMode == ResultsValueMode.Percent
+            ? new[]
+            {
+                ToPercent(breakdown.ForVotes, totals),
+                ToPercent(breakdown.AgainstVotes, totals),
+                ToPercent(breakdown.AbstainVotes, totals)
+            }
+            : new[]
+            {
+                (double)breakdown.ForVotes,
+                (double)breakdown.AgainstVotes,
+                (double)breakdown.AbstainVotes
+            };
+    }
+
+    private static double[] BuildElectionData(IEnumerable<ElectionResult> results, ResultsValueMode valueMode)
+    {
+        var resultList = results.ToList();
+        var total = resultList.Sum(r => r.Votes);
+
+        if (total == 0)
+        {
+            return resultList.Select(_ => 0d).ToArray();
+        }
+
+        return valueMode == ResultsValueMode.Percent
+            ? resultList.Select(r => ToPercent(r.Votes, total)).ToArray()
+            : resultList.Select(r => (double)r.Votes).ToArray();
+    }
+
+    private static int TotalVotes(VoteBreakdown breakdown) => breakdown.ForVotes + breakdown.AgainstVotes + breakdown.AbstainVotes;
+
+    private static double ToPercent(int value, int total) => total == 0 ? 0d : (double)value / total * 100d;
+
+    private static string FormatPercent(int value, int total)
+    {
+        if (total == 0)
+        {
+            return "0%";
+        }
+
+        var percent = (double)value / total * 100d;
+        return percent.ToString("0.##" , CultureInfo.InvariantCulture) + "%";
+    }
+
+    private static string FormatVotes(int value) => value.ToString(CultureInfo.InvariantCulture);
+}

--- a/src/Executive/Meetings/Meetings/Domain/Errors/Errors.cs
+++ b/src/Executive/Meetings/Meetings/Domain/Errors/Errors.cs
@@ -52,6 +52,12 @@ public static partial class Errors
 
         public static readonly Error OnlyChairpersonCanEndVoting = new Error(nameof(OnlyChairpersonCanEndVoting), "Only the Chairperson can end a voting session.", string.Empty);
 
+        public static readonly Error OnlyChairpersonCanPresentResults = new Error(nameof(OnlyChairpersonCanPresentResults), "Only the chairperson can present results.", string.Empty);
+
+        public static readonly Error VotingResultsNotReady = new Error(nameof(VotingResultsNotReady), "Voting results are not ready to present.", string.Empty);
+
+        public static readonly Error ElectionResultsNotReady = new Error(nameof(ElectionResultsNotReady), "Election results are not ready to present.", string.Empty);
+
         public static readonly Error OnlyChairpersonCanManageSpeakerQueue = new Error(nameof(OnlyChairpersonCanManageSpeakerQueue), "Only the chairperson can manage the speaker queue.", string.Empty);
 
         public static readonly Error SpeakingTimeNotConfigured = new Error(nameof(SpeakingTimeNotConfigured), "Speaking time limit has not been configured for the discussion.", string.Empty);

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/PresentElectionResults.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/PresentElectionResults.cs
@@ -1,0 +1,69 @@
+using MediatR;
+
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Identity;
+using YourBrand.Meetings.Domain.Entities;
+
+namespace YourBrand.Meetings.Features.Procedure.Chairman;
+
+public sealed record PresentElectionResults(string OrganizationId, int Id, ElectionResultsPresentationOptions Options) : IRequest<Result<string>>;
+
+public sealed class PresentElectionResultsHandler(
+    IApplicationDbContext context,
+    IUserContext userContext,
+    IHubContext<MeetingsProcedureHub, IMeetingsProcedureHubClient> hubContext)
+    : IRequestHandler<PresentElectionResults, Result<string>>
+{
+    public async Task<Result<string>> Handle(PresentElectionResults request, CancellationToken cancellationToken)
+    {
+        var meeting = await context.Meetings
+            .InOrganization(request.OrganizationId)
+            .Include(x => x.Agenda)
+            .ThenInclude(x => x.Items.OrderBy(x => x.Order))
+            .FirstOrDefaultAsync(x => x.Id == request.Id, cancellationToken);
+
+        if (meeting is null)
+        {
+            return Errors.Meetings.MeetingNotFound;
+        }
+
+        var attendee = meeting.GetAttendeeByUserId(userContext.UserId);
+
+        if (attendee is null)
+        {
+            return Errors.Meetings.YouAreNotAttendeeOfMeeting;
+        }
+
+        var chairFunction = meeting.GetChairpersonFunction(attendee);
+
+        if (chairFunction is null)
+        {
+            return Errors.Meetings.OnlyChairpersonCanPresentResults;
+        }
+
+        var agendaItem = meeting.GetCurrentAgendaItem();
+
+        if (agendaItem is null)
+        {
+            return Errors.Meetings.NoActiveAgendaItem;
+        }
+
+        if (agendaItem.Type.Id != AgendaItemType.Election.Id)
+        {
+            return Errors.Meetings.NoOngoingElection;
+        }
+
+        if (agendaItem.Election is null || agendaItem.Election.State != ElectionState.ResultReady)
+        {
+            return Errors.Meetings.ElectionResultsNotReady;
+        }
+
+        await hubContext.Clients
+            .Group($"meeting-{meeting.Id}")
+            .OnElectionResultsPresented(agendaItem.Id, request.Options);
+
+        return Result.SuccessWith(agendaItem.Id);
+    }
+}

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/PresentVotingResults.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Chairman/PresentVotingResults.cs
@@ -1,0 +1,69 @@
+using MediatR;
+
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Identity;
+using YourBrand.Meetings.Domain.Entities;
+
+namespace YourBrand.Meetings.Features.Procedure.Chairman;
+
+public sealed record PresentVotingResults(string OrganizationId, int Id, VotingResultsPresentationOptions Options) : IRequest<Result<string>>;
+
+public sealed class PresentVotingResultsHandler(
+    IApplicationDbContext context,
+    IUserContext userContext,
+    IHubContext<MeetingsProcedureHub, IMeetingsProcedureHubClient> hubContext)
+    : IRequestHandler<PresentVotingResults, Result<string>>
+{
+    public async Task<Result<string>> Handle(PresentVotingResults request, CancellationToken cancellationToken)
+    {
+        var meeting = await context.Meetings
+            .InOrganization(request.OrganizationId)
+            .Include(x => x.Agenda)
+            .ThenInclude(x => x.Items.OrderBy(x => x.Order))
+            .FirstOrDefaultAsync(x => x.Id == request.Id, cancellationToken);
+
+        if (meeting is null)
+        {
+            return Errors.Meetings.MeetingNotFound;
+        }
+
+        var attendee = meeting.GetAttendeeByUserId(userContext.UserId);
+
+        if (attendee is null)
+        {
+            return Errors.Meetings.YouAreNotAttendeeOfMeeting;
+        }
+
+        var chairFunction = meeting.GetChairpersonFunction(attendee);
+
+        if (chairFunction is null)
+        {
+            return Errors.Meetings.OnlyChairpersonCanPresentResults;
+        }
+
+        var agendaItem = meeting.GetCurrentAgendaItem();
+
+        if (agendaItem is null)
+        {
+            return Errors.Meetings.NoActiveAgendaItem;
+        }
+
+        if (agendaItem.Type.Id != AgendaItemType.Voting.Id)
+        {
+            return Errors.Meetings.NoOngoingVoting;
+        }
+
+        if (agendaItem.Voting is null || agendaItem.Voting.State != VotingState.ResultReady)
+        {
+            return Errors.Meetings.VotingResultsNotReady;
+        }
+
+        await hubContext.Clients
+            .Group($"meeting-{meeting.Id}")
+            .OnVotingResultsPresented(agendaItem.Id, request.Options);
+
+        return Result.SuccessWith(agendaItem.Id);
+    }
+}

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Elections/ElectionDto.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Elections/ElectionDto.cs
@@ -3,4 +3,12 @@ using YourBrand.Meetings.Features.Agendas;
 
 namespace YourBrand.Meetings.Features.Procedure.Elections;
 
-public sealed record ElectionDto(string Id, ElectionState State, IEnumerable<ElectionCandidateDto> Candidates, ElectionCandidateDto? ElectedCandidate, MeetingFunctionDto? MeetingFunction);
+public sealed record ElectionResultDto(string CandidateId, string CandidateName, int Votes);
+
+public sealed record ElectionDto(
+    string Id,
+    ElectionState State,
+    IEnumerable<ElectionCandidateDto> Candidates,
+    ElectionCandidateDto? ElectedCandidate,
+    MeetingFunctionDto? MeetingFunction,
+    IEnumerable<ElectionResultDto> Results);

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Elections/Mappings.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Elections/Mappings.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using YourBrand.Meetings.Features;
 using YourBrand.Meetings.Features.Agendas;
 
@@ -5,11 +6,27 @@ namespace YourBrand.Meetings.Features.Procedure.Elections;
 
 public static partial class Mappings
 {
-    public static ElectionDto ToDto(this Domain.Entities.Election election) =>
-        new(
+    public static ElectionDto ToDto(this Domain.Entities.Election election)
+    {
+        var results = Enumerable.Empty<ElectionResultDto>();
+
+        if (election.State == Domain.Entities.ElectionState.ResultReady)
+        {
+            var activeCandidates = election.Candidates.Where(c => c.WithdrawnAt is null).ToList();
+            results = activeCandidates
+                .Select(candidate => new ElectionResultDto(
+                    candidate.Id,
+                    candidate.Name,
+                    election.Ballots.Count(b => b.SelectedCandidateId == candidate.Id)))
+                .ToList();
+        }
+
+        return new(
             election.Id,
             election.State,
             election.Candidates.Select(x => x.ToDto()),
             election.ElectedCandidate?.ToDto(),
-            election.MeetingFunction?.ToDto());
+            election.MeetingFunction?.ToDto(),
+            results);
+    }
 }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Voting/Mapper.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Voting/Mapper.cs
@@ -1,9 +1,26 @@
-﻿using YourBrand.Meetings.Features.Organizations;
-using YourBrand.Meetings.Features.Users;
+using System.Linq;
 
 namespace YourBrand.Meetings.Features.Procedure.Voting;
 
-public static partial class Mappings
+public static class Mapper
 {
-    public static VotingDto ToDto(this Domain.Entities.Voting voting) => new(voting.Id, voting.State, voting.HasPassed);
+    public static VotingDto ToDto(this Domain.Entities.Voting voting)
+    {
+        VoteBreakdownDto? breakdown = null;
+
+        if (voting.State == Domain.Entities.VotingState.ResultReady)
+        {
+            var counts = voting.Votes
+                .Where(v => v.Option.HasValue)
+                .GroupBy(v => v.Option!.Value)
+                .ToDictionary(g => g.Key, g => g.Count());
+
+            breakdown = new VoteBreakdownDto(
+                counts.GetValueOrDefault(Domain.Entities.VoteOption.For),
+                counts.GetValueOrDefault(Domain.Entities.VoteOption.Against),
+                counts.GetValueOrDefault(Domain.Entities.VoteOption.Abstain));
+        }
+
+        return new VotingDto(voting.Id, voting.State, voting.HasPassed, breakdown);
+    }
 }

--- a/src/Executive/Meetings/Meetings/Features/Procedure/Voting/VotingDto.cs
+++ b/src/Executive/Meetings/Meetings/Features/Procedure/Voting/VotingDto.cs
@@ -1,3 +1,5 @@
 namespace YourBrand.Meetings.Features.Procedure.Voting;
 
-public sealed record VotingDto(string Id, VotingState State, bool HasPassed);
+public sealed record VoteBreakdownDto(int ForVotes, int AgainstVotes, int AbstainVotes);
+
+public sealed record VotingDto(string Id, VotingState State, bool HasPassed, VoteBreakdownDto? Breakdown);


### PR DESCRIPTION
## Summary
- surface voting outcomes on the attendee, control, and public display procedure pages
- render election winners (or lack thereof) together with the associated meeting function
- reload voting and election data when agenda items complete or hub notifications signal state changes

## Testing
- dotnet build src/Executive/Meetings/Meetings.UI/Meetings.UI.csproj

------
https://chatgpt.com/codex/tasks/task_e_68fca2995110832fa7c854884e051eae