### PR TITLE
Add supplier ordering capabilities to inventory service

### DIFF
--- a/src/Inventory/Inventory/Application/Items/Commands/UpdateItem.cs
+++ b/src/Inventory/Inventory/Application/Items/Commands/UpdateItem.cs
@@ -17,9 +17,9 @@ public record UpdateItem(string Id, string NewId, string Name, string GroupId, s
 
             if (item is null) throw new Exception();
 
-            item.Name = request.Name;
-            item.GroupId = request.GroupId;
-            item.Unit = request.Unit;
+            item.Rename(request.Name);
+            item.ChangeGroup(request.GroupId);
+            item.ChangeUnit(request.Unit);
 
             await context.SaveChangesAsync(cancellationToken);
         }

--- a/src/Inventory/Inventory/Application/Mappings.cs
+++ b/src/Inventory/Inventory/Application/Mappings.cs
@@ -89,6 +89,7 @@ public static class Mappings
             order.OrderNumber,
             order.OrderedAt,
             order.ExpectedDelivery,
+            order.ReceivedAt,
             order.Lines.Select(x => x.ToDto()).ToList(),
             order.TotalQuantityOutstanding);
     }

--- a/src/Inventory/Inventory/Application/Mappings.cs
+++ b/src/Inventory/Inventory/Application/Mappings.cs
@@ -1,8 +1,11 @@
+using System.Linq;
+
 using YourBrand.Inventory.Application.Items;
 using YourBrand.Inventory.Application.Items.Groups;
 using YourBrand.Inventory.Application.Sites;
 using YourBrand.Inventory.Application.Warehouses;
 using YourBrand.Inventory.Application.Warehouses.Items;
+using YourBrand.Inventory.Application.Suppliers;
 using YourBrand.Inventory.Domain.Entities;
 
 namespace YourBrand.Inventory.Application;
@@ -56,5 +59,51 @@ public static class Mappings
         return new SiteDto(
             item.Id,
             item.Name);
+    }
+
+    public static SupplierDto ToDto(this Supplier supplier)
+    {
+        return new SupplierDto(
+            supplier.Id,
+            supplier.Name,
+            supplier.Items.Select(x => x.ToDto()).ToList());
+    }
+
+    public static SupplierItemDto ToDto(this SupplierItem supplierItem)
+    {
+        return new SupplierItemDto(
+            supplierItem.Id,
+            supplierItem.ItemId,
+            supplierItem.Item.Name,
+            supplierItem.SupplierItemId,
+            supplierItem.UnitCost,
+            supplierItem.LeadTimeDays);
+    }
+
+    public static SupplierOrderDto ToDto(this SupplierOrder order)
+    {
+        return new SupplierOrderDto(
+            order.Id,
+            order.SupplierId,
+            order.Supplier.Name,
+            order.OrderNumber,
+            order.OrderedAt,
+            order.ExpectedDelivery,
+            order.Lines.Select(x => x.ToDto()).ToList(),
+            order.TotalQuantityOutstanding);
+    }
+
+    public static SupplierOrderLineDto ToDto(this SupplierOrderLine line)
+    {
+        return new SupplierOrderLineDto(
+            line.Id,
+            line.SupplierItemId,
+            line.SupplierItem.ItemId,
+            line.SupplierItem.Item.Name,
+            line.QuantityOrdered,
+            line.ExpectedQuantity,
+            line.QuantityReceived,
+            line.QuantityOutstanding,
+            line.ExpectedOn);
     }
 }

--- a/src/Inventory/Inventory/Application/Sites/Commands/UpdateSiteCommand.cs
+++ b/src/Inventory/Inventory/Application/Sites/Commands/UpdateSiteCommand.cs
@@ -16,7 +16,7 @@ public record UpdateSiteCommand(string Id, string Name) : IRequest
 
             if (site is null) throw new Exception();
 
-            site.Name = request.Name;
+            site.Rename(request.Name);
 
             await context.SaveChangesAsync(cancellationToken);
 

--- a/src/Inventory/Inventory/Application/Suppliers/Commands/AddSupplierItem.cs
+++ b/src/Inventory/Inventory/Application/Suppliers/Commands/AddSupplierItem.cs
@@ -1,0 +1,50 @@
+using System.Linq;
+
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Inventory.Application.Suppliers;
+using YourBrand.Inventory.Domain;
+using YourBrand.Inventory.Domain.Entities;
+
+namespace YourBrand.Inventory.Application.Suppliers.Commands;
+
+public record AddSupplierItem(
+    string SupplierId,
+    string ItemId,
+    string? SupplierItemId,
+    decimal? UnitCost,
+    int? LeadTimeDays) : IRequest<SupplierItemDto>
+{
+    public class Handler(IInventoryContext context) : IRequestHandler<AddSupplierItem, SupplierItemDto>
+    {
+        public async Task<SupplierItemDto> Handle(AddSupplierItem request, CancellationToken cancellationToken)
+        {
+            var supplier = await context.Suppliers
+                .Include(x => x.Items)
+                    .ThenInclude(x => x.Item)
+                .FirstOrDefaultAsync(x => x.Id == request.SupplierId, cancellationToken);
+
+            if (supplier is null)
+            {
+                throw new InvalidOperationException($"Supplier '{request.SupplierId}' was not found.");
+            }
+
+            var item = await context.Items.FirstOrDefaultAsync(x => x.Id == request.ItemId, cancellationToken);
+
+            if (item is null)
+            {
+                throw new InvalidOperationException($"Item '{request.ItemId}' was not found.");
+            }
+
+            var supplierItem = new SupplierItem(supplier, item, request.SupplierItemId, request.UnitCost, request.LeadTimeDays);
+
+            context.SupplierItems.Add(supplierItem);
+
+            await context.SaveChangesAsync(cancellationToken);
+
+            return supplierItem.ToDto();
+        }
+    }
+}

