### PR TITLE
Add expiring inventory reservations workflow

### DIFF
--- a/src/Inventory/Inventory.Tests/Domain/Entities/ItemTest.cs
+++ b/src/Inventory/Inventory.Tests/Domain/Entities/ItemTest.cs
@@ -22,11 +22,29 @@ public class WarehouseItemTest
     public void ReserveQuantity()
     {
         var item = CreateWarehouseItem(100);
-        item.Reserve(20);
+        var reservation = item.Reserve(20, TimeSpan.FromMinutes(5));
 
         item.QuantityReserved.ShouldBe(20);
         item.QuantityOnHand.ShouldBe(100);
         item.QuantityAvailable.ShouldBe(80);
+        reservation.ShouldNotBeNull();
+        reservation.Status.ShouldBe(WarehouseItemReservationStatus.Pending);
+        reservation.RemainingQuantity.ShouldBe(20);
+        reservation.ExpiresAt.ShouldBeGreaterThan(DateTimeOffset.UtcNow);
+    }
+
+    [Fact]
+    public void ExpiredReservationIsReleased()
+    {
+        var item = CreateWarehouseItem(50);
+        var reservation = item.Reserve(10, TimeSpan.FromMinutes(5));
+
+        item.ReleaseReservation(reservation.Id, WarehouseItemReservationStatus.Expired);
+
+        item.QuantityReserved.ShouldBe(0);
+        item.QuantityAvailable.ShouldBe(50);
+        reservation.Status.ShouldBe(WarehouseItemReservationStatus.Expired);
+        reservation.RemainingQuantity.ShouldBe(0);
     }
 
     [Fact]

--- a/src/Inventory/Inventory/Application/Mappings.cs
+++ b/src/Inventory/Inventory/Application/Mappings.cs
@@ -51,7 +51,27 @@ public static class Mappings
             item.QuantityPicked,
             item.QuantityReserved,
             item.QuantityAvailable,
-            item.QuantityThreshold);
+            item.QuantityThreshold,
+            item.Reservations
+                .OrderBy(r => r.ReservedAt)
+                .Select(r => r.ToDto())
+                .ToList());
+    }
+
+    public static WarehouseItemReservationDto ToDto(this WarehouseItemReservation reservation)
+    {
+        return new WarehouseItemReservationDto(
+            reservation.Id,
+            reservation.Quantity,
+            reservation.ConsumedQuantity,
+            reservation.ReleasedQuantity,
+            reservation.RemainingQuantity,
+            (WarehouseItemReservationStatusDto)reservation.Status,
+            reservation.ReservedAt,
+            reservation.ExpiresAt,
+            reservation.ConfirmedAt,
+            reservation.ReleasedAt,
+            reservation.Reference);
     }
 
     public static SiteDto ToDto(this Site item)

--- a/src/Inventory/Inventory/Application/Warehouse/Items/Commands/ConfirmReservation.cs
+++ b/src/Inventory/Inventory/Application/Warehouse/Items/Commands/ConfirmReservation.cs
@@ -1,0 +1,36 @@
+using System;
+
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Inventory.Domain;
+
+namespace YourBrand.Inventory.Application.Warehouses.Items.Commands;
+
+public record ConfirmWarehouseItemReservation(string WarehouseId, string Id, string ReservationId) : IRequest
+{
+    public class Handler(IInventoryContext context) : IRequestHandler<ConfirmWarehouseItemReservation>
+    {
+        public async Task Handle(ConfirmWarehouseItemReservation request, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(request.ReservationId))
+            {
+                throw new ArgumentNullException(nameof(request.ReservationId));
+            }
+
+            var item = await context.WarehouseItems
+                .Include(i => i.Reservations)
+                .FirstOrDefaultAsync(i => i.WarehouseId == request.WarehouseId && i.ItemId == request.Id, cancellationToken);
+
+            if (item is null)
+            {
+                throw new Exception();
+            }
+
+            item.ConfirmReservation(request.ReservationId);
+
+            await context.SaveChangesAsync(cancellationToken);
+        }
+    }
+}

--- a/src/Inventory/Inventory/Application/Warehouse/Items/Commands/PickItems.cs
+++ b/src/Inventory/Inventory/Application/Warehouse/Items/Commands/PickItems.cs
@@ -20,7 +20,9 @@ public record PickWarehouseItems(string WarehouseId, string Id, int Quantity, bo
                 throw new ArgumentOutOfRangeException(nameof(request.Quantity));
             }
 