--- a/src/Inventory/Inventory/Application/Suppliers/Commands/CreateSupplier.cs
+++ b/src/Inventory/Inventory/Application/Suppliers/Commands/CreateSupplier.cs
@@ -1,0 +1,36 @@
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Inventory.Application.Suppliers;
+using YourBrand.Inventory.Domain;
+using YourBrand.Inventory.Domain.Entities;
+
+namespace YourBrand.Inventory.Application.Suppliers.Commands;
+
+public record CreateSupplier(string Id, string Name) : IRequest<SupplierDto>
+{
+    public class Handler(IInventoryContext context) : IRequestHandler<CreateSupplier, SupplierDto>
+    {
+        public async Task<SupplierDto> Handle(CreateSupplier request, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(request.Id))
+            {
+                throw new ArgumentException("Supplier id cannot be empty.", nameof(request.Id));
+            }
+
+            if (await context.Suppliers.AnyAsync(x => x.Id == request.Id, cancellationToken))
+            {
+                throw new InvalidOperationException($"Supplier with id '{request.Id}' already exists.");
+            }
+
+            var supplier = new Supplier(request.Id, request.Name);
+
+            context.Suppliers.Add(supplier);
+
+            await context.SaveChangesAsync(cancellationToken);
+
+            return supplier.ToDto();
+        }
+    }
+}

--- a/src/Inventory/Inventory/Application/Suppliers/Commands/CreateSupplierOrder.cs
+++ b/src/Inventory/Inventory/Application/Suppliers/Commands/CreateSupplierOrder.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Inventory.Application.Suppliers;
+using YourBrand.Inventory.Domain;
+
+namespace YourBrand.Inventory.Application.Suppliers.Commands;
+
+public record CreateSupplierOrder(
+    string SupplierId,
+    string OrderNumber,
+    DateTime OrderedAt,
+    DateTime? ExpectedDelivery,
+    IReadOnlyCollection<CreateSupplierOrderLine> Lines) : IRequest<SupplierOrderDto>;
+
+public record CreateSupplierOrderLine(string SupplierItemId, int ExpectedQuantity, DateTime? ExpectedOn);
+
+public class CreateSupplierOrderHandler(IInventoryContext context) : IRequestHandler<CreateSupplierOrder, SupplierOrderDto>
+{
+    public async Task<SupplierOrderDto> Handle(CreateSupplierOrder request, CancellationToken cancellationToken)
+    {
+        var supplier = await context.Suppliers
+            .Include(x => x.Items)
+                .ThenInclude(x => x.Item)
+            .FirstOrDefaultAsync(x => x.Id == request.SupplierId, cancellationToken);
+
+        if (supplier is null)
+        {
+            throw new InvalidOperationException($"Supplier '{request.SupplierId}' was not found.");
+        }
+
+        if (request.Lines is null || request.Lines.Count == 0)
+        {
+            throw new InvalidOperationException("At least one order line is required.");
+        }
+
+        var order = supplier.PlaceOrder(request.OrderNumber, request.OrderedAt, request.ExpectedDelivery);
+
+        foreach (var line in request.Lines)
+        {
+            var supplierItem = supplier.Items.FirstOrDefault(x => x.Id == line.SupplierItemId);
+
+            if (supplierItem is null)
+            {
+                throw new InvalidOperationException($"Supplier item '{line.SupplierItemId}' does not belong to supplier '{supplier.Id}'.");
+            }
+
+            order.AddLine(supplierItem, line.ExpectedQuantity, line.ExpectedOn);
+        }
+
+        context.SupplierOrders.Add(order);
+
+        await context.SaveChangesAsync(cancellationToken);
+
+        var persistedOrder = await context.SupplierOrders
+            .AsNoTracking()
+            .Include(x => x.Supplier)
+            .Include(x => x.Lines)
+                .ThenInclude(x => x.SupplierItem)
+                    .ThenInclude(x => x.Item)
+            .FirstAsync(x => x.Id == order.Id, cancellationToken);
+
+        return persistedOrder.ToDto();
+    }
+}

--- a/src/Inventory/Inventory/Application/Suppliers/Commands/UpdateSupplierOrderExpectedDelivery.cs
+++ b/src/Inventory/Inventory/Application/Suppliers/Commands/UpdateSupplierOrderExpectedDelivery.cs
@@ -1,0 +1,35 @@
+using System;
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Inventory.Application;
+using YourBrand.Inventory.Domain;
+
+namespace YourBrand.Inventory.Application.Suppliers.Commands;
+
+public record UpdateSupplierOrderExpectedDelivery(string SupplierId, string OrderId, DateTime? ExpectedDelivery) : IRequest<SupplierOrderDto>;
+
+public class UpdateSupplierOrderExpectedDeliveryHandler(IInventoryContext context) : IRequestHandler<UpdateSupplierOrderExpectedDelivery, SupplierOrderDto>
+{
+    public async Task<SupplierOrderDto> Handle(UpdateSupplierOrderExpectedDelivery request, CancellationToken cancellationToken)
+    {
+        var order = await context.SupplierOrders
+            .Include(x => x.Supplier)
+            .Include(x => x.Lines)
+                .ThenInclude(x => x.SupplierItem)
+                    .ThenInclude(x => x.Item)
+            .FirstOrDefaultAsync(x => x.Id == request.OrderId && x.SupplierId == request.SupplierId, cancellationToken);
+
+        if (order is null)
+        {
+            throw new InvalidOperationException($"Supplier order '{request.OrderId}' for supplier '{request.SupplierId}' was not found.");
+        }
+
+        order.UpdateExpectedDelivery(request.ExpectedDelivery);
+
+        await context.SaveChangesAsync(cancellationToken);
+
+        return order.ToDto();
+    }
+}

--- a/src/Inventory/Inventory/Application/Suppliers/Commands/VerifySupplierOrderReceipt.cs
+++ b/src/Inventory/Inventory/Application/Suppliers/Commands/VerifySupplierOrderReceipt.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Inventory.Application;
+using YourBrand.Inventory.Domain;
+
+namespace YourBrand.Inventory.Application.Suppliers.Commands;
+
+public record VerifySupplierOrderReceipt(string SupplierId, string OrderId, IReadOnlyCollection<VerifySupplierOrderReceiptLine> Lines) : IRequest<SupplierOrderDto>;
+
+public record VerifySupplierOrderReceiptLine(string LineId, int QuantityReceived);
+
+public class VerifySupplierOrderReceiptHandler(IInventoryContext context) : IRequestHandler<VerifySupplierOrderReceipt, SupplierOrderDto>
+{
+    public async Task<SupplierOrderDto> Handle(VerifySupplierOrderReceipt request, CancellationToken cancellationToken)
+    {
+        var order = await context.SupplierOrders
+            .Include(x => x.Supplier)
+            .Include(x => x.Lines)
+                .ThenInclude(x => x.SupplierItem)
+                    .ThenInclude(x => x.Item)
+            .FirstOrDefaultAsync(x => x.Id == request.OrderId && x.SupplierId == request.SupplierId, cancellationToken);
+
+        if (order is null)
+        {
+            throw new InvalidOperationException($"Supplier order '{request.OrderId}' for supplier '{request.SupplierId}' was not found.");
+        }
+
+        if (!order.IsReceived)
+        {
+            throw new InvalidOperationException($"Supplier order '{request.OrderId}' must be marked as received before it can be verified.");
+        }
+
+        foreach (var lineRequest in request.Lines)
+        {
+            var line = order.Lines.FirstOrDefault(x => x.Id == lineRequest.LineId);
+
+            if (line is null)
+            {
+                throw new InvalidOperationException($"Order line '{lineRequest.LineId}' was not found on supplier order '{request.OrderId}'.");
+            }
+
+            line.UpdateQuantityReceived(lineRequest.QuantityReceived);
+        }
+
+        await context.SaveChangesAsync(cancellationToken);
+
+        return order.ToDto();
+    }
+}

--- a/src/Inventory/Inventory/Application/Suppliers/Queries/GetSupplier.cs
+++ b/src/Inventory/Inventory/Application/Suppliers/Queries/GetSupplier.cs
@@ -1,0 +1,26 @@
+using System.Linq;
+
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Inventory.Application.Suppliers;
+using YourBrand.Inventory.Domain;
+
+namespace YourBrand.Inventory.Application.Suppliers.Queries;
+
+public record GetSupplier(string Id) : IRequest<SupplierDto?>;
+
+public class GetSupplierHandler(IInventoryContext context) : IRequestHandler<GetSupplier, SupplierDto?>
+{
+    public async Task<SupplierDto?> Handle(GetSupplier request, CancellationToken cancellationToken)
+    {
+        var supplier = await context.Suppliers
+            .AsNoTracking()
+            .Include(x => x.Items)
+                .ThenInclude(x => x.Item)
+            .FirstOrDefaultAsync(x => x.Id == request.Id, cancellationToken);
+
+        return supplier?.ToDto();
+    }
+}

--- a/src/Inventory/Inventory/Application/Suppliers/Queries/GetSupplierOrder.cs
+++ b/src/Inventory/Inventory/Application/Suppliers/Queries/GetSupplierOrder.cs
@@ -1,0 +1,26 @@
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Inventory.Application.Suppliers;
+using YourBrand.Inventory.Domain;
+
+namespace YourBrand.Inventory.Application.Suppliers.Queries;
+
+public record GetSupplierOrder(string SupplierId, string OrderId) : IRequest<SupplierOrderDto?>;
+
+public class GetSupplierOrderHandler(IInventoryContext context) : IRequestHandler<GetSupplierOrder, SupplierOrderDto?>
+{
+    public async Task<SupplierOrderDto?> Handle(GetSupplierOrder request, CancellationToken cancellationToken)
+    {
+        var order = await context.SupplierOrders
+            .AsNoTracking()
+            .Include(x => x.Supplier)
+            .Include(x => x.Lines)
+                .ThenInclude(x => x.SupplierItem)
+                    .ThenInclude(x => x.Item)
+            .FirstOrDefaultAsync(x => x.Id == request.OrderId && x.SupplierId == request.SupplierId, cancellationToken);
+
+        return order?.ToDto();
+    }
+}

--- a/src/Inventory/Inventory/Application/Suppliers/Queries/GetSupplierOrders.cs
+++ b/src/Inventory/Inventory/Application/Suppliers/Queries/GetSupplierOrders.cs
@@ -1,0 +1,30 @@
+using System.Linq;
+
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Inventory.Application.Suppliers;
+using YourBrand.Inventory.Domain;
+
+namespace YourBrand.Inventory.Application.Suppliers.Queries;
+
+public record GetSupplierOrders(string SupplierId) : IRequest<IEnumerable<SupplierOrderDto>>;
+
+public class GetSupplierOrdersHandler(IInventoryContext context) : IRequestHandler<GetSupplierOrders, IEnumerable<SupplierOrderDto>>
+{
+    public async Task<IEnumerable<SupplierOrderDto>> Handle(GetSupplierOrders request, CancellationToken cancellationToken)
+    {
+        var orders = await context.SupplierOrders
+            .AsNoTracking()
+            .Include(x => x.Supplier)
+            .Include(x => x.Lines)
+                .ThenInclude(x => x.SupplierItem)
+                    .ThenInclude(x => x.Item)
+            .Where(x => x.SupplierId == request.SupplierId)
+            .OrderByDescending(x => x.OrderedAt)
+            .ToListAsync(cancellationToken);
+
+        return orders.Select(x => x.ToDto());
+    }
+}

--- a/src/Inventory/Inventory/Application/Suppliers/Queries/GetSuppliers.cs
+++ b/src/Inventory/Inventory/Application/Suppliers/Queries/GetSuppliers.cs
@@ -1,0 +1,26 @@
+using System.Linq;
+
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Inventory.Application.Suppliers;
+using YourBrand.Inventory.Domain;
+
+namespace YourBrand.Inventory.Application.Suppliers.Queries;
+
+public record GetSuppliers() : IRequest<IEnumerable<SupplierDto>>;
+
+public class GetSuppliersHandler(IInventoryContext context) : IRequestHandler<GetSuppliers, IEnumerable<SupplierDto>>
+{
+    public async Task<IEnumerable<SupplierDto>> Handle(GetSuppliers request, CancellationToken cancellationToken)
+    {
+        var suppliers = await context.Suppliers
+            .AsNoTracking()
+            .Include(x => x.Items)
+                .ThenInclude(x => x.Item)
+            .ToListAsync(cancellationToken);
+
+        return suppliers.Select(x => x.ToDto());
+    }
+}