-            var item = await context.WarehouseItems.FirstOrDefaultAsync(i => i.WarehouseId == request.WarehouseId && i.ItemId == request.Id, cancellationToken);
+            var item = await context.WarehouseItems
+                .Include(i => i.Reservations)
+                .FirstOrDefaultAsync(i => i.WarehouseId == request.WarehouseId && i.ItemId == request.Id, cancellationToken);
 
             if (item is null) throw new Exception();
 

--- a/src/Inventory/Inventory/Application/Warehouse/Items/Commands/ReleaseReservation.cs
+++ b/src/Inventory/Inventory/Application/Warehouse/Items/Commands/ReleaseReservation.cs
@@ -1,0 +1,37 @@
+using System;
+
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Inventory.Domain;
+using YourBrand.Inventory.Domain.Enums;
+
+namespace YourBrand.Inventory.Application.Warehouses.Items.Commands;
+
+public record ReleaseWarehouseItemReservation(string WarehouseId, string Id, string ReservationId) : IRequest
+{
+    public class Handler(IInventoryContext context) : IRequestHandler<ReleaseWarehouseItemReservation>
+    {
+        public async Task Handle(ReleaseWarehouseItemReservation request, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(request.ReservationId))
+            {
+                throw new ArgumentNullException(nameof(request.ReservationId));
+            }
+
+            var item = await context.WarehouseItems
+                .Include(i => i.Reservations)
+                .FirstOrDefaultAsync(i => i.WarehouseId == request.WarehouseId && i.ItemId == request.Id, cancellationToken);
+
+            if (item is null)
+            {
+                throw new Exception();
+            }
+
+            item.ReleaseReservation(request.ReservationId, WarehouseItemReservationStatus.Released);
+
+            await context.SaveChangesAsync(cancellationToken);
+        }
+    }
+}

--- a/src/Inventory/Inventory/Application/Warehouse/Items/Commands/ReserveItems.cs
+++ b/src/Inventory/Inventory/Application/Warehouse/Items/Commands/ReserveItems.cs
@@ -20,7 +20,9 @@ public record ReserveWarehouseItems(string WarehouseId, string Id, int Quantity)
                 throw new ArgumentOutOfRangeException(nameof(request.Quantity));
             }
 
-            var item = await context.WarehouseItems.FirstOrDefaultAsync(i => i.Id == request.Id, cancellationToken);
+            var item = await context.WarehouseItems
+                .Include(i => i.Reservations)
+                .FirstOrDefaultAsync(i => i.Id == request.Id, cancellationToken);
 
             if (item is null) throw new Exception();
 

--- a/src/Inventory/Inventory/Application/Warehouse/Items/Commands/ShipItems.cs
+++ b/src/Inventory/Inventory/Application/Warehouse/Items/Commands/ShipItems.cs
@@ -20,7 +20,9 @@ public record ShipWarehouseItems(string WarehouseId, string Id, int Quantity, bo
                 throw new ArgumentOutOfRangeException(nameof(request.Quantity));
             }
 
-            var item = await context.WarehouseItems.FirstOrDefaultAsync(i => i.WarehouseId == request.WarehouseId && i.ItemId == request.Id, cancellationToken);
+            var item = await context.WarehouseItems
+                .Include(i => i.Reservations)
+                .FirstOrDefaultAsync(i => i.WarehouseId == request.WarehouseId && i.ItemId == request.Id, cancellationToken);
 
             if (item is null) throw new Exception();
 

--- a/src/Inventory/Inventory/Application/Warehouse/Items/Queries/GetItem.cs
+++ b/src/Inventory/Inventory/Application/Warehouse/Items/Queries/GetItem.cs
@@ -17,6 +17,7 @@ public record GetWarehouseItem(string WarehouseId, string Id) : IRequest<Warehou
                 .ThenInclude(x => x.Group)
                 .Include(x => x.Warehouse)
                 .ThenInclude(x => x.Site)
+                .Include(x => x.Reservations)
                 .AsSplitQuery()
                 .AsNoTracking()
                 .FirstOrDefaultAsync(x => x.WarehouseId == request.WarehouseId && x.ItemId == request.Id, cancellationToken);