--- a/src/Inventory/Inventory/Application/Suppliers/SupplierDto.cs
+++ b/src/Inventory/Inventory/Application/Suppliers/SupplierDto.cs
@@ -14,6 +14,7 @@ public record SupplierOrderDto(
     string OrderNumber,
     DateTime OrderedAt,
     DateTime? ExpectedDelivery,
+    DateTime? ReceivedAt,
     IReadOnlyCollection<SupplierOrderLineDto> Lines,
     int TotalQuantityOutstanding);
 

--- a/src/Inventory/Inventory/Application/Suppliers/SupplierDto.cs
+++ b/src/Inventory/Inventory/Application/Suppliers/SupplierDto.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+
+namespace YourBrand.Inventory.Application.Suppliers;
+
+public record SupplierDto(string Id, string Name, IReadOnlyCollection<SupplierItemDto> Items);
+
+public record SupplierItemDto(string Id, string ItemId, string ItemName, string? SupplierItemId, decimal? UnitCost, int? LeadTimeDays);
+
+public record SupplierOrderDto(
+    string Id,
+    string SupplierId,
+    string SupplierName,
+    string OrderNumber,
+    DateTime OrderedAt,
+    DateTime? ExpectedDelivery,
+    IReadOnlyCollection<SupplierOrderLineDto> Lines,
+    int TotalQuantityOutstanding);
+
+public record SupplierOrderLineDto(
+    string Id,
+    string SupplierItemId,
+    string ItemId,
+    string ItemName,
+    int QuantityOrdered,
+    int ExpectedQuantity,
+    int QuantityReceived,
+    int QuantityOutstanding,
+    DateTime? ExpectedOn);

--- a/src/Inventory/Inventory/Application/Suppliers/SuppliersController.cs
+++ b/src/Inventory/Inventory/Application/Suppliers/SuppliersController.cs
@@ -67,6 +67,20 @@ public class SuppliersController(IMediator mediator) : ControllerBase
     {
         return await mediator.Send(new UpdateSupplierOrderExpectedDelivery(supplierId, orderId, dto.ExpectedDelivery), cancellationToken);
     }
+
+    [HttpPut("{supplierId}/Orders/{orderId}/Receipt")]
+    public async Task<SupplierOrderDto> RegisterSupplierOrderReceipt(string supplierId, string orderId, RegisterSupplierOrderReceiptDto dto, CancellationToken cancellationToken)
+    {
+        return await mediator.Send(new RegisterSupplierOrderReceipt(supplierId, orderId, dto.ReceivedAt), cancellationToken);
+    }
+
+    [HttpPut("{supplierId}/Orders/{orderId}/Receipt/Verification")]
+    public async Task<SupplierOrderDto> VerifySupplierOrderReceipt(string supplierId, string orderId, VerifySupplierOrderReceiptDto dto, CancellationToken cancellationToken)
+    {
+        var lines = dto.Lines.Select(line => new VerifySupplierOrderReceiptLine(line.LineId, line.QuantityReceived)).ToList();
+
+        return await mediator.Send(new VerifySupplierOrderReceipt(supplierId, orderId, lines), cancellationToken);
+    }
 }
 
 public record CreateSupplierDto(string Id, string Name);
@@ -78,3 +92,9 @@ public record CreateSupplierOrderDto(string OrderNumber, DateTime OrderedAt, Dat
 public record CreateSupplierOrderLineDto(string SupplierItemId, int ExpectedQuantity, DateTime? ExpectedOn);
 
 public record UpdateSupplierOrderExpectedDeliveryDto(DateTime? ExpectedDelivery);
+
+public record RegisterSupplierOrderReceiptDto(DateTime ReceivedAt);
+
+public record VerifySupplierOrderReceiptDto(IReadOnlyCollection<VerifySupplierOrderReceiptLineDto> Lines);
+
+public record VerifySupplierOrderReceiptLineDto(string LineId, int QuantityReceived);

--- a/src/Inventory/Inventory/Application/Suppliers/SuppliersController.cs
+++ b/src/Inventory/Inventory/Application/Suppliers/SuppliersController.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Asp.Versioning;
+
+using MediatR;
+
+using Microsoft.AspNetCore.Mvc;
+
+using YourBrand.Inventory.Application.Suppliers.Commands;
+using YourBrand.Inventory.Application.Suppliers.Queries;
+
+namespace YourBrand.Inventory.Application.Suppliers;
+
+[ApiController]
+[ApiVersion("1")]
+[Route("v{version:apiVersion}/Suppliers")]
+public class SuppliersController(IMediator mediator) : ControllerBase
+{
+    [HttpGet]
+    public async Task<IEnumerable<SupplierDto>> GetSuppliers(CancellationToken cancellationToken)
+    {
+        return await mediator.Send(new GetSuppliers(), cancellationToken);
+    }
+
+    [HttpGet("{id}")]
+    public async Task<SupplierDto?> GetSupplier(string id, CancellationToken cancellationToken)
+    {
+        return await mediator.Send(new GetSupplier(id), cancellationToken);
+    }
+
+    [HttpPost]
+    public async Task<SupplierDto> CreateSupplier(CreateSupplierDto dto, CancellationToken cancellationToken)
+    {
+        return await mediator.Send(new CreateSupplier(dto.Id, dto.Name), cancellationToken);
+    }
+
+    [HttpPost("{supplierId}/Items")]
+    public async Task<SupplierItemDto> AddSupplierItem(string supplierId, AddSupplierItemDto dto, CancellationToken cancellationToken)
+    {
+        return await mediator.Send(new AddSupplierItem(supplierId, dto.ItemId, dto.SupplierItemId, dto.UnitCost, dto.LeadTimeDays), cancellationToken);
+    }
+
+    [HttpGet("{supplierId}/Orders")]
+    public async Task<IEnumerable<SupplierOrderDto>> GetSupplierOrders(string supplierId, CancellationToken cancellationToken)
+    {
+        return await mediator.Send(new GetSupplierOrders(supplierId), cancellationToken);
+    }
+
+    [HttpGet("{supplierId}/Orders/{orderId}")]
+    public async Task<SupplierOrderDto?> GetSupplierOrder(string supplierId, string orderId, CancellationToken cancellationToken)
+    {
+        return await mediator.Send(new GetSupplierOrder(supplierId, orderId), cancellationToken);
+    }
+
+    [HttpPost("{supplierId}/Orders")]
+    public async Task<SupplierOrderDto> CreateSupplierOrder(string supplierId, CreateSupplierOrderDto dto, CancellationToken cancellationToken)
+    {
+        var lines = dto.Lines.Select(line => new CreateSupplierOrderLine(line.SupplierItemId, line.ExpectedQuantity, line.ExpectedOn)).ToList();
+
+        return await mediator.Send(new CreateSupplierOrder(supplierId, dto.OrderNumber, dto.OrderedAt, dto.ExpectedDelivery, lines), cancellationToken);
+    }
+}
+
+public record CreateSupplierDto(string Id, string Name);
+
+public record AddSupplierItemDto(string ItemId, string? SupplierItemId, decimal? UnitCost, int? LeadTimeDays);
+
+public record CreateSupplierOrderDto(string OrderNumber, DateTime OrderedAt, DateTime? ExpectedDelivery, IReadOnlyCollection<CreateSupplierOrderLineDto> Lines);
+
+public record CreateSupplierOrderLineDto(string SupplierItemId, int ExpectedQuantity, DateTime? ExpectedOn);

--- a/src/Inventory/Inventory/Application/Suppliers/SuppliersController.cs
+++ b/src/Inventory/Inventory/Application/Suppliers/SuppliersController.cs
@@ -61,6 +61,12 @@ public class SuppliersController(IMediator mediator) : ControllerBase
 
         return await mediator.Send(new CreateSupplierOrder(supplierId, dto.OrderNumber, dto.OrderedAt, dto.ExpectedDelivery, lines), cancellationToken);
     }