--- a/src/Inventory/Inventory/Application/Warehouse/Items/Queries/GetItems.cs
+++ b/src/Inventory/Inventory/Application/Warehouse/Items/Queries/GetItems.cs
@@ -64,6 +64,7 @@ public record GetWarehouseItems(int Page = 0, int PageSize = 10, string? Warehou
                 .ThenInclude(x => x.Group)
                 .Include(x => x.Warehouse)
                 .ThenInclude(x => x.Site)
+                .Include(x => x.Reservations)
                 .Skip(request.Page * request.PageSize)
                 .Take(request.PageSize)
                 .ToListAsync(cancellationToken);

--- a/src/Inventory/Inventory/Application/Warehouse/Items/WarehouseItemDto.cs
+++ b/src/Inventory/Inventory/Application/Warehouse/Items/WarehouseItemDto.cs
@@ -1,4 +1,6 @@
-﻿using YourBrand.Inventory.Application.Items;
+﻿using System.Collections.Generic;
+
+using YourBrand.Inventory.Application.Items;
 
 namespace YourBrand.Inventory.Application.Warehouses.Items;
 
@@ -11,4 +13,5 @@ public record WarehouseItemDto(
     int QuantityPicked,
     int QuantityReserved,
     int QuantityAvailable,
-    int QuantityThreshold);
+    int QuantityThreshold,
+    IReadOnlyCollection<WarehouseItemReservationDto> Reservations);

--- a/src/Inventory/Inventory/Application/Warehouse/Items/WarehouseItemReservationDto.cs
+++ b/src/Inventory/Inventory/Application/Warehouse/Items/WarehouseItemReservationDto.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace YourBrand.Inventory.Application.Warehouses.Items;
+
+public record WarehouseItemReservationDto(
+    string Id,
+    int Quantity,
+    int ConsumedQuantity,
+    int ReleasedQuantity,
+    int RemainingQuantity,
+    WarehouseItemReservationStatusDto Status,
+    DateTimeOffset ReservedAt,
+    DateTimeOffset ExpiresAt,
+    DateTimeOffset? ConfirmedAt,
+    DateTimeOffset? ReleasedAt,
+    string? Reference);

--- a/src/Inventory/Inventory/Application/Warehouse/Items/WarehouseItemReservationStatusDto.cs
+++ b/src/Inventory/Inventory/Application/Warehouse/Items/WarehouseItemReservationStatusDto.cs
@@ -1,0 +1,10 @@
+namespace YourBrand.Inventory.Application.Warehouses.Items;
+
+public enum WarehouseItemReservationStatusDto
+{
+    Pending,
+    Confirmed,
+    Completed,
+    Released,
+    Expired
+}

--- a/src/Inventory/Inventory/Application/Warehouse/Items/WarehouseItemsController.cs
+++ b/src/Inventory/Inventory/Application/Warehouse/Items/WarehouseItemsController.cs
@@ -45,9 +45,21 @@ public class WarehouseItemsController(IMediator mediator) : ControllerBase
     }
 
     [HttpPut("{id}/Reserve")]
-    public async Task ReserveItems(string warehouseId, string id, ReserveItemsDto dto, CancellationToken cancellationToken)
+    public async Task<WarehouseItemReservationDto> ReserveItems(string warehouseId, string id, ReserveItemsDto dto, CancellationToken cancellationToken)
     {
-        await mediator.Send(new ReserveWarehouseItems2(warehouseId, id, dto.Quantity), cancellationToken);
+        return await mediator.Send(new CreateWarehouseItemReservation(warehouseId, id, dto.Quantity, dto.HoldDurationMinutes, dto.Reference), cancellationToken);
+    }
+
+    [HttpPut("{id}/Reservations/{reservationId}/Confirm")]
+    public async Task ConfirmReservation(string warehouseId, string id, string reservationId, CancellationToken cancellationToken)
+    {
+        await mediator.Send(new ConfirmWarehouseItemReservation(warehouseId, id, reservationId), cancellationToken);
+    }
+
+    [HttpDelete("{id}/Reservations/{reservationId}")]
+    public async Task ReleaseReservation(string warehouseId, string id, string reservationId, CancellationToken cancellationToken)
+    {
+        await mediator.Send(new ReleaseWarehouseItemReservation(warehouseId, id, reservationId), cancellationToken);
     }
 
     [HttpPut("{id}/Pick")]