+
+    [HttpPut("{supplierId}/Orders/{orderId}/ExpectedDelivery")]
+    public async Task<SupplierOrderDto> UpdateSupplierOrderExpectedDelivery(string supplierId, string orderId, UpdateSupplierOrderExpectedDeliveryDto dto, CancellationToken cancellationToken)
+    {
+        return await mediator.Send(new UpdateSupplierOrderExpectedDelivery(supplierId, orderId, dto.ExpectedDelivery), cancellationToken);
+    }
 }
 
 public record CreateSupplierDto(string Id, string Name);
@@ -70,3 +76,5 @@ public record AddSupplierItemDto(string ItemId, string? SupplierItemId, decimal?
 public record CreateSupplierOrderDto(string OrderNumber, DateTime OrderedAt, DateTime? ExpectedDelivery, IReadOnlyCollection<CreateSupplierOrderLineDto> Lines);
 
 public record CreateSupplierOrderLineDto(string SupplierItemId, int ExpectedQuantity, DateTime? ExpectedOn);
+
+public record UpdateSupplierOrderExpectedDeliveryDto(DateTime? ExpectedDelivery);

--- a/src/Inventory/Inventory/Domain/Entities/Item.cs
+++ b/src/Inventory/Inventory/Domain/Entities/Item.cs
@@ -11,6 +11,7 @@ namespace YourBrand.Inventory.Domain.Entities;
 public class Item : AuditableEntity<string>
 {
     private readonly HashSet<WarehouseItem> warehouseItems = new();
+    private readonly HashSet<SupplierItem> supplierItems = new();
 
     protected Item() { }
 
@@ -44,6 +45,8 @@ public class Item : AuditableEntity<string>
     public int QuantityAvailable => warehouseItems.Sum(x => x.QuantityAvailable);
 
     public IReadOnlyCollection<WarehouseItem> WarehouseItems => warehouseItems;
+
+    public IReadOnlyCollection<SupplierItem> SupplierItems => supplierItems;
 
     public void Rename(string name)
     {
@@ -122,6 +125,19 @@ public class Item : AuditableEntity<string>
         {
             RecalculateAvailability();
         }
+    }
+
+    internal void AttachSupplierItem(SupplierItem supplierItem)
+    {
+        if (!supplierItems.Contains(supplierItem))
+        {
+            supplierItems.Add(supplierItem);
+        }
+    }
+
+    internal void DetachSupplierItem(SupplierItem supplierItem)
+    {
+        supplierItems.Remove(supplierItem);
     }
 
     internal void RecalculateAvailability()

--- a/src/Inventory/Inventory/Domain/Entities/Supplier.cs
+++ b/src/Inventory/Inventory/Domain/Entities/Supplier.cs
@@ -1,0 +1,72 @@
+namespace YourBrand.Inventory.Domain.Entities;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using YourBrand.Inventory.Domain.Common;
+
+public class Supplier : AuditableEntity<string>
+{
+    private readonly HashSet<SupplierItem> items = new();
+    private readonly HashSet<SupplierOrder> orders = new();
+
+    protected Supplier() { }
+
+    public Supplier(string id, string name)
+        : base(id)
+    {
+        Rename(name);
+    }
+
+    public string Name { get; private set; } = null!;
+
+    public IReadOnlyCollection<SupplierItem> Items => items;
+
+    public IReadOnlyCollection<SupplierOrder> Orders => orders;
+
+    public void Rename(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException("Supplier name cannot be empty.", nameof(name));
+        }
+
+        Name = name.Trim();
+    }
+
+    public SupplierOrder PlaceOrder(string orderNumber, DateTime orderedAt, DateTime? expectedDelivery = null)
+    {
+        var order = new SupplierOrder(this, orderNumber, orderedAt, expectedDelivery);
+        AttachOrder(order);
+        return order;
+    }
+
+    internal void AttachItem(SupplierItem supplierItem)
+    {
+        if (!items.Contains(supplierItem))
+        {
+            items.Add(supplierItem);
+        }
+    }
+
+    internal void DetachItem(SupplierItem supplierItem)
+    {
+        items.Remove(supplierItem);
+    }
+
+    internal void AttachOrder(SupplierOrder supplierOrder)
+    {
+        if (!orders.Contains(supplierOrder))
+        {
+            orders.Add(supplierOrder);
+        }
+    }
+
+    internal void DetachOrder(SupplierOrder supplierOrder)
+    {
+        orders.Remove(supplierOrder);
+    }
+
+    public bool SuppliesItem(string itemId) => items.Any(x => x.ItemId == itemId);
+}

--- a/src/Inventory/Inventory/Domain/Entities/SupplierItem.cs
+++ b/src/Inventory/Inventory/Domain/Entities/SupplierItem.cs
@@ -1,0 +1,70 @@
+namespace YourBrand.Inventory.Domain.Entities;
+
+using System;
+using System.Collections.Generic;
+
+using YourBrand.Inventory.Domain.Common;
+
+public class SupplierItem : AuditableEntity<string>
+{
+    private readonly HashSet<SupplierOrderLine> orderLines = new();
+
+    protected SupplierItem() { }
+
+    public SupplierItem(Supplier supplier, Item item, string? supplierItemId, decimal? unitCost, int? leadTimeDays)
+        : base(Guid.NewGuid().ToString())
+    {
+        Supplier = supplier ?? throw new ArgumentNullException(nameof(supplier));
+        SupplierId = supplier.Id;
+
+        Item = item ?? throw new ArgumentNullException(nameof(item));
+        ItemId = item.Id;
+
+        UpdateDetails(supplierItemId, unitCost, leadTimeDays);
+
+        supplier.AttachItem(this);
+        item.AttachSupplierItem(this);
+    }
+
+    public string SupplierId { get; private set; } = null!;
+
+    public Supplier Supplier { get; private set; } = null!;
+
+    public string ItemId { get; private set; } = null!;
+
+    public Item Item { get; private set; } = null!;
+
+    public string? SupplierItemId { get; private set; }
+
+    public decimal? UnitCost { get; private set; }
+
+    public int? LeadTimeDays { get; private set; }
+
+    public IReadOnlyCollection<SupplierOrderLine> OrderLines => orderLines;
+
+    public void UpdateDetails(string? supplierItemId, decimal? unitCost, int? leadTimeDays)
+    {
+        SupplierItemId = string.IsNullOrWhiteSpace(supplierItemId) ? null : supplierItemId.Trim();
+        UnitCost = unitCost;
+
+        if (leadTimeDays is < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(leadTimeDays));
+        }
+
+        LeadTimeDays = leadTimeDays;
+    }
+
+    internal void AttachOrderLine(SupplierOrderLine line)
+    {
+        if (!orderLines.Contains(line))
+        {
+            orderLines.Add(line);
+        }
+    }
+
+    internal void DetachOrderLine(SupplierOrderLine line)
+    {
+        orderLines.Remove(line);
+    }
+}