@@ -77,7 +89,7 @@ public class WarehouseItemsController(IMediator mediator) : ControllerBase
 
 public record AdjustQuantityOnHandDto(int Quantity);
 
-public record ReserveItemsDto(int Quantity);
+public record ReserveItemsDto(int Quantity, int? HoldDurationMinutes = null, string? Reference = null);
 
 public record PickItemsDto(int Quantity, bool FromReserved = false);
 

--- a/src/Inventory/Inventory/Domain/Entities/WarehouseItemReservation.cs
+++ b/src/Inventory/Inventory/Domain/Entities/WarehouseItemReservation.cs
@@ -1,0 +1,165 @@
+using System;
+
+using YourBrand.Inventory.Domain.Common;
+using YourBrand.Inventory.Domain.Enums;
+
+namespace YourBrand.Inventory.Domain.Entities;
+
+public class WarehouseItemReservation : AuditableEntity<string>
+{
+    private WarehouseItemReservation()
+    {
+    }
+
+    internal WarehouseItemReservation(WarehouseItem warehouseItem, int quantity, DateTimeOffset reservedAt, DateTimeOffset expiresAt, string? reference)
+        : base(Guid.NewGuid().ToString())
+    {
+        WarehouseItem = warehouseItem ?? throw new ArgumentNullException(nameof(warehouseItem));
+        WarehouseItemId = warehouseItem.Id;
+
+        if (quantity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(quantity));
+        }
+
+        Quantity = quantity;
+        ReservedAt = reservedAt;
+        ExpiresAt = expiresAt;
+        Reference = reference;
+        Status = WarehouseItemReservationStatus.Pending;
+    }
+
+    public string WarehouseItemId { get; private set; } = null!;
+
+    public WarehouseItem WarehouseItem { get; private set; } = null!;
+
+    public int Quantity { get; private set; }
+
+    public int ConsumedQuantity { get; private set; }
+
+    public int ReleasedQuantity { get; private set; }
+
+    public WarehouseItemReservationStatus Status { get; private set; }
+
+    public DateTimeOffset ReservedAt { get; private set; }
+
+    public DateTimeOffset ExpiresAt { get; private set; }
+
+    public DateTimeOffset? ConfirmedAt { get; private set; }
+
+    public DateTimeOffset? ReleasedAt { get; private set; }
+
+    public string? Reference { get; private set; }
+
+    public int RemainingQuantity => Quantity - ConsumedQuantity - ReleasedQuantity;
+
+    public bool IsActive => Status is WarehouseItemReservationStatus.Pending or WarehouseItemReservationStatus.Confirmed;
+
+    public void Confirm()
+    {
+        if (Status == WarehouseItemReservationStatus.Confirmed)
+        {
+            return;
+        }
+
+        if (Status != WarehouseItemReservationStatus.Pending)
+        {
+            throw new InvalidOperationException("Only pending reservations can be confirmed.");
+        }
+
+        Status = WarehouseItemReservationStatus.Confirmed;
+        ConfirmedAt = DateTimeOffset.UtcNow;
+    }
+
+    public int Consume(int quantity)
+    {
+        if (quantity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(quantity));
+        }
+
+        if (quantity > RemainingQuantity)
+        {
+            throw new InvalidOperationException("Cannot consume more than the remaining reserved quantity.");
+        }
+
+        ConsumedQuantity += quantity;
+
+        if (RemainingQuantity == 0)
+        {
+            Status = WarehouseItemReservationStatus.Completed;
+        }
+
+        return quantity;
+    }
+
+    public int ReleaseRemaining(WarehouseItemReservationStatus status)
+    {
+        if (status is not WarehouseItemReservationStatus.Released and not WarehouseItemReservationStatus.Expired)
+        {
+            throw new ArgumentOutOfRangeException(nameof(status));
+        }
+
+        if (Status is WarehouseItemReservationStatus.Completed or WarehouseItemReservationStatus.Released or WarehouseItemReservationStatus.Expired)
+        {
+            return 0;
+        }
+
+        var released = RemainingQuantity;
+
+        if (released == 0)
+        {
+            Status = WarehouseItemReservationStatus.Completed;
+            return 0;
+        }
+
+        ReleasedQuantity += released;
+        Status = status;
+        ReleasedAt = DateTimeOffset.UtcNow;
+
+        return released;
+    }
+
+    public int Release(int quantity, WarehouseItemReservationStatus status)
+    {
+        if (status is not WarehouseItemReservationStatus.Released and not WarehouseItemReservationStatus.Expired)
+        {
+            throw new ArgumentOutOfRangeException(nameof(status));
+        }
+
+        if (quantity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(quantity));
+        }
+
+        if (quantity > RemainingQuantity)
+        {
+            throw new InvalidOperationException("Cannot release more than the remaining reserved quantity.");
+        }
+
+        ReleasedQuantity += quantity;
+
+        if (RemainingQuantity == 0)
+        {
+            Status = status;
+            ReleasedAt = DateTimeOffset.UtcNow;
+        }
+
+        return quantity;
+    }
+
+    public void Extend(TimeSpan extension)
+    {
+        if (extension <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(extension));
+        }
+
+        if (Status is WarehouseItemReservationStatus.Released or WarehouseItemReservationStatus.Expired)
+        {
+            throw new InvalidOperationException("Cannot extend a released or expired reservation.");
+        }
+
+        ExpiresAt = ExpiresAt.Add(extension);
+    }
+}

--- a/src/Inventory/Inventory/Domain/Enums/WarehouseItemReservationStatus.cs
+++ b/src/Inventory/Inventory/Domain/Enums/WarehouseItemReservationStatus.cs
@@ -1,0 +1,10 @@
+namespace YourBrand.Inventory.Domain.Enums;
+
+public enum WarehouseItemReservationStatus
+{
+    Pending,
+    Confirmed,
+    Completed,
+    Released,
+    Expired
+}

--- a/src/Inventory/Inventory/Domain/IInventoryContext.cs
+++ b/src/Inventory/Inventory/Domain/IInventoryContext.cs
@@ -9,6 +9,7 @@ public interface IInventoryContext
     DbSet<Site> Sites { get; }
     DbSet<Warehouse> Warehouses { get; }
     DbSet<WarehouseItem> WarehouseItems { get; }
+    DbSet<WarehouseItemReservation> WarehouseItemReservations { get; }
     DbSet<ItemGroup> ItemGroups { get; }
     DbSet<Item> Items { get; }
     DbSet<Supplier> Suppliers { get; }

--- a/src/Inventory/Inventory/Infrastructure/BackgroundJobs/ReleaseExpiredReservationsJob.cs
+++ b/src/Inventory/Inventory/Infrastructure/BackgroundJobs/ReleaseExpiredReservationsJob.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Linq;
+
+using Microsoft.EntityFrameworkCore;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+using Quartz;
+
+using YourBrand.Inventory.Domain.Enums;
+using YourBrand.Inventory.Infrastructure.Persistence;
+
+namespace YourBrand.Inventory.Infrastructure.BackgroundJobs;
+
+public class ReleaseExpiredReservationsJob : IJob
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<ReleaseExpiredReservationsJob> _logger;
+
+    public ReleaseExpiredReservationsJob(IServiceProvider serviceProvider, ILogger<ReleaseExpiredReservationsJob> logger)
+    {
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+    }
+
+    public async Task Execute(IJobExecutionContext context)
+    {
+        using var scope = _serviceProvider.CreateScope();
+
+        var dbContext = scope.ServiceProvider.GetRequiredService<InventoryContext>();
+
+        var now = DateTimeOffset.UtcNow;
+
+        var reservations = await dbContext.WarehouseItemReservations
+            .Include(r => r.WarehouseItem)
+            .ThenInclude(i => i.Reservations)
+            .Where(r => r.Status == WarehouseItemReservationStatus.Pending && r.ExpiresAt <= now)
+            .ToListAsync(context.CancellationToken);
+
+        if (reservations.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var reservation in reservations)
+        {
+            try
+            {
+                reservation.WarehouseItem.ReleaseReservation(reservation.Id, WarehouseItemReservationStatus.Expired);
+            }
+            catch (Exception exc)
+            {
+                _logger.LogError(exc, "Failed to release expired reservation {ReservationId}", reservation.Id);
+            }
+        }
+
+        await dbContext.SaveChangesAsync(context.CancellationToken);
+    }
+}