--- a/src/Inventory/Inventory/Domain/Entities/SupplierOrder.cs
+++ b/src/Inventory/Inventory/Domain/Entities/SupplierOrder.cs
@@ -38,6 +38,10 @@ public class SupplierOrder : AuditableEntity<string>
 
     public DateTime? ExpectedDelivery { get; private set; }
 
+    public DateTime? ReceivedAt { get; private set; }
+
+    public bool IsReceived => ReceivedAt is not null;
+
     public IReadOnlyCollection<SupplierOrderLine> Lines => lines;
 
     public int TotalQuantityOrdered => lines.Sum(x => x.QuantityOrdered);
@@ -71,6 +75,16 @@ public class SupplierOrder : AuditableEntity<string>
     public void UpdateExpectedDelivery(DateTime? expectedDelivery)
     {
         ExpectedDelivery = expectedDelivery;
+    }
+
+    public void RegisterReceipt(DateTime receivedAt)
+    {
+        if (receivedAt < OrderedAt)
+        {
+            throw new InvalidOperationException("Receipt date cannot be earlier than the order date.");
+        }
+
+        ReceivedAt = receivedAt;
     }
 
     internal void AttachLine(SupplierOrderLine line)

--- a/src/Inventory/Inventory/Domain/Entities/SupplierOrder.cs
+++ b/src/Inventory/Inventory/Domain/Entities/SupplierOrder.cs
@@ -1,0 +1,88 @@
+namespace YourBrand.Inventory.Domain.Entities;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using YourBrand.Inventory.Domain.Common;
+
+public class SupplierOrder : AuditableEntity<string>
+{
+    private readonly HashSet<SupplierOrderLine> lines = new();
+
+    protected SupplierOrder() { }
+
+    public SupplierOrder(Supplier supplier, string orderNumber, DateTime orderedAt, DateTime? expectedDelivery = null)
+        : base(Guid.NewGuid().ToString())
+    {
+        Supplier = supplier ?? throw new ArgumentNullException(nameof(supplier));
+        SupplierId = supplier.Id;
+
+        OrderNumber = string.IsNullOrWhiteSpace(orderNumber)
+            ? throw new ArgumentException("Order number cannot be empty.", nameof(orderNumber))
+            : orderNumber.Trim();
+
+        OrderedAt = orderedAt;
+        ExpectedDelivery = expectedDelivery;
+
+        supplier.AttachOrder(this);
+    }
+
+    public string SupplierId { get; private set; } = null!;
+
+    public Supplier Supplier { get; private set; } = null!;
+
+    public string OrderNumber { get; private set; } = null!;
+
+    public DateTime OrderedAt { get; private set; }
+
+    public DateTime? ExpectedDelivery { get; private set; }
+
+    public IReadOnlyCollection<SupplierOrderLine> Lines => lines;
+
+    public int TotalQuantityOrdered => lines.Sum(x => x.QuantityOrdered);
+
+    public int TotalQuantityExpected => lines.Sum(x => x.ExpectedQuantity);
+
+    public int TotalQuantityOutstanding => lines.Sum(x => x.QuantityOutstanding);
+
+    public SupplierOrderLine AddLine(SupplierItem supplierItem, int expectedQuantity, DateTime? expectedOn = null)
+    {
+        if (supplierItem is null)
+        {
+            throw new ArgumentNullException(nameof(supplierItem));
+        }
+
+        if (supplierItem.SupplierId != SupplierId)
+        {
+            throw new InvalidOperationException("Supplier item does not belong to this supplier.");
+        }
+
+        if (expectedQuantity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(expectedQuantity));
+        }
+
+        var line = new SupplierOrderLine(this, supplierItem, expectedQuantity, expectedOn);
+        AttachLine(line);
+        return line;
+    }
+
+    public void UpdateExpectedDelivery(DateTime? expectedDelivery)
+    {
+        ExpectedDelivery = expectedDelivery;
+    }
+
+    internal void AttachLine(SupplierOrderLine line)
+    {
+        if (!lines.Contains(line))
+        {
+            lines.Add(line);
+        }
+    }
+
+    internal void DetachLine(SupplierOrderLine line)
+    {
+        lines.Remove(line);
+    }
+}

--- a/src/Inventory/Inventory/Domain/Entities/SupplierOrderLine.cs
+++ b/src/Inventory/Inventory/Domain/Entities/SupplierOrderLine.cs
@@ -1,0 +1,80 @@
+namespace YourBrand.Inventory.Domain.Entities;
+
+using System;
+
+using YourBrand.Inventory.Domain.Common;
+
+public class SupplierOrderLine : AuditableEntity<string>
+{
+    protected SupplierOrderLine() { }
+
+    internal SupplierOrderLine(SupplierOrder order, SupplierItem supplierItem, int expectedQuantity, DateTime? expectedOn)
+        : base(Guid.NewGuid().ToString())
+    {
+        Order = order ?? throw new ArgumentNullException(nameof(order));
+        OrderId = order.Id;
+
+        SupplierItem = supplierItem ?? throw new ArgumentNullException(nameof(supplierItem));
+        SupplierItemId = supplierItem.Id;
+
+        QuantityOrdered = expectedQuantity;
+        ExpectedQuantity = expectedQuantity;
+        ExpectedOn = expectedOn;
+
+        order.AttachLine(this);
+        supplierItem.AttachOrderLine(this);
+    }
+
+    public string OrderId { get; private set; } = null!;
+
+    public SupplierOrder Order { get; private set; } = null!;
+
+    public string SupplierItemId { get; private set; } = null!;
+
+    public SupplierItem SupplierItem { get; private set; } = null!;
+
+    public int QuantityOrdered { get; private set; }
+
+    public int ExpectedQuantity { get; private set; }
+
+    public int QuantityReceived { get; private set; }
+
+    public int QuantityOutstanding => ExpectedQuantity - QuantityReceived;
+
+    public DateTime? ExpectedOn { get; private set; }
+
+    public void ChangeExpectedQuantity(int quantity)
+    {
+        if (quantity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(quantity));
+        }
+
+        if (quantity < QuantityReceived)
+        {
+            throw new InvalidOperationException("Expected quantity cannot be less than the quantity already received.");
+        }
+
+        ExpectedQuantity = quantity;
+    }
+
+    public void RegisterReceipt(int quantity)
+    {
+        if (quantity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(quantity));
+        }
+
+        if (QuantityReceived + quantity > ExpectedQuantity)
+        {
+            throw new InvalidOperationException("Cannot receive more items than expected.");
+        }
+
+        QuantityReceived += quantity;
+    }
+
+    public void UpdateExpectedOn(DateTime? expectedOn)
+    {
+        ExpectedOn = expectedOn;
+    }
+}

--- a/src/Inventory/Inventory/Domain/Entities/SupplierOrderLine.cs
+++ b/src/Inventory/Inventory/Domain/Entities/SupplierOrderLine.cs
@@ -77,4 +77,19 @@ public class SupplierOrderLine : AuditableEntity<string>
     {
         ExpectedOn = expectedOn;
     }
+
+    public void UpdateQuantityReceived(int quantity)
+    {
+        if (quantity < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(quantity));
+        }
+
+        if (quantity > ExpectedQuantity)
+        {
+            throw new InvalidOperationException("Cannot receive more items than expected.");
+        }
+
+        QuantityReceived = quantity;
+    }
 }

--- a/src/Inventory/Inventory/Domain/IInventoryContext.cs
+++ b/src/Inventory/Inventory/Domain/IInventoryContext.cs
@@ -11,6 +11,10 @@ public interface IInventoryContext
     DbSet<WarehouseItem> WarehouseItems { get; }
     DbSet<ItemGroup> ItemGroups { get; }
     DbSet<Item> Items { get; }
+    DbSet<Supplier> Suppliers { get; }
+    DbSet<SupplierItem> SupplierItems { get; }
+    DbSet<SupplierOrder> SupplierOrders { get; }
+    DbSet<SupplierOrderLine> SupplierOrderLines { get; }
 
     Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Inventory/Inventory/Infrastructure/Persistence/Configurations/SupplierConfiguration.cs