--- a/src/Inventory/Inventory/Infrastructure/Persistence/Configurations/WarehouseItemConfiguration.cs
+++ b/src/Inventory/Inventory/Infrastructure/Persistence/Configurations/WarehouseItemConfiguration.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 using YourBrand.Inventory.Domain.Entities;
@@ -30,5 +31,13 @@ public class WarehouseItemConfiguration : IEntityTypeConfiguration<WarehouseItem
             .WithMany(warehouse => warehouse.Items)
             .HasForeignKey(w => w.WarehouseId)
             .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasMany(w => w.Reservations)
+            .WithOne(r => r.WarehouseItem)
+            .HasForeignKey(r => r.WarehouseItemId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Navigation(w => w.Reservations)
+            .UsePropertyAccessMode(PropertyAccessMode.Field);
     }
 }

--- a/src/Inventory/Inventory/Infrastructure/Persistence/Configurations/WarehouseItemReservationConfiguration.cs
+++ b/src/Inventory/Inventory/Infrastructure/Persistence/Configurations/WarehouseItemReservationConfiguration.cs
@@ -1,0 +1,41 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using YourBrand.Inventory.Domain.Entities;
+namespace YourBrand.Inventory.Infrastructure.Persistence.Configurations;
+
+public class WarehouseItemReservationConfiguration : IEntityTypeConfiguration<WarehouseItemReservation>
+{
+    public void Configure(EntityTypeBuilder<WarehouseItemReservation> builder)
+    {
+        builder.ToTable("WarehouseItemReservations");
+
+        builder.Property(r => r.Quantity)
+            .IsRequired();
+
+        builder.Property(r => r.ConsumedQuantity)
+            .IsRequired();
+
+        builder.Property(r => r.ReleasedQuantity)
+            .IsRequired();
+
+        builder.Property(r => r.Status)
+            .HasConversion<string>()
+            .HasMaxLength(32)
+            .IsRequired();
+
+        builder.Property(r => r.ReservedAt)
+            .IsRequired();
+
+        builder.Property(r => r.ExpiresAt)
+            .IsRequired();
+
+        builder.Property(r => r.Reference)
+            .HasMaxLength(256);
+
+        builder.HasOne(r => r.WarehouseItem)
+            .WithMany(w => w.Reservations)
+            .HasForeignKey(r => r.WarehouseItemId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/Inventory/Inventory/Infrastructure/Persistence/InventoryContext.cs
+++ b/src/Inventory/Inventory/Infrastructure/Persistence/InventoryContext.cs
@@ -35,6 +35,7 @@ public class InventoryContext(
     public DbSet<Site> Sites { get; set; } = null!;
     public DbSet<Warehouse> Warehouses { get; set; } = null!;
     public DbSet<WarehouseItem> WarehouseItems { get; set; } = null!;
+    public DbSet<WarehouseItemReservation> WarehouseItemReservations { get; set; } = null!;
     public DbSet<ItemGroup> ItemGroups { get; set; } = null!;
 
     public DbSet<Item> Items { get; set; } = null!;

--- a/src/Inventory/Inventory/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Inventory/Inventory/Infrastructure/ServiceCollectionExtensions.cs
@@ -1,3 +1,5 @@
+using System;
+
 using MediatR;
 
 using Quartz;
@@ -42,6 +44,15 @@ public static class ServiceCollectionExtensions
                     .AddTrigger(trigger => trigger.ForJob(jobKey)
                         .WithSimpleSchedule(schedule => schedule
                             .WithIntervalInSeconds(10)
+                            .RepeatForever()));
+
+                var releaseReservationsJobKey = new JobKey(nameof(ReleaseExpiredReservationsJob));
+
+                configure
+                    .AddJob<ReleaseExpiredReservationsJob>(releaseReservationsJobKey)
+                    .AddTrigger(trigger => trigger.ForJob(releaseReservationsJobKey)
+                        .WithSimpleSchedule(schedule => schedule
+                            .WithInterval(TimeSpan.FromMinutes(1))
                             .RepeatForever()));
             });
 


### PR DESCRIPTION
## Summary
- add domain model and persistence for warehouse item reservations with timed expiration and consumption tracking
- expose API commands and DTOs for creating, confirming, and releasing reservations and include them in warehouse item responses
- schedule a Quartz job to automatically expire pending reservations and extend unit coverage for reservation behavior

## Testing
- dotnet test src/Inventory/Inventory.Tests/Inventory.Tests.csproj --no-build --logger "console;verbosity=minimal"

------
https://chatgpt.com/codex/tasks/task_e_690a49068138832f9959901dd70a13ac