+++ b/src/Inventory/Inventory/Infrastructure/Persistence/Configurations/SupplierConfiguration.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using YourBrand.Inventory.Domain.Entities;
+
+namespace YourBrand.Inventory.Infrastructure.Persistence.Configurations;
+
+public class SupplierConfiguration : IEntityTypeConfiguration<Supplier>
+{
+    public void Configure(EntityTypeBuilder<Supplier> builder)
+    {
+        builder.ToTable("Suppliers");
+
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.Id)
+            .HasMaxLength(64);
+
+        builder.Property(x => x.Name)
+            .IsRequired()
+            .HasMaxLength(256);
+
+        builder.HasMany(x => x.Items)
+            .WithOne(x => x.Supplier)
+            .HasForeignKey(x => x.SupplierId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasMany(x => x.Orders)
+            .WithOne(x => x.Supplier)
+            .HasForeignKey(x => x.SupplierId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/Inventory/Inventory/Infrastructure/Persistence/Configurations/SupplierItemConfiguration.cs
+++ b/src/Inventory/Inventory/Infrastructure/Persistence/Configurations/SupplierItemConfiguration.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using YourBrand.Inventory.Domain.Entities;
+
+namespace YourBrand.Inventory.Infrastructure.Persistence.Configurations;
+
+public class SupplierItemConfiguration : IEntityTypeConfiguration<SupplierItem>
+{
+    public void Configure(EntityTypeBuilder<SupplierItem> builder)
+    {
+        builder.ToTable("SupplierItems");
+
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.SupplierId)
+            .IsRequired()
+            .HasMaxLength(64);
+
+        builder.Property(x => x.ItemId)
+            .IsRequired()
+            .HasMaxLength(64);
+
+        builder.Property(x => x.SupplierItemId)
+            .HasMaxLength(128);
+
+        builder.Property(x => x.UnitCost)
+            .HasPrecision(18, 2);
+
+        builder.HasOne(x => x.Item)
+            .WithMany(x => x.SupplierItems)
+            .HasForeignKey(x => x.ItemId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasMany(x => x.OrderLines)
+            .WithOne(x => x.SupplierItem)
+            .HasForeignKey(x => x.SupplierItemId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/Inventory/Inventory/Infrastructure/Persistence/Configurations/SupplierOrderConfiguration.cs
+++ b/src/Inventory/Inventory/Infrastructure/Persistence/Configurations/SupplierOrderConfiguration.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using YourBrand.Inventory.Domain.Entities;
+
+namespace YourBrand.Inventory.Infrastructure.Persistence.Configurations;
+
+public class SupplierOrderConfiguration : IEntityTypeConfiguration<SupplierOrder>
+{
+    public void Configure(EntityTypeBuilder<SupplierOrder> builder)
+    {
+        builder.ToTable("SupplierOrders");
+
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.SupplierId)
+            .IsRequired()
+            .HasMaxLength(64);
+
+        builder.Property(x => x.OrderNumber)
+            .IsRequired()
+            .HasMaxLength(128);
+
+        builder.Property(x => x.OrderedAt)
+            .IsRequired();
+
+        builder.HasMany(x => x.Lines)
+            .WithOne(x => x.Order)
+            .HasForeignKey(x => x.OrderId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/Inventory/Inventory/Infrastructure/Persistence/Configurations/SupplierOrderConfiguration.cs
+++ b/src/Inventory/Inventory/Infrastructure/Persistence/Configurations/SupplierOrderConfiguration.cs
@@ -24,6 +24,8 @@ public class SupplierOrderConfiguration : IEntityTypeConfiguration<SupplierOrder
         builder.Property(x => x.OrderedAt)
             .IsRequired();
 
+        builder.Property(x => x.ExpectedDelivery);
+
         builder.HasMany(x => x.Lines)
             .WithOne(x => x.Order)
             .HasForeignKey(x => x.OrderId)

--- a/src/Inventory/Inventory/Infrastructure/Persistence/Configurations/SupplierOrderConfiguration.cs
+++ b/src/Inventory/Inventory/Infrastructure/Persistence/Configurations/SupplierOrderConfiguration.cs
@@ -26,6 +26,8 @@ public class SupplierOrderConfiguration : IEntityTypeConfiguration<SupplierOrder
 
         builder.Property(x => x.ExpectedDelivery);
 
+        builder.Property(x => x.ReceivedAt);
+
         builder.HasMany(x => x.Lines)
             .WithOne(x => x.Order)
             .HasForeignKey(x => x.OrderId)

--- a/src/Inventory/Inventory/Infrastructure/Persistence/Configurations/SupplierOrderLineConfiguration.cs
+++ b/src/Inventory/Inventory/Infrastructure/Persistence/Configurations/SupplierOrderLineConfiguration.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using YourBrand.Inventory.Domain.Entities;
+
+namespace YourBrand.Inventory.Infrastructure.Persistence.Configurations;
+
+public class SupplierOrderLineConfiguration : IEntityTypeConfiguration<SupplierOrderLine>
+{
+    public void Configure(EntityTypeBuilder<SupplierOrderLine> builder)
+    {
+        builder.ToTable("SupplierOrderLines");
+
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.OrderId)
+            .IsRequired()
+            .HasMaxLength(64);
+
+        builder.Property(x => x.SupplierItemId)
+            .IsRequired()
+            .HasMaxLength(64);
+
+        builder.Property(x => x.QuantityOrdered)
+            .IsRequired();
+
+        builder.Property(x => x.ExpectedQuantity)
+            .IsRequired();
+
+        builder.Property(x => x.QuantityReceived)
+            .IsRequired();
+    }
+}

--- a/src/Inventory/Inventory/Infrastructure/Persistence/InventoryContext.cs
+++ b/src/Inventory/Inventory/Infrastructure/Persistence/InventoryContext.cs
@@ -39,6 +39,14 @@ public class InventoryContext(
 
     public DbSet<Item> Items { get; set; } = null!;
 
+    public DbSet<Supplier> Suppliers { get; set; } = null!;
+
+    public DbSet<SupplierItem> SupplierItems { get; set; } = null!;
+
+    public DbSet<SupplierOrder> SupplierOrders { get; set; } = null!;
+
+    public DbSet<SupplierOrderLine> SupplierOrderLines { get; set; } = null!;
+
     public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
     {
         var entities = ChangeTracker

--- a/src/Inventory/Inventory/Infrastructure/Persistence/SeedData.cs
+++ b/src/Inventory/Inventory/Infrastructure/Persistence/SeedData.cs
@@ -48,6 +48,27 @@ public class SeedData
 
                 await context.SaveChangesAsync();
 
+                var supplier = new Supplier("default-supplier", "Default Supplier");
+                context.Suppliers.Add(supplier);
+
+                await context.SaveChangesAsync();
+
+                var supplierItem1 = new SupplierItem(supplier, t1, "TS-B-S", 5.75m, 7);
+                var supplierItem2 = new SupplierItem(supplier, t2, "TS-B-M", 5.75m, 7);
+                var supplierItem3 = new SupplierItem(supplier, t3, "TS-B-L", 5.75m, 7);
+
+                context.SupplierItems.AddRange(supplierItem1, supplierItem2, supplierItem3);
+
+                await context.SaveChangesAsync();
+
+                var supplierOrder = new SupplierOrder(supplier, "PO-1001", DateTime.UtcNow, DateTime.UtcNow.AddDays(10));
+                supplierOrder.AddLine(supplierItem1, 50, DateTime.UtcNow.AddDays(10));
+                supplierOrder.AddLine(supplierItem2, 50, DateTime.UtcNow.AddDays(10));
+
+                context.SupplierOrders.Add(supplierOrder);
+
+                await context.SaveChangesAsync();
+
                 var shop1site = new Site("shop-1", "Shop 1");
                 context.Sites.Add(shop1site);
 


### PR DESCRIPTION
## Summary
- introduce supplier, supplier item, and supplier order aggregates with persistence mappings to support inbound orders
- add application DTOs, commands, queries, and a controller for managing suppliers and their purchase orders
- wire new sets through the inventory context, update seed data, and adjust existing update commands to use domain behavior

## Testing
- dotnet test src/Inventory/Inventory.Tests/Inventory.Tests.csproj

------
https://chatgpt.com/codex/tasks/task_e_6909d9cc6ef4832fbe7492b647c113f8