### PR TITLE
Add shipment management to inventory service

### DIFF
--- a/src/Inventory/Inventory.Client/OpenAPIs/inventory.yaml
+++ b/src/Inventory/Inventory.Client/OpenAPIs/inventory.yaml
@@ -436,6 +436,295 @@ paths:
       responses:
         200:
           description: ''
+  /v1/Warehouses/{warehouseId}/Shipments:
+    get:
+      tags:
+      - Shipments
+      operationId: Shipments_GetShipments
+      parameters:
+      - name: warehouseId
+        in: path
+        required: true
+        schema:
+          type: string
+        x-position: 1
+      - name: page
+        in: query
+        schema:
+          type: integer
+          format: int32
+          default: 1
+        x-position: 2
+      - name: pageSize
+        in: query
+        schema:
+          type: integer
+          format: int32
+          default: 10
+        x-position: 3
+      - name: orderNo
+        in: query
+        schema:
+          type: string
+          nullable: true
+        x-position: 4
+      - name: searchString
+        in: query
+        schema:
+          type: string
+          nullable: true
+        x-position: 5
+      - name: sortBy
+        in: query
+        schema:
+          type: string
+          nullable: true
+        x-position: 6
+      - name: sortDirection
+        in: query
+        schema:
+          oneOf:
+          - nullable: true
+            oneOf:
+            - $ref: '#/components/schemas/SortDirection'
+        x-position: 7
+      responses:
+        200:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ItemsResultOfShipment'
+    post:
+      tags:
+      - Shipments
+      operationId: Shipments_CreateShipment
+      parameters:
+      - name: warehouseId
+        in: path
+        required: true
+        schema:
+          type: string
+        x-position: 1
+      requestBody:
+        x-name: dto
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateShipment'
+        required: true
+        x-position: 2
+      responses:
+        200:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Shipment'
+  /v1/Warehouses/{warehouseId}/Shipments/{shipmentId}:
+    get:
+      tags:
+      - Shipments
+      operationId: Shipments_GetShipment
+      parameters:
+      - name: warehouseId
+        in: path
+        required: true
+        schema:
+          type: string
+        x-position: 1
+      - name: shipmentId
+        in: path
+        required: true
+        schema:
+          type: string
+        x-position: 2
+      responses:
+        200:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Shipment'
+    put:
+      tags:
+      - Shipments
+      operationId: Shipments_UpdateShipment
+      parameters:
+      - name: warehouseId
+        in: path
+        required: true
+        schema:
+          type: string
+        x-position: 1
+      - name: shipmentId
+        in: path
+        required: true
+        schema:
+          type: string
+        x-position: 2
+      requestBody:
+        x-name: dto
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateShipment'
+        required: true
+        x-position: 3
+      responses:
+        200:
+          description: ''
+    delete:
+      tags:
+      - Shipments
+      operationId: Shipments_DeleteShipment
+      parameters:
+      - name: warehouseId
+        in: path
+        required: true
+        schema:
+          type: string
+        x-position: 1
+      - name: shipmentId
+        in: path
+        required: true
+        schema:
+          type: string
+        x-position: 2
+      responses:
+        200:
+          description: ''
+  /v1/Warehouses/{warehouseId}/Shipments/{shipmentId}/Items:
+    post:
+      tags:
+      - Shipments
+      operationId: Shipments_AddShipmentItem
+      parameters:
+      - name: warehouseId
+        in: path
+        required: true
+        schema:
+          type: string
+        x-position: 1
+      - name: shipmentId
+        in: path
+        required: true
+        schema:
+          type: string
+        x-position: 2
+      requestBody:
+        x-name: dto
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddShipmentItem'
+        required: true
+        x-position: 3
+      responses:
+        200:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ShipmentItem'
+  /v1/Warehouses/{warehouseId}/Shipments/{shipmentId}/Items/{shipmentItemId}:
+    put:
+      tags:
+      - Shipments
+      operationId: Shipments_UpdateShipmentItem
+      parameters:
+      - name: warehouseId
+        in: path
+        required: true
+        schema:
+          type: string
+        x-position: 1
+      - name: shipmentId
+        in: path
+        required: true
+        schema:
+          type: string
+        x-position: 2
+      - name: shipmentItemId
+        in: path
+        required: true
+        schema:
+          type: string
+        x-position: 3
+      requestBody:
+        x-name: dto
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateShipmentItem'
+        required: true
+        x-position: 4
+      responses:
+        200:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ShipmentItem'
+    delete:
+      tags:
+      - Shipments
+      operationId: Shipments_RemoveShipmentItem
+      parameters:
+      - name: warehouseId
+        in: path
+        required: true
+        schema:
+          type: string
+        x-position: 1
+      - name: shipmentId
+        in: path
+        required: true
+        schema:
+          type: string
+        x-position: 2
+      - name: shipmentItemId
+        in: path
+        required: true
+        schema:
+          type: string
+        x-position: 3
+      responses:
+        200:
+          description: ''
+  /v1/Warehouses/{warehouseId}/Shipments/{shipmentId}/Ship:
+    post:
+      tags:
+      - Shipments
+      operationId: Shipments_ShipShipment
+      parameters:
+      - name: warehouseId
+        in: path
+        required: true
+        schema:
+          type: string
+        x-position: 1
+      - name: shipmentId
+        in: path
+        required: true
+        schema:
+          type: string
+        x-position: 2
+      requestBody:
+        x-name: dto
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ShipShipment'
+        required: true
+        x-position: 3
+      responses:
+        200:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Shipment'
   /v1/Sites:
     get:
       tags:
@@ -964,6 +1253,135 @@ components:
         quantityThreshold:
           type: integer
           format: int32
+    ItemsResultOfShipment:
+      type: object
+      additionalProperties: false
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Shipment'
+        totalItems:
+          type: integer
+          format: int32
+    Shipment:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+        orderNo:
+          type: string
+        warehouse:
+          $ref: '#/components/schemas/Warehouse'
+        destination:
+          $ref: '#/components/schemas/ShippingDetails'
+        service:
+          type: string
+        created:
+          type: string
+          format: date-time
+        shippedAt:
+          type: string
+          format: date-time
+          nullable: true
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ShipmentItem'
+    ShipmentItem:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+        warehouseItem:
+          $ref: '#/components/schemas/WarehouseItem'
+        quantity:
+          type: integer
+          format: int32
+        isShipped:
+          type: boolean
+        shippedAt:
+          type: string
+          format: date-time
+          nullable: true
+    ShippingDetails:
+      type: object
+      additionalProperties: false
+      properties:
+        firstName:
+          type: string
+        lastName:
+          type: string
+        careOf:
+          type: string
+          nullable: true
+        address:
+          $ref: '#/components/schemas/Address'
+    Address:
+      type: object
+      additionalProperties: false
+      properties:
+        street:
+          type: string
+        city:
+          type: string
+        postalCode:
+          type: string
+        country:
+          type: string
+        addressLine2:
+          type: string
+          nullable: true
+        stateOrProvince:
+          type: string
+          nullable: true
+        careOf:
+          type: string
+          nullable: true
+    CreateShipment:
+      type: object
+      additionalProperties: false
+      properties:
+        orderNo:
+          type: string
+        destination:
+          $ref: '#/components/schemas/ShippingDetails'
+        service:
+          type: string
+    UpdateShipment:
+      type: object
+      additionalProperties: false
+      properties:
+        destination:
+          $ref: '#/components/schemas/ShippingDetails'
+        service:
+          type: string
+    AddShipmentItem:
+      type: object
+      additionalProperties: false
+      properties:
+        warehouseItemId:
+          type: string
+        quantity:
+          type: integer
+          format: int32
+    UpdateShipmentItem:
+      type: object
+      additionalProperties: false
+      properties:
+        quantity:
+          type: integer
+          format: int32
+    ShipShipment:
+      type: object
+      additionalProperties: false
+      properties:
+        shippedAt:
+          type: string
+          format: date-time
+          nullable: true
     Item:
       type: object
       additionalProperties: false

--- a/src/Inventory/Inventory.Components/WarehouseItemSelector.razor
+++ b/src/Inventory/Inventory.Components/WarehouseItemSelector.razor
@@ -1,0 +1,75 @@
+@using System.Linq
+@using System.Linq.Expressions
+@inject IWarehouseItemsClient WarehouseItemsClient
+
+<MudAutocomplete T="WarehouseItem" Label="@Label" Dense="true" Variant="Variant" Style="@Style" Class="@Class" Value="Value" ValueChanged="ValueChanged"
+    For="For" SearchFunc="SearchWarehouseItems" ToStringFunc="DisplayText"
+    ResetValueOnEmptyText="true" CoerceText="false" CoerceValue="false">
+    <ItemTemplate Context="context">
+        <MudText Typo="Typo.body1">@context.Item.Name</MudText>
+        <MudText Typo="Typo.body2">@context.Warehouse.Name</MudText>
+    </ItemTemplate>
+
+    <ItemSelectedTemplate Context="context">
+        <MudText Typo="Typo.body1">@context.Item.Name</MudText>
+        <MudText Typo="Typo.body2">@context.Warehouse.Name</MudText>
+    </ItemSelectedTemplate>
+</MudAutocomplete>
+
+@code {
+    [Parameter]
+    public string Label { get; set; } = "Warehouse Item";
+
+    [Parameter]
+    public WarehouseItem? Value { get; set; }
+
+    [Parameter]
+    public EventCallback<WarehouseItem?> ValueChanged { get; set; }
+
+    [Parameter]
+    public Expression<Func<WarehouseItem?>>? For { get; set; }
+
+    [Parameter]
+    public string? Style { get; set; }
+
+    [Parameter]
+    public string? Class { get; set; }
+
+    [Parameter]
+    public Variant Variant { get; set; }
+
+    [Parameter]
+    [EditorRequired]
+    public string WarehouseId { get; set; } = default!;
+
+    [Parameter]
+    public bool AllowOnlyAvailable { get; set; }
+
+    private string DisplayText(WarehouseItem item) => $"{item.Item.Name} ({item.QuantityAvailable})";
+
+    private async Task<IEnumerable<WarehouseItem>?> SearchWarehouseItems(string text, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(WarehouseId))
+        {
+            return Array.Empty<WarehouseItem>();
+        }
+
+        try
+        {
+            var result = await WarehouseItemsClient.GetItemsAsync(WarehouseId, 1, 10, null, text, null, null, cancellationToken);
+
+            if (AllowOnlyAvailable)
+            {
+                return result.Items.Where(x => x.QuantityAvailable > 0);
+            }
+
+            return result.Items;
+        }
+        catch (AccessTokenNotAvailableException exception)
+        {
+            exception.Redirect();
+        }
+
+        return Array.Empty<WarehouseItem>();
+    }
+}

--- a/src/Inventory/Inventory.Components/_Imports.razor
+++ b/src/Inventory/Inventory.Components/_Imports.razor
@@ -6,8 +6,8 @@
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web
-@using Microsoft.AspNetCore.Components.WebAssembly.Authentication
 @using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.AspNetCore.Components.WebAssembly.Authentication
 @using Microsoft.JSInterop
 @using MudBlazor
 @using YourBrand.Inventory.Client

--- a/src/Inventory/Inventory.UI/ModuleInitializer.cs
+++ b/src/Inventory/Inventory.UI/ModuleInitializer.cs
@@ -38,6 +38,7 @@ public class ModuleInitializer : IModuleInitializer
 
         group.CreateItem("items", () => resources["Items"], MudBlazor.Icons.Material.Filled.ListAlt, "/inventory/items");
         group.CreateItem("warehouses", () => resources["Warehouses"], MudBlazor.Icons.Material.Filled.ListAlt, "/inventory/warehouses");
+        group.CreateItem("shipments", () => resources["Shipments"], MudBlazor.Icons.Material.Filled.LocalShipping, "/inventory/warehouses/shipments");
         group.CreateItem("sites", () => resources["Sites"], MudBlazor.Icons.Material.Filled.ListAlt, "/inventory/sites");
 
         return Task.CompletedTask;

--- a/src/Inventory/Inventory.UI/Resources.resx
+++ b/src/Inventory/Inventory.UI/Resources.resx
@@ -21,6 +21,9 @@
     <data name="Warehouses">
         <value>Warehouses</value>
     </data>
+    <data name="Shipments">
+        <value>Shipments</value>
+    </data>
     <data name="Sites">
         <value>Sites</value>
     </data>

--- a/src/Inventory/Inventory.UI/Resources.sv.resx
+++ b/src/Inventory/Inventory.UI/Resources.sv.resx
@@ -21,6 +21,9 @@
     <data name="Warehouses">
         <value>Lagerlokaler</value>
     </data>
+    <data name="Shipments">
+        <value>Leveranser</value>
+    </data>
     <data name="Sites">
         <value>Platser</value>
     </data>

--- a/src/Inventory/Inventory.UI/Warehouses/Shipments/ShipmentDialog.razor
+++ b/src/Inventory/Inventory.UI/Warehouses/Shipments/ShipmentDialog.razor
@@ -1,0 +1,239 @@
+@using System.ComponentModel.DataAnnotations
+@inject IShipmentsClient ShipmentsClient
+@inject ISnackbar Snackbar
+
+<EditForm EditContext="@editContext" OnValidSubmit="OnValidSubmit">
+    <DataAnnotationsValidator />
+    <MudDialog>
+        <DialogContent>
+            <MudContainer Style="max-height: 600px; overflow-y: auto;">
+                <MudTextField Label="Order number" Variant="Variant.Outlined" Class="mt-4" @bind-Value="Model.OrderNo" For="() => Model.OrderNo" Disabled="@Model.IsExisting" />
+
+                <MudTextField Label="Service" Variant="Variant.Outlined" Class="mt-4" @bind-Value="Model.Service" For="() => Model.Service" />
+
+                <MudText Typo="Typo.subtitle1" Class="mt-6">Shipping details</MudText>
+
+                <MudGrid Class="mt-2">
+                    <MudItem xs="12" md="6">
+                        <MudTextField Label="First name" Variant="Variant.Outlined" @bind-Value="Model.Destination.FirstName" For="() => Model.Destination.FirstName" />
+                    </MudItem>
+                    <MudItem xs="12" md="6">
+                        <MudTextField Label="Last name" Variant="Variant.Outlined" @bind-Value="Model.Destination.LastName" For="() => Model.Destination.LastName" />
+                    </MudItem>
+                    <MudItem xs="12" md="12">
+                        <MudTextField Label="Care of" Variant="Variant.Outlined" @bind-Value="Model.Destination.CareOf" For="() => Model.Destination.CareOf" />
+                    </MudItem>
+                    <MudItem xs="12" md="12">
+                        <MudTextField Label="Address line 1" Variant="Variant.Outlined" @bind-Value="Model.Destination.Address.Street" For="() => Model.Destination.Address.Street" />
+                    </MudItem>
+                    <MudItem xs="12" md="12">
+                        <MudTextField Label="Address line 2" Variant="Variant.Outlined" @bind-Value="Model.Destination.Address.AddressLine2" For="() => Model.Destination.Address.AddressLine2" />
+                    </MudItem>
+                    <MudItem xs="12" md="6">
+                        <MudTextField Label="Postal code" Variant="Variant.Outlined" @bind-Value="Model.Destination.Address.PostalCode" For="() => Model.Destination.Address.PostalCode" />
+                    </MudItem>
+                    <MudItem xs="12" md="6">
+                        <MudTextField Label="City" Variant="Variant.Outlined" @bind-Value="Model.Destination.Address.City" For="() => Model.Destination.Address.City" />
+                    </MudItem>
+                    <MudItem xs="12" md="6">
+                        <MudTextField Label="State or province" Variant="Variant.Outlined" @bind-Value="Model.Destination.Address.StateOrProvince" For="() => Model.Destination.Address.StateOrProvince" />
+                    </MudItem>
+                    <MudItem xs="12" md="6">
+                        <MudTextField Label="Country" Variant="Variant.Outlined" @bind-Value="Model.Destination.Address.Country" For="() => Model.Destination.Address.Country" />
+                    </MudItem>
+                </MudGrid>
+            </MudContainer>
+        </DialogContent>
+
+        <DialogActions>
+            <MudButton Variant="Variant.Text" Color="Color.Secondary" OnClick="() => Dialog.Cancel()">Cancel</MudButton>
+            <MudButton ButtonType="ButtonType.Submit" Variant="Variant.Text" Color="Color.Primary">
+                @(Model.IsExisting ? "Save" : "Create")
+            </MudButton>
+        </DialogActions>
+    </MudDialog>
+</EditForm>
+
+@code {
+    private readonly ShipmentFormModel Model = new();
+    private EditContext? editContext;
+
+    [CascadingParameter]
+    public IMudDialogInstance Dialog { get; set; } = default!;
+
+    [Parameter]
+    public string WarehouseId { get; set; } = default!;
+
+    [Parameter]
+    public string? ShipmentId { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        editContext = new EditContext(Model);
+
+        if (!string.IsNullOrEmpty(ShipmentId))
+        {
+            Model.IsExisting = true;
+            var shipment = await ShipmentsClient.GetShipmentAsync(WarehouseId, ShipmentId);
+
+            if (shipment is null)
+            {
+                throw new InvalidOperationException("Shipment not found");
+            }
+
+            Model.OrderNo = shipment.OrderNo;
+            Model.Service = shipment.Service;
+            Model.Destination = ShippingDetailsModel.FromDto(shipment.Destination);
+        }
+        else
+        {
+            Model.IsExisting = false;
+        }
+    }
+
+    private async Task OnValidSubmit()
+    {
+        if (string.IsNullOrEmpty(WarehouseId))
+        {
+            return;
+        }
+
+        try
+        {
+            if (Model.IsExisting && ShipmentId is not null)
+            {
+                await ShipmentsClient.UpdateShipmentAsync(WarehouseId, ShipmentId, new UpdateShipment
+                {
+                    Destination = Model.Destination.ToDto(),
+                    Service = Model.Service
+                });
+
+                Dialog.Close(DialogResult.Ok(true));
+            }
+            else
+            {
+                var shipment = await ShipmentsClient.CreateShipmentAsync(WarehouseId, new CreateShipment
+                {
+                    OrderNo = Model.OrderNo,
+                    Service = Model.Service,
+                    Destination = Model.Destination.ToDto()
+                });
+
+                Dialog.Close(DialogResult.Ok(shipment));
+            }
+        }
+        catch (AccessTokenNotAvailableException exception)
+        {
+            exception.Redirect();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+    public class ShipmentFormModel
+    {
+        [Required]
+        public string OrderNo { get; set; } = string.Empty;
+
+        [Required]
+        public string Service { get; set; } = string.Empty;
+
+        [Required]
+        public ShippingDetailsModel Destination { get; set; } = new();
+
+        public bool IsExisting { get; set; }
+    }
+
+    public class ShippingDetailsModel
+    {
+        [Required]
+        public string FirstName { get; set; } = string.Empty;
+
+        [Required]
+        public string LastName { get; set; } = string.Empty;
+
+        public string? CareOf { get; set; }
+
+        [Required]
+        public AddressModel Address { get; set; } = new();
+
+        public ShippingDetails ToDto()
+        {
+            return new ShippingDetails
+            {
+                FirstName = FirstName,
+                LastName = LastName,
+                CareOf = CareOf,
+                Address = Address.ToDto()
+            };
+        }
+
+        public static ShippingDetailsModel FromDto(ShippingDetails? dto)
+        {
+            if (dto is null)
+            {
+                return new ShippingDetailsModel();
+            }
+
+            return new ShippingDetailsModel
+            {
+                FirstName = dto.FirstName,
+                LastName = dto.LastName,
+                CareOf = dto.CareOf,
+                Address = AddressModel.FromDto(dto.Address)
+            };
+        }
+    }
+
+    public class AddressModel
+    {
+        [Required]
+        public string Street { get; set; } = string.Empty;
+
+        public string? AddressLine2 { get; set; }
+
+        [Required]
+        public string PostalCode { get; set; } = string.Empty;
+
+        [Required]
+        public string City { get; set; } = string.Empty;
+
+        public string? StateOrProvince { get; set; }
+
+        [Required]
+        public string Country { get; set; } = string.Empty;
+
+        public Address ToDto()
+        {
+            return new Address
+            {
+                Street = Street,
+                AddressLine2 = AddressLine2,
+                PostalCode = PostalCode,
+                City = City,
+                StateOrProvince = StateOrProvince,
+                Country = Country
+            };
+        }
+
+        public static AddressModel FromDto(Address? dto)
+        {
+            if (dto is null)
+            {
+                return new AddressModel();
+            }
+
+            return new AddressModel
+            {
+                Street = dto.Street,
+                AddressLine2 = dto.AddressLine2,
+                PostalCode = dto.PostalCode,
+                City = dto.City,
+                StateOrProvince = dto.StateOrProvince,
+                Country = dto.Country
+            };
+        }
+    }
+}

--- a/src/Inventory/Inventory.UI/Warehouses/Shipments/ShipmentItemDialog.razor
+++ b/src/Inventory/Inventory.UI/Warehouses/Shipments/ShipmentItemDialog.razor
@@ -1,0 +1,127 @@
+@using System.ComponentModel.DataAnnotations
+@using System.Linq
+@inject IShipmentsClient ShipmentsClient
+@inject ISnackbar Snackbar
+
+<EditForm EditContext="@editContext" OnValidSubmit="OnValidSubmit">
+    <DataAnnotationsValidator />
+    <MudDialog>
+        <DialogContent>
+            <MudContainer Style="max-height: 400px; overflow-y: auto;">
+                @if (IsNew)
+                {
+                    <WarehouseItemSelector Label="Warehouse item" Variant="Variant.Outlined" WarehouseId="WarehouseId" Class="mt-4" @bind-Value="Model.WarehouseItem" For="() => Model.WarehouseItem" AllowOnlyAvailable="true" />
+                }
+
+                <MudNumericField Label="Quantity" Variant="Variant.Outlined" Class="mt-4" @bind-Value="Model.Quantity" For="() => Model.Quantity" Min="1" />
+            </MudContainer>
+        </DialogContent>
+
+        <DialogActions>
+            <MudButton Variant="Variant.Text" Color="Color.Secondary" OnClick="() => Dialog.Cancel()">Cancel</MudButton>
+            <MudButton ButtonType="ButtonType.Submit" Variant="Variant.Text" Color="Color.Primary">
+                @(IsNew ? "Add" : "Save")
+            </MudButton>
+        </DialogActions>
+    </MudDialog>
+</EditForm>
+
+@code {
+    private readonly ShipmentItemFormModel Model = new();
+    private EditContext? editContext;
+
+    [CascadingParameter]
+    public IMudDialogInstance Dialog { get; set; } = default!;
+
+    [Parameter]
+    public string WarehouseId { get; set; } = default!;
+
+    [Parameter]
+    public string ShipmentId { get; set; } = default!;
+
+    [Parameter]
+    public string? ShipmentItemId { get; set; }
+
+    private bool IsNew => string.IsNullOrEmpty(ShipmentItemId);
+
+    protected override async Task OnInitializedAsync()
+    {
+        editContext = new EditContext(Model);
+
+        if (IsNew)
+        {
+            Model.Quantity = 1;
+            return;
+        }
+
+        var shipment = await ShipmentsClient.GetShipmentAsync(WarehouseId, ShipmentId);
+        var item = shipment?.Items?.FirstOrDefault(x => x.Id == ShipmentItemId);
+
+        if (item is null)
+        {
+            throw new InvalidOperationException("Shipment item not found");
+        }
+
+        Model.Quantity = item.Quantity;
+        Model.WarehouseItem = item.WarehouseItem;
+    }
+
+    private async Task OnValidSubmit()
+    {
+        if (IsNew)
+        {
+            if (Model.WarehouseItem is null)
+            {
+                Snackbar.Add("Select a warehouse item", Severity.Error);
+                return;
+            }
+
+            try
+            {
+                await ShipmentsClient.AddShipmentItemAsync(WarehouseId, ShipmentId, new AddShipmentItem
+                {
+                    WarehouseItemId = Model.WarehouseItem.Id,
+                    Quantity = Model.Quantity
+                });
+
+                Dialog.Close(DialogResult.Ok(true));
+            }
+            catch (AccessTokenNotAvailableException exception)
+            {
+                exception.Redirect();
+            }
+            catch (Exception ex)
+            {
+                Snackbar.Add(ex.Message, Severity.Error);
+            }
+        }
+        else if (ShipmentItemId is not null)
+        {
+            try
+            {
+                await ShipmentsClient.UpdateShipmentItemAsync(WarehouseId, ShipmentId, ShipmentItemId, new UpdateShipmentItem
+                {
+                    Quantity = Model.Quantity
+                });
+
+                Dialog.Close(DialogResult.Ok(true));
+            }
+            catch (AccessTokenNotAvailableException exception)
+            {
+                exception.Redirect();
+            }
+            catch (Exception ex)
+            {
+                Snackbar.Add(ex.Message, Severity.Error);
+            }
+        }
+    }
+
+    public class ShipmentItemFormModel
+    {
+        public WarehouseItem? WarehouseItem { get; set; }
+
+        [Range(1, int.MaxValue)]
+        public int Quantity { get; set; } = 1;
+    }
+}

--- a/src/Inventory/Inventory.UI/Warehouses/Shipments/ShipmentItemsDialog.razor
+++ b/src/Inventory/Inventory.UI/Warehouses/Shipments/ShipmentItemsDialog.razor
@@ -1,0 +1,152 @@
+@using System.Linq
+@inject IShipmentsClient ShipmentsClient
+@inject IDialogService DialogService
+@inject ISnackbar Snackbar
+
+<MudDialog>
+    <DialogContent>
+        <MudContainer Style="max-height: 600px; overflow-y: auto;">
+            <MudStack Spacing="2">
+                <MudStack Row AlignItems="AlignItems.Center" Spacing="2">
+                    <MudButton Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Add" Color="Color.Default" Disabled="@Loading"
+                               OnClick="async () => await OnAddItem()">
+                        Add item
+                    </MudButton>
+                </MudStack>
+
+                <MudTable T="ShipmentItem" Dense="true" Hover="true" Bordered="false" Striped="true" Items="Items">
+                    <HeaderContent>
+                        <MudTh>Item</MudTh>
+                        <MudTh>Quantity</MudTh>
+                        <MudTh>Shipped</MudTh>
+                        <MudTh></MudTh>
+                    </HeaderContent>
+                    <RowTemplate Context="item">
+                        <MudTd DataLabel="Item">@item.WarehouseItem?.Item?.Name</MudTd>
+                        <MudTd DataLabel="Quantity">@item.Quantity</MudTd>
+                        <MudTd DataLabel="Shipped">@(item.IsShipped ? item.ShippedAt?.ToLocalTime().ToString("g") : "No")</MudTd>
+                        <MudTd>
+                            <MudIconButton Size="Size.Small" Icon="@Icons.Material.Filled.Edit" OnClick="async () => await OnEditItem(item)" Disabled="@(Loading || item.IsShipped)" />
+                            <MudIconButton Size="Size.Small" Icon="@Icons.Material.Filled.Delete" Color="Color.Error" OnClick="async () => await OnRemoveItem(item)" Disabled="@(Loading || item.IsShipped)" />
+                        </MudTd>
+                    </RowTemplate>
+                </MudTable>
+            </MudStack>
+        </MudContainer>
+    </DialogContent>
+    <DialogActions>
+        <MudButton Variant="Variant.Text" Color="Color.Primary" OnClick="() => Dialog.Close(DialogResult.Ok(true))">Done</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    private bool Loading { get; set; }
+    private IReadOnlyList<ShipmentItem> Items { get; set; } = Array.Empty<ShipmentItem>();
+
+    [CascadingParameter]
+    public IMudDialogInstance Dialog { get; set; } = default!;
+
+    [Parameter]
+    public string WarehouseId { get; set; } = default!;
+
+    [Parameter]
+    public string ShipmentId { get; set; } = default!;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadItems();
+    }
+
+    private async Task LoadItems()
+    {
+        Loading = true;
+        try
+        {
+            var shipment = await ShipmentsClient.GetShipmentAsync(WarehouseId, ShipmentId);
+            IReadOnlyList<ShipmentItem>? shipmentItems = shipment?.Items?.ToList();
+            Items = shipmentItems ?? Array.Empty<ShipmentItem>();
+        }
+        catch (AccessTokenNotAvailableException exception)
+        {
+            exception.Redirect();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+        finally
+        {
+            Loading = false;
+        }
+    }
+
+    private async Task OnAddItem()
+    {
+        var parameters = new DialogParameters
+        {
+            { nameof(ShipmentItemDialog.WarehouseId), WarehouseId },
+            { nameof(ShipmentItemDialog.ShipmentId), ShipmentId }
+        };
+
+        var options = new DialogOptions
+        {
+            MaxWidth = MaxWidth.ExtraLarge
+        };
+
+        var dialog = await DialogService.ShowAsync<ShipmentItemDialog>("Add item", parameters, options);
+        var result = await dialog.Result;
+
+        if (!result.Canceled)
+        {
+            await LoadItems();
+        }
+    }
+
+    private async Task OnEditItem(ShipmentItem item)
+    {
+        var parameters = new DialogParameters
+        {
+            { nameof(ShipmentItemDialog.WarehouseId), WarehouseId },
+            { nameof(ShipmentItemDialog.ShipmentId), ShipmentId },
+            { nameof(ShipmentItemDialog.ShipmentItemId), item.Id }
+        };
+
+        var options = new DialogOptions
+        {
+            MaxWidth = MaxWidth.ExtraLarge
+        };
+
+        var dialog = await DialogService.ShowAsync<ShipmentItemDialog>($"Update {item.WarehouseItem?.Item?.Name}", parameters, options);
+        var result = await dialog.Result;
+
+        if (!result.Canceled)
+        {
+            await LoadItems();
+        }
+    }
+
+    private async Task OnRemoveItem(ShipmentItem item)
+    {
+        bool? confirmed = await DialogService.ShowMessageBox("Remove item", $"Remove {item.WarehouseItem?.Item?.Name} from shipment?", yesText: "Remove", cancelText: "Cancel");
+
+        if (confirmed != true)
+        {
+            return;
+        }
+
+        try
+        {
+            await ShipmentsClient.RemoveShipmentItemAsync(WarehouseId, ShipmentId, item.Id);
+            Snackbar.Add($"Removed {item.WarehouseItem?.Item?.Name}", Severity.Success);
+            await LoadItems();
+        }
+        catch (AccessTokenNotAvailableException exception)
+        {
+            exception.Redirect();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+}

--- a/src/Inventory/Inventory.UI/Warehouses/Shipments/ShipmentsPage.razor
+++ b/src/Inventory/Inventory.UI/Warehouses/Shipments/ShipmentsPage.razor
@@ -1,0 +1,279 @@
+@page "/inventory/warehouses/shipments"
+@attribute [Authorize]
+@inject IShipmentsClient ShipmentsClient
+@inject NavigationManager NavigationManager
+@inject IDialogService DialogService
+@inject ISnackbar Snackbar
+
+<AppPageTitle>Shipments</AppPageTitle>
+
+<MudText Typo="Typo.h3" Class="mb-4">Shipments</MudText>
+
+<MudButton Variant="Variant.Filled" OnClick="async () => await OnShipmentClicked(null)" StartIcon="@Icons.Material.Filled.Add" Color="Color.Default" Class="mb-2 me-2" Disabled="@(!CanEdit)">
+    New shipment
+</MudButton>
+
+<MudPaper Class="pa-4" Elevation="25">
+    <MudTable @ref="table" T="Shipment" Elevation="0" ServerData="LoadData" Dense="false" Hover="true" Bordered="false"
+              Striped="true" OnRowClick="ShipmentOnClick">
+        <ToolBarContent>
+
+            <WarehouseSelector Value="Warehouse" ValueChanged="OnWarehouseChanged" For="() => Warehouse" />
+
+            <MudSpacer />
+
+            <MudTextField T="string" Value="orderNo" ValueChanged="OnOrderNoChanged" Placeholder="Order No" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.ConfirmationNumber" IconSize="Size.Medium" Immediate="true" DebounceInterval="200"></MudTextField>
+
+            <MudTextField T="string" Value="searchString" ValueChanged="@(s => OnSearch(s))" Placeholder="Search" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Immediate="true" DebounceInterval="200"></MudTextField>
+        </ToolBarContent>
+        <HeaderContent>
+            <MudTh><MudTableSortLabel T="Shipment" SortLabel="OrderNo">Order No</MudTableSortLabel></MudTh>
+            <MudTh><MudTableSortLabel T="Shipment" SortLabel="Created">Created</MudTableSortLabel></MudTh>
+            <MudTh><MudTableSortLabel T="Shipment" SortLabel="Destination.FirstName">Recipient</MudTableSortLabel></MudTh>
+            <MudTh><MudTableSortLabel T="Shipment" SortLabel="Service">Service</MudTableSortLabel></MudTh>
+            <MudTh><MudTableSortLabel T="Shipment" SortLabel="ShippedAt">Shipped</MudTableSortLabel></MudTh>
+            <MudTh></MudTh>
+        </HeaderContent>
+        <RowTemplate Context="shipment">
+            <MudTd DataLabel="Order No">@shipment.OrderNo</MudTd>
+            <MudTd DataLabel="Created">@shipment.Created.ToLocalTime().ToString("g")</MudTd>
+            <MudTd DataLabel="Recipient">@GetRecipient(shipment)</MudTd>
+            <MudTd DataLabel="Service">@shipment.Service</MudTd>
+            <MudTd DataLabel="Shipped">@shipment.ShippedAt?.ToLocalTime().ToString("g")</MudTd>
+            <MudTd>
+                <MudIconButton Size="Size.Small" Icon="@Icons.Material.Filled.Inventory2" OnClick="async () => await OnManageItems(shipment)" Disabled="@(!CanEdit)" />
+                <MudIconButton Size="Size.Small" Icon="@Icons.Material.Filled.Edit" OnClick="async () => await OnShipmentClicked(shipment)" Disabled="@(!CanEdit)" />
+                <MudIconButton Size="Size.Small" Icon="@Icons.Material.Filled.LocalShipping" OnClick="async () => await OnShip(shipment)" Disabled="@(shipment.ShippedAt.HasValue || !CanEdit)" />
+                <MudIconButton Size="Size.Small" Icon="@Icons.Material.Filled.Delete" Color="Color.Error" OnClick="async () => await OnDelete(shipment)" Disabled="@(!CanEdit)" />
+            </MudTd>
+        </RowTemplate>
+        <PagerContent>
+            <MudTablePager />
+        </PagerContent>
+    </MudTable>
+</MudPaper>
+
+@code {
+    MudTable<Shipment>? table;
+    string? searchString;
+    string? orderNo;
+
+    public Warehouse? Warehouse { get; set; }
+
+    private bool CanEdit => Warehouse is not null;
+
+    private async Task<TableData<Shipment>> LoadData(TableState state, CancellationToken cancellationToken)
+    {
+        if (Warehouse is null)
+        {
+            return new TableData<Shipment>
+            {
+                Items = Array.Empty<Shipment>(),
+                TotalItems = 0
+            };
+        }
+
+        try
+        {
+            var sortLabel = state.SortDirection == MudBlazor.SortDirection.None ? null : state.SortLabel;
+            var sortDirection = state.SortDirection == MudBlazor.SortDirection.None
+                ? (YourBrand.Inventory.Client.SortDirection?)null
+                : (state.SortDirection == MudBlazor.SortDirection.Ascending
+                    ? YourBrand.Inventory.Client.SortDirection.Asc
+                    : YourBrand.Inventory.Client.SortDirection.Desc);
+
+            var results = await ShipmentsClient.GetShipmentsAsync(Warehouse.Id, state.Page + 1, state.PageSize, orderNo, searchString, sortLabel, sortDirection, cancellationToken);
+            return new TableData<Shipment> { Items = results.Items, TotalItems = results.TotalItems };
+        }
+        catch (AccessTokenNotAvailableException exception)
+        {
+            exception.Redirect();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+
+        return new TableData<Shipment>
+        {
+            Items = Array.Empty<Shipment>(),
+            TotalItems = 0
+        };
+    }
+
+    private async Task ShipmentOnClick(TableRowClickEventArgs<Shipment> ev)
+    {
+        await OnShipmentClicked(ev.Item);
+    }
+
+    private void OnSearch(string text)
+    {
+        searchString = string.IsNullOrWhiteSpace(text) ? null : text;
+        table?.ReloadServerData();
+    }
+
+    private void OnOrderNoChanged(string? value)
+    {
+        orderNo = string.IsNullOrWhiteSpace(value) ? null : value;
+        table?.ReloadServerData();
+    }
+
+    private async Task OnWarehouseChanged(Warehouse warehouse)
+    {
+        Warehouse = warehouse;
+
+        if (table is not null)
+        {
+            await table.ReloadServerData();
+        }
+    }
+
+    private async Task OnShipmentClicked(Shipment? shipment)
+    {
+        if (Warehouse is null)
+        {
+            return;
+        }
+
+        try
+        {
+            var parameters = new DialogParameters
+            {
+                { nameof(ShipmentDialog.WarehouseId), Warehouse.Id },
+                { nameof(ShipmentDialog.ShipmentId), shipment?.Id }
+            };
+
+            var options = new DialogOptions
+            {
+                MaxWidth = MaxWidth.ExtraLarge
+            };
+
+            var dialog = await DialogService.ShowAsync<ShipmentDialog>(shipment is null ? "New Shipment" : $"Edit {shipment.OrderNo}", parameters, options);
+            var result = await dialog.Result;
+
+            if (!result.Canceled && table is not null)
+            {
+                await table.ReloadServerData();
+            }
+        }
+        catch (AccessTokenNotAvailableException exception)
+        {
+            exception.Redirect();
+        }
+    }
+
+    private async Task OnManageItems(Shipment shipment)
+    {
+        if (Warehouse is null)
+        {
+            return;
+        }
+
+        try
+        {
+            var parameters = new DialogParameters
+            {
+                { nameof(ShipmentItemsDialog.WarehouseId), Warehouse.Id },
+                { nameof(ShipmentItemsDialog.ShipmentId), shipment.Id }
+            };
+
+            var options = new DialogOptions
+            {
+                FullWidth = true,
+                MaxWidth = MaxWidth.Large
+            };
+
+            var dialog = await DialogService.ShowAsync<ShipmentItemsDialog>($"Items for {shipment.OrderNo}", parameters, options);
+            var result = await dialog.Result;
+
+            if (!result.Canceled && table is not null)
+            {
+                await table.ReloadServerData();
+            }
+        }
+        catch (AccessTokenNotAvailableException exception)
+        {
+            exception.Redirect();
+        }
+    }
+
+    private async Task OnShip(Shipment shipment)
+    {
+        if (Warehouse is null)
+        {
+            return;
+        }
+
+        bool? confirmed = await DialogService.ShowMessageBox("Ship shipment", $"Mark shipment {shipment.OrderNo} as shipped?", yesText: "Ship", cancelText: "Cancel");
+
+        if (confirmed != true)
+        {
+            return;
+        }
+
+        try
+        {
+            await ShipmentsClient.ShipShipmentAsync(Warehouse.Id, shipment.Id, new ShipShipment { ShippedAt = null });
+            Snackbar.Add($"Shipment {shipment.OrderNo} marked as shipped.", Severity.Success);
+
+            if (table is not null)
+            {
+                await table.ReloadServerData();
+            }
+        }
+        catch (AccessTokenNotAvailableException exception)
+        {
+            exception.Redirect();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+    private async Task OnDelete(Shipment shipment)
+    {
+        if (Warehouse is null)
+        {
+            return;
+        }
+
+        bool? confirmed = await DialogService.ShowMessageBox("Delete shipment", $"Are you sure you want to delete shipment {shipment.OrderNo}?", yesText: "Delete", cancelText: "Cancel");
+
+        if (confirmed != true)
+        {
+            return;
+        }
+
+        try
+        {
+            await ShipmentsClient.DeleteShipmentAsync(Warehouse.Id, shipment.Id);
+            Snackbar.Add($"Shipment {shipment.OrderNo} deleted.", Severity.Success);
+
+            if (table is not null)
+            {
+                await table.ReloadServerData();
+            }
+        }
+        catch (AccessTokenNotAvailableException exception)
+        {
+            exception.Redirect();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+    private static string GetRecipient(Shipment shipment)
+    {
+        if (shipment.Destination is null)
+        {
+            return string.Empty;
+        }
+
+        return string.IsNullOrWhiteSpace(shipment.Destination.CareOf)
+            ? $"{shipment.Destination.FirstName} {shipment.Destination.LastName}"
+            : $"{shipment.Destination.FirstName} {shipment.Destination.LastName} ({shipment.Destination.CareOf})";
+    }
+}

--- a/src/Inventory/Inventory.UI/_Imports.razor
+++ b/src/Inventory/Inventory.UI/_Imports.razor
@@ -6,7 +6,8 @@
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.AspNetCore.Components.Web.Virtualization
-@using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
+@using Microsoft.AspNetCore.Components.WebAssembly.Authentication
 @using Microsoft.JSInterop
 @using MudBlazor
+@using YourBrand.Inventory
 @using YourBrand.Inventory.Client

--- a/src/Inventory/Inventory/Application/Mappings.cs
+++ b/src/Inventory/Inventory/Application/Mappings.cs
@@ -5,6 +5,7 @@ using YourBrand.Inventory.Application.Items.Groups;
 using YourBrand.Inventory.Application.Sites;
 using YourBrand.Inventory.Application.Warehouses;
 using YourBrand.Inventory.Application.Warehouses.Items;
+using YourBrand.Inventory.Application.Warehouses.Shipments;
 using YourBrand.Inventory.Application.Suppliers;
 using YourBrand.Inventory.Domain.Entities;
 
@@ -106,5 +107,28 @@ public static class Mappings
             line.QuantityReceived,
             line.QuantityOutstanding,
             line.ExpectedOn);
+    }
+
+    public static ShipmentDto ToDto(this Shipment shipment)
+    {
+        return new ShipmentDto(
+            shipment.Id,
+            shipment.OrderNo,
+            shipment.Warehouse.ToDto(),
+            shipment.Destination,
+            shipment.Service,
+            shipment.Created,
+            shipment.ShippedAt,
+            shipment.Items.Select(x => x.ToDto()).ToList());
+    }
+
+    public static ShipmentItemDto ToDto(this ShipmentItem shipmentItem)
+    {
+        return new ShipmentItemDto(
+            shipmentItem.Id,
+            shipmentItem.WarehouseItem.ToDto(),
+            shipmentItem.Quantity,
+            shipmentItem.IsShipped,
+            shipmentItem.ShippedAt);
     }
 }

--- a/src/Inventory/Inventory/Application/Mappings.cs
+++ b/src/Inventory/Inventory/Application/Mappings.cs
@@ -8,6 +8,8 @@ using YourBrand.Inventory.Application.Warehouses.Items;
 using YourBrand.Inventory.Application.Warehouses.Shipments;
 using YourBrand.Inventory.Application.Suppliers;
 using YourBrand.Inventory.Domain.Entities;
+using YourBrand.Inventory.Domain.ValueObjects;
+using YourBrand.Domain;
 
 namespace YourBrand.Inventory.Application;
 
@@ -115,7 +117,7 @@ public static class Mappings
             shipment.Id,
             shipment.OrderNo,
             shipment.Warehouse.ToDto(),
-            shipment.Destination,
+            shipment.Destination.ToDto(),
             shipment.Service,
             shipment.Created,
             shipment.ShippedAt,
@@ -130,5 +132,30 @@ public static class Mappings
             shipmentItem.Quantity,
             shipmentItem.IsShipped,
             shipmentItem.ShippedAt);
+    }
+
+    public static ShippingDetailsDto ToDto(this ShippingDetails destination)
+    {
+        return new ShippingDetailsDto(
+            destination.FirstName,
+            destination.LastName,
+            destination.CareOf,
+            destination.Address.ToDto());
+    }
+
+    public static ShippingDetails ToValueObject(this ShippingDetailsDto destination)
+    {
+        if (destination.Address is null)
+        {
+            throw new ArgumentException("Destination address is required.", nameof(destination));
+        }
+
+        return new ShippingDetails
+        {
+            FirstName = destination.FirstName,
+            LastName = destination.LastName,
+            CareOf = destination.CareOf,
+            Address = destination.Address.ToAddress()
+        };
     }
 }

--- a/src/Inventory/Inventory/Application/Warehouse/Shipments/Commands/AddShipmentItem.cs
+++ b/src/Inventory/Inventory/Application/Warehouse/Shipments/Commands/AddShipmentItem.cs
@@ -1,0 +1,58 @@
+using System;
+
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Inventory.Domain;
+
+namespace YourBrand.Inventory.Application.Warehouses.Shipments.Commands;
+
+public record AddShipmentItem(string WarehouseId, string ShipmentId, string WarehouseItemId, int Quantity) : IRequest<ShipmentItemDto>;
+
+public class AddShipmentItemHandler(IInventoryContext context) : IRequestHandler<AddShipmentItem, ShipmentItemDto>
+{
+    public async Task<ShipmentItemDto> Handle(AddShipmentItem request, CancellationToken cancellationToken)
+    {
+        if (request.Quantity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(request.Quantity));
+        }
+
+        var shipment = await context.Shipments
+            .Include(x => x.Items)
+                .ThenInclude(x => x.WarehouseItem)
+                    .ThenInclude(x => x.Item)
+                        .ThenInclude(x => x.Group)
+            .Include(x => x.Items)
+                .ThenInclude(x => x.WarehouseItem)
+                    .ThenInclude(x => x.Warehouse)
+                        .ThenInclude(x => x.Site)
+            .FirstOrDefaultAsync(x => x.Id == request.ShipmentId && x.WarehouseId == request.WarehouseId, cancellationToken)
+            ?? throw new InvalidOperationException("Shipment not found.");
+
+        var warehouseItem = await context.WarehouseItems
+            .Include(x => x.Item)
+                .ThenInclude(x => x.Group)
+            .Include(x => x.Warehouse)
+                .ThenInclude(x => x.Site)
+            .FirstOrDefaultAsync(x => x.Id == request.WarehouseItemId && x.WarehouseId == request.WarehouseId, cancellationToken)
+            ?? throw new InvalidOperationException("Warehouse item not found.");
+
+        var shipmentItem = shipment.AddItem(warehouseItem, request.Quantity);
+
+        await context.SaveChangesAsync(cancellationToken);
+
+        var persisted = await context.ShipmentItems
+            .Include(x => x.WarehouseItem)
+                .ThenInclude(x => x.Item)
+                    .ThenInclude(x => x.Group)
+            .Include(x => x.WarehouseItem)
+                .ThenInclude(x => x.Warehouse)
+                    .ThenInclude(x => x.Site)
+            .AsNoTracking()
+            .FirstAsync(x => x.Id == shipmentItem.Id, cancellationToken);
+
+        return persisted.ToDto();
+    }
+}

--- a/src/Inventory/Inventory/Application/Warehouse/Shipments/Commands/CreateShipment.cs
+++ b/src/Inventory/Inventory/Application/Warehouse/Shipments/Commands/CreateShipment.cs
@@ -1,0 +1,45 @@
+using System;
+
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Inventory.Domain;
+using YourBrand.Inventory.Domain.Entities;
+
+namespace YourBrand.Inventory.Application.Warehouses.Shipments.Commands;
+
+public record CreateShipment(string WarehouseId, string OrderNo, string Destination, string Service) : IRequest<ShipmentDto>;
+
+public class CreateShipmentHandler(IInventoryContext context) : IRequestHandler<CreateShipment, ShipmentDto>
+{
+    public async Task<ShipmentDto> Handle(CreateShipment request, CancellationToken cancellationToken)
+    {
+        var warehouse = await context.Warehouses
+            .Include(x => x.Site)
+            .FirstOrDefaultAsync(x => x.Id == request.WarehouseId, cancellationToken)
+            ?? throw new InvalidOperationException("Warehouse not found.");
+
+        var shipment = new Shipment(warehouse, request.OrderNo, request.Destination, request.Service);
+
+        context.Shipments.Add(shipment);
+
+        await context.SaveChangesAsync(cancellationToken);
+
+        var persisted = await context.Shipments
+            .Include(x => x.Warehouse)
+                .ThenInclude(x => x.Site)
+            .Include(x => x.Items)
+                .ThenInclude(x => x.WarehouseItem)
+                    .ThenInclude(x => x.Item)
+                        .ThenInclude(x => x.Group)
+            .Include(x => x.Items)
+                .ThenInclude(x => x.WarehouseItem)
+                    .ThenInclude(x => x.Warehouse)
+                        .ThenInclude(x => x.Site)
+            .AsNoTracking()
+            .FirstAsync(x => x.Id == shipment.Id, cancellationToken);
+
+        return persisted.ToDto();
+    }
+}

--- a/src/Inventory/Inventory/Application/Warehouse/Shipments/Commands/CreateShipment.cs
+++ b/src/Inventory/Inventory/Application/Warehouse/Shipments/Commands/CreateShipment.cs
@@ -4,23 +4,29 @@ using MediatR;
 
 using Microsoft.EntityFrameworkCore;
 
+using YourBrand.Inventory.Application;
 using YourBrand.Inventory.Domain;
 using YourBrand.Inventory.Domain.Entities;
 
 namespace YourBrand.Inventory.Application.Warehouses.Shipments.Commands;
 
-public record CreateShipment(string WarehouseId, string OrderNo, string Destination, string Service) : IRequest<ShipmentDto>;
+public record CreateShipment(string WarehouseId, string OrderNo, ShippingDetailsDto Destination, string Service) : IRequest<ShipmentDto>;
 
 public class CreateShipmentHandler(IInventoryContext context) : IRequestHandler<CreateShipment, ShipmentDto>
 {
     public async Task<ShipmentDto> Handle(CreateShipment request, CancellationToken cancellationToken)
     {
+        if (request.Destination is null)
+        {
+            throw new ArgumentNullException(nameof(request.Destination));
+        }
+
         var warehouse = await context.Warehouses
             .Include(x => x.Site)
             .FirstOrDefaultAsync(x => x.Id == request.WarehouseId, cancellationToken)
             ?? throw new InvalidOperationException("Warehouse not found.");
 
-        var shipment = new Shipment(warehouse, request.OrderNo, request.Destination, request.Service);
+        var shipment = new Shipment(warehouse, request.OrderNo, request.Destination.ToValueObject(), request.Service);
 
         context.Shipments.Add(shipment);
 

--- a/src/Inventory/Inventory/Application/Warehouse/Shipments/Commands/DeleteShipment.cs
+++ b/src/Inventory/Inventory/Application/Warehouse/Shipments/Commands/DeleteShipment.cs
@@ -1,0 +1,29 @@
+using System;
+
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Inventory.Domain;
+
+namespace YourBrand.Inventory.Application.Warehouses.Shipments.Commands;
+
+public record DeleteShipment(string WarehouseId, string ShipmentId) : IRequest;
+
+public class DeleteShipmentHandler(IInventoryContext context) : IRequestHandler<DeleteShipment>
+{
+    public async Task Handle(DeleteShipment request, CancellationToken cancellationToken)
+    {
+        var shipment = await context.Shipments
+            .Include(x => x.Items)
+                .ThenInclude(x => x.WarehouseItem)
+            .FirstOrDefaultAsync(x => x.Id == request.ShipmentId && x.WarehouseId == request.WarehouseId, cancellationToken)
+            ?? throw new InvalidOperationException("Shipment not found.");
+
+        shipment.Cancel();
+
+        context.Shipments.Remove(shipment);
+
+        await context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Inventory/Inventory/Application/Warehouse/Shipments/Commands/RemoveShipmentItem.cs
+++ b/src/Inventory/Inventory/Application/Warehouse/Shipments/Commands/RemoveShipmentItem.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Linq;
+
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Inventory.Domain;
+
+namespace YourBrand.Inventory.Application.Warehouses.Shipments.Commands;
+
+public record RemoveShipmentItem(string WarehouseId, string ShipmentId, string ShipmentItemId) : IRequest;
+
+public class RemoveShipmentItemHandler(IInventoryContext context) : IRequestHandler<RemoveShipmentItem>
+{
+    public async Task Handle(RemoveShipmentItem request, CancellationToken cancellationToken)
+    {
+        var shipment = await context.Shipments
+            .Include(x => x.Items)
+                .ThenInclude(x => x.WarehouseItem)
+            .FirstOrDefaultAsync(x => x.Id == request.ShipmentId && x.WarehouseId == request.WarehouseId, cancellationToken)
+            ?? throw new InvalidOperationException("Shipment not found.");
+
+        var shipmentItem = shipment.Items.FirstOrDefault(x => x.Id == request.ShipmentItemId)
+            ?? throw new InvalidOperationException("Shipment item not found.");
+
+        shipment.RemoveItem(shipmentItem.Id);
+
+        context.ShipmentItems.Remove(shipmentItem);
+
+        await context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Inventory/Inventory/Application/Warehouse/Shipments/Commands/ShipShipment.cs
+++ b/src/Inventory/Inventory/Application/Warehouse/Shipments/Commands/ShipShipment.cs
@@ -1,0 +1,37 @@
+using System;
+
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Inventory.Domain;
+
+namespace YourBrand.Inventory.Application.Warehouses.Shipments.Commands;
+
+public record ShipShipment(string WarehouseId, string ShipmentId, DateTimeOffset? ShippedAt = null) : IRequest<ShipmentDto>;
+
+public class ShipShipmentHandler(IInventoryContext context) : IRequestHandler<ShipShipment, ShipmentDto>
+{
+    public async Task<ShipmentDto> Handle(ShipShipment request, CancellationToken cancellationToken)
+    {
+        var shipment = await context.Shipments
+            .Include(x => x.Warehouse)
+                .ThenInclude(x => x.Site)
+            .Include(x => x.Items)
+                .ThenInclude(x => x.WarehouseItem)
+                    .ThenInclude(x => x.Item)
+                        .ThenInclude(x => x.Group)
+            .Include(x => x.Items)
+                .ThenInclude(x => x.WarehouseItem)
+                    .ThenInclude(x => x.Warehouse)
+                        .ThenInclude(x => x.Site)
+            .FirstOrDefaultAsync(x => x.Id == request.ShipmentId && x.WarehouseId == request.WarehouseId, cancellationToken)
+            ?? throw new InvalidOperationException("Shipment not found.");
+
+        shipment.Ship(request.ShippedAt);
+
+        await context.SaveChangesAsync(cancellationToken);
+
+        return shipment.ToDto();
+    }
+}

--- a/src/Inventory/Inventory/Application/Warehouse/Shipments/Commands/UpdateShipment.cs
+++ b/src/Inventory/Inventory/Application/Warehouse/Shipments/Commands/UpdateShipment.cs
@@ -1,0 +1,27 @@
+using System;
+
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Inventory.Domain;
+
+namespace YourBrand.Inventory.Application.Warehouses.Shipments.Commands;
+
+public record UpdateShipment(string WarehouseId, string ShipmentId, string Destination, string Service) : IRequest;
+
+public class UpdateShipmentHandler(IInventoryContext context) : IRequestHandler<UpdateShipment>
+{
+    public async Task Handle(UpdateShipment request, CancellationToken cancellationToken)
+    {
+        var shipment = await context.Shipments
+            .Include(x => x.Warehouse)
+            .FirstOrDefaultAsync(x => x.Id == request.ShipmentId && x.WarehouseId == request.WarehouseId, cancellationToken)
+            ?? throw new InvalidOperationException("Shipment not found.");
+
+        shipment.ChangeDestination(request.Destination);
+        shipment.ChangeService(request.Service);
+
+        await context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Inventory/Inventory/Application/Warehouse/Shipments/Commands/UpdateShipment.cs
+++ b/src/Inventory/Inventory/Application/Warehouse/Shipments/Commands/UpdateShipment.cs
@@ -4,22 +4,28 @@ using MediatR;
 
 using Microsoft.EntityFrameworkCore;
 
+using YourBrand.Inventory.Application;
 using YourBrand.Inventory.Domain;
 
 namespace YourBrand.Inventory.Application.Warehouses.Shipments.Commands;
 
-public record UpdateShipment(string WarehouseId, string ShipmentId, string Destination, string Service) : IRequest;
+public record UpdateShipment(string WarehouseId, string ShipmentId, ShippingDetailsDto Destination, string Service) : IRequest;
 
 public class UpdateShipmentHandler(IInventoryContext context) : IRequestHandler<UpdateShipment>
 {
     public async Task Handle(UpdateShipment request, CancellationToken cancellationToken)
     {
+        if (request.Destination is null)
+        {
+            throw new ArgumentNullException(nameof(request.Destination));
+        }
+
         var shipment = await context.Shipments
             .Include(x => x.Warehouse)
             .FirstOrDefaultAsync(x => x.Id == request.ShipmentId && x.WarehouseId == request.WarehouseId, cancellationToken)
             ?? throw new InvalidOperationException("Shipment not found.");
 
-        shipment.ChangeDestination(request.Destination);
+        shipment.ChangeDestination(request.Destination.ToValueObject());
         shipment.ChangeService(request.Service);
 
         await context.SaveChangesAsync(cancellationToken);

--- a/src/Inventory/Inventory/Application/Warehouse/Shipments/Commands/UpdateShipmentItem.cs
+++ b/src/Inventory/Inventory/Application/Warehouse/Shipments/Commands/UpdateShipmentItem.cs
@@ -1,0 +1,44 @@
+using System;
+
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Inventory.Domain;
+
+namespace YourBrand.Inventory.Application.Warehouses.Shipments.Commands;
+
+public record UpdateShipmentItem(string WarehouseId, string ShipmentId, string ShipmentItemId, int Quantity) : IRequest<ShipmentItemDto>;
+
+public class UpdateShipmentItemHandler(IInventoryContext context) : IRequestHandler<UpdateShipmentItem, ShipmentItemDto>
+{
+    public async Task<ShipmentItemDto> Handle(UpdateShipmentItem request, CancellationToken cancellationToken)
+    {
+        if (request.Quantity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(request.Quantity));
+        }
+
+        var shipmentItem = await context.ShipmentItems
+            .Include(x => x.Shipment)
+            .Include(x => x.WarehouseItem)
+                .ThenInclude(x => x.Item)
+                    .ThenInclude(x => x.Group)
+            .Include(x => x.WarehouseItem)
+                .ThenInclude(x => x.Warehouse)
+                    .ThenInclude(x => x.Site)
+            .FirstOrDefaultAsync(x => x.Id == request.ShipmentItemId && x.ShipmentId == request.ShipmentId, cancellationToken)
+            ?? throw new InvalidOperationException("Shipment item not found.");
+
+        if (shipmentItem.Shipment.WarehouseId != request.WarehouseId)
+        {
+            throw new InvalidOperationException("Shipment item does not belong to the specified warehouse.");
+        }
+
+        shipmentItem.ChangeQuantity(request.Quantity);
+
+        await context.SaveChangesAsync(cancellationToken);
+
+        return shipmentItem.ToDto();
+    }
+}

--- a/src/Inventory/Inventory/Application/Warehouse/Shipments/Queries/GetShipment.cs
+++ b/src/Inventory/Inventory/Application/Warehouse/Shipments/Queries/GetShipment.cs
@@ -1,0 +1,31 @@
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Inventory.Domain;
+
+namespace YourBrand.Inventory.Application.Warehouses.Shipments.Queries;
+
+public record GetShipment(string WarehouseId, string ShipmentId) : IRequest<ShipmentDto?>;
+
+public class GetShipmentHandler(IInventoryContext context) : IRequestHandler<GetShipment, ShipmentDto?>
+{
+    public async Task<ShipmentDto?> Handle(GetShipment request, CancellationToken cancellationToken)
+    {
+        var shipment = await context.Shipments
+            .AsNoTracking()
+            .Include(x => x.Warehouse)
+                .ThenInclude(x => x.Site)
+            .Include(x => x.Items)
+                .ThenInclude(x => x.WarehouseItem)
+                    .ThenInclude(x => x.Item)
+                        .ThenInclude(x => x.Group)
+            .Include(x => x.Items)
+                .ThenInclude(x => x.WarehouseItem)
+                    .ThenInclude(x => x.Warehouse)
+                        .ThenInclude(x => x.Site)
+            .FirstOrDefaultAsync(x => x.Id == request.ShipmentId && x.WarehouseId == request.WarehouseId, cancellationToken);
+
+        return shipment?.ToDto();
+    }
+}

--- a/src/Inventory/Inventory/Application/Warehouse/Shipments/Queries/GetShipments.cs
+++ b/src/Inventory/Inventory/Application/Warehouse/Shipments/Queries/GetShipments.cs
@@ -28,7 +28,20 @@ public class GetShipmentsHandler(IInventoryContext context) : IRequestHandler<Ge
 
         if (!string.IsNullOrWhiteSpace(request.SearchString))
         {
-            query = query.Where(x => x.OrderNo.Contains(request.SearchString) || x.Destination.Contains(request.SearchString));
+            var search = request.SearchString;
+
+            query = query.Where(x =>
+                x.OrderNo.Contains(search) ||
+                x.Destination.FirstName.Contains(search) ||
+                x.Destination.LastName.Contains(search) ||
+                (x.Destination.CareOf != null && x.Destination.CareOf.Contains(search)) ||
+                x.Destination.Address.Street.Contains(search) ||
+                (x.Destination.Address.AddressLine2 != null && x.Destination.Address.AddressLine2.Contains(search)) ||
+                x.Destination.Address.City.Contains(search) ||
+                (x.Destination.Address.StateOrProvince != null && x.Destination.Address.StateOrProvince.Contains(search)) ||
+                (x.Destination.Address.CareOf != null && x.Destination.Address.CareOf.Contains(search)) ||
+                x.Destination.Address.PostalCode.Contains(search) ||
+                x.Destination.Address.Country.Contains(search));
         }
 
         var sortDirectionIsDesc = request.SortDirection switch
@@ -42,8 +55,12 @@ public class GetShipmentsHandler(IInventoryContext context) : IRequestHandler<Ge
         {
             "orderNo" when sortDirectionIsDesc => query.OrderByDescending(x => x.OrderNo),
             "orderNo" => query.OrderBy(x => x.OrderNo),
-            "destination" when sortDirectionIsDesc => query.OrderByDescending(x => x.Destination),
-            "destination" => query.OrderBy(x => x.Destination),
+            "destination" when sortDirectionIsDesc => query
+                .OrderByDescending(x => x.Destination.LastName)
+                .ThenByDescending(x => x.Destination.FirstName),
+            "destination" => query
+                .OrderBy(x => x.Destination.LastName)
+                .ThenBy(x => x.Destination.FirstName),
             "shippedAt" when sortDirectionIsDesc => query.OrderByDescending(x => x.ShippedAt),
             "shippedAt" => query.OrderBy(x => x.ShippedAt),
             _ when sortDirectionIsDesc => query.OrderByDescending(x => x.Created),

--- a/src/Inventory/Inventory/Application/Warehouse/Shipments/Queries/GetShipments.cs
+++ b/src/Inventory/Inventory/Application/Warehouse/Shipments/Queries/GetShipments.cs
@@ -1,0 +1,72 @@
+using System.Linq;
+
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Inventory.Application.Common.Models;
+using YourBrand.Inventory.Domain;
+
+using ModelSortDirection = YourBrand.Inventory.Application.Common.Models.SortDirection;
+
+namespace YourBrand.Inventory.Application.Warehouses.Shipments.Queries;
+
+public record GetShipments(int Page, int PageSize, string WarehouseId, string? OrderNo = null, string? SearchString = null, string? SortBy = null, ModelSortDirection? SortDirection = null) : IRequest<ItemsResult<ShipmentDto>>;
+
+public class GetShipmentsHandler(IInventoryContext context) : IRequestHandler<GetShipments, ItemsResult<ShipmentDto>>
+{
+    public async Task<ItemsResult<ShipmentDto>> Handle(GetShipments request, CancellationToken cancellationToken)
+    {
+        var query = context.Shipments
+            .AsNoTracking()
+            .Where(x => x.WarehouseId == request.WarehouseId);
+
+        if (!string.IsNullOrWhiteSpace(request.OrderNo))
+        {
+            query = query.Where(x => x.OrderNo == request.OrderNo);
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.SearchString))
+        {
+            query = query.Where(x => x.OrderNo.Contains(request.SearchString) || x.Destination.Contains(request.SearchString));
+        }
+
+        var sortDirectionIsDesc = request.SortDirection switch
+        {
+            ModelSortDirection.Asc => false,
+            ModelSortDirection.Desc => true,
+            _ => true
+        };
+
+        query = request.SortBy switch
+        {
+            "orderNo" when sortDirectionIsDesc => query.OrderByDescending(x => x.OrderNo),
+            "orderNo" => query.OrderBy(x => x.OrderNo),
+            "destination" when sortDirectionIsDesc => query.OrderByDescending(x => x.Destination),
+            "destination" => query.OrderBy(x => x.Destination),
+            "shippedAt" when sortDirectionIsDesc => query.OrderByDescending(x => x.ShippedAt),
+            "shippedAt" => query.OrderBy(x => x.ShippedAt),
+            _ when sortDirectionIsDesc => query.OrderByDescending(x => x.Created),
+            _ => query.OrderBy(x => x.Created)
+        };
+
+        var total = await query.CountAsync(cancellationToken);
+
+        var shipments = await query
+            .Skip(request.Page * request.PageSize)
+            .Take(request.PageSize)
+            .Include(x => x.Warehouse)
+                .ThenInclude(x => x.Site)
+            .Include(x => x.Items)
+                .ThenInclude(x => x.WarehouseItem)
+                    .ThenInclude(x => x.Item)
+                        .ThenInclude(x => x.Group)
+            .Include(x => x.Items)
+                .ThenInclude(x => x.WarehouseItem)
+                    .ThenInclude(x => x.Warehouse)
+                        .ThenInclude(x => x.Site)
+            .ToListAsync(cancellationToken);
+
+        return new ItemsResult<ShipmentDto>(shipments.Select(x => x.ToDto()), total);
+    }
+}

--- a/src/Inventory/Inventory/Application/Warehouse/Shipments/ShipmentDto.cs
+++ b/src/Inventory/Inventory/Application/Warehouse/Shipments/ShipmentDto.cs
@@ -1,0 +1,33 @@
+using System;
+
+using YourBrand.Inventory.Application.Warehouses;
+using YourBrand.Inventory.Application.Warehouses.Items;
+
+namespace YourBrand.Inventory.Application.Warehouses.Shipments;
+
+public record ShipmentDto(
+    string Id,
+    string OrderNo,
+    WarehouseDto Warehouse,
+    string Destination,
+    string Service,
+    DateTimeOffset Created,
+    DateTimeOffset? ShippedAt,
+    IReadOnlyCollection<ShipmentItemDto> Items);
+
+public record ShipmentItemDto(
+    string Id,
+    WarehouseItemDto WarehouseItem,
+    int Quantity,
+    bool IsShipped,
+    DateTimeOffset? ShippedAt);
+
+public record CreateShipmentDto(string OrderNo, string Destination, string Service);
+
+public record UpdateShipmentDto(string Destination, string Service);
+
+public record AddShipmentItemDto(string WarehouseItemId, int Quantity);
+
+public record UpdateShipmentItemDto(int Quantity);
+
+public record ShipShipmentDto(DateTimeOffset? ShippedAt);

--- a/src/Inventory/Inventory/Application/Warehouse/Shipments/ShipmentDto.cs
+++ b/src/Inventory/Inventory/Application/Warehouse/Shipments/ShipmentDto.cs
@@ -1,5 +1,6 @@
 using System;
 
+using YourBrand.Domain;
 using YourBrand.Inventory.Application.Warehouses;
 using YourBrand.Inventory.Application.Warehouses.Items;
 
@@ -9,7 +10,7 @@ public record ShipmentDto(
     string Id,
     string OrderNo,
     WarehouseDto Warehouse,
-    string Destination,
+    ShippingDetailsDto Destination,
     string Service,
     DateTimeOffset Created,
     DateTimeOffset? ShippedAt,
@@ -22,9 +23,11 @@ public record ShipmentItemDto(
     bool IsShipped,
     DateTimeOffset? ShippedAt);
 
-public record CreateShipmentDto(string OrderNo, string Destination, string Service);
+public record ShippingDetailsDto(string FirstName, string LastName, string? CareOf, AddressDto Address);
 
-public record UpdateShipmentDto(string Destination, string Service);
+public record CreateShipmentDto(string OrderNo, ShippingDetailsDto Destination, string Service);
+
+public record UpdateShipmentDto(ShippingDetailsDto Destination, string Service);
 
 public record AddShipmentItemDto(string WarehouseItemId, int Quantity);
 

--- a/src/Inventory/Inventory/Application/Warehouse/Shipments/ShipmentsController.cs
+++ b/src/Inventory/Inventory/Application/Warehouse/Shipments/ShipmentsController.cs
@@ -1,0 +1,82 @@
+using Asp.Versioning;
+
+using MediatR;
+
+using Microsoft.AspNetCore.Mvc;
+
+using YourBrand.Inventory.Application;
+using YourBrand.Inventory.Application.Common.Models;
+using YourBrand.Inventory.Application.Warehouses.Shipments.Commands;
+using YourBrand.Inventory.Application.Warehouses.Shipments.Queries;
+
+using ModelSortDirection = YourBrand.Inventory.Application.Common.Models.SortDirection;
+
+namespace YourBrand.Inventory.Application.Warehouses.Shipments;
+
+[ApiController]
+[ApiVersion("1")]
+[Route("v{version:apiVersion}/Warehouses/{warehouseId}/Shipments")]
+public class ShipmentsController(IMediator mediator) : ControllerBase
+{
+    [HttpGet]
+    public async Task<ItemsResult<ShipmentDto>> GetShipments(
+        string warehouseId,
+        int page = 1,
+        int pageSize = 10,
+        string? orderNo = null,
+        string? searchString = null,
+        string? sortBy = null,
+        ModelSortDirection? sortDirection = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await mediator.Send(new GetShipments(page - 1, pageSize, warehouseId, orderNo, searchString, sortBy, sortDirection), cancellationToken);
+    }
+
+    [HttpGet("{shipmentId}")]
+    public async Task<ShipmentDto?> GetShipment(string warehouseId, string shipmentId, CancellationToken cancellationToken)
+    {
+        return await mediator.Send(new GetShipment(warehouseId, shipmentId), cancellationToken);
+    }
+
+    [HttpPost]
+    public async Task<ShipmentDto> CreateShipment(string warehouseId, CreateShipmentDto dto, CancellationToken cancellationToken)
+    {
+        return await mediator.Send(new CreateShipment(warehouseId, dto.OrderNo, dto.Destination, dto.Service), cancellationToken);
+    }
+
+    [HttpPut("{shipmentId}")]
+    public async Task UpdateShipment(string warehouseId, string shipmentId, UpdateShipmentDto dto, CancellationToken cancellationToken)
+    {
+        await mediator.Send(new UpdateShipment(warehouseId, shipmentId, dto.Destination, dto.Service), cancellationToken);
+    }
+
+    [HttpDelete("{shipmentId}")]
+    public async Task DeleteShipment(string warehouseId, string shipmentId, CancellationToken cancellationToken)
+    {
+        await mediator.Send(new DeleteShipment(warehouseId, shipmentId), cancellationToken);
+    }
+
+    [HttpPost("{shipmentId}/Items")]
+    public async Task<ShipmentItemDto> AddShipmentItem(string warehouseId, string shipmentId, AddShipmentItemDto dto, CancellationToken cancellationToken)
+    {
+        return await mediator.Send(new AddShipmentItem(warehouseId, shipmentId, dto.WarehouseItemId, dto.Quantity), cancellationToken);
+    }
+
+    [HttpPut("{shipmentId}/Items/{shipmentItemId}")]
+    public async Task<ShipmentItemDto> UpdateShipmentItem(string warehouseId, string shipmentId, string shipmentItemId, UpdateShipmentItemDto dto, CancellationToken cancellationToken)
+    {
+        return await mediator.Send(new UpdateShipmentItem(warehouseId, shipmentId, shipmentItemId, dto.Quantity), cancellationToken);
+    }
+
+    [HttpDelete("{shipmentId}/Items/{shipmentItemId}")]
+    public async Task RemoveShipmentItem(string warehouseId, string shipmentId, string shipmentItemId, CancellationToken cancellationToken)
+    {
+        await mediator.Send(new RemoveShipmentItem(warehouseId, shipmentId, shipmentItemId), cancellationToken);
+    }
+
+    [HttpPost("{shipmentId}/Ship")]
+    public async Task<ShipmentDto> ShipShipment(string warehouseId, string shipmentId, ShipShipmentDto dto, CancellationToken cancellationToken)
+    {
+        return await mediator.Send(new ShipShipment(warehouseId, shipmentId, dto.ShippedAt), cancellationToken);
+    }
+}

--- a/src/Inventory/Inventory/Domain/Entities/Shipment.cs
+++ b/src/Inventory/Inventory/Domain/Entities/Shipment.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using YourBrand.Inventory.Domain.Common;
+
+namespace YourBrand.Inventory.Domain.Entities;
+
+public class Shipment : AuditableEntity<string>
+{
+    private readonly HashSet<ShipmentItem> items = new();
+
+    protected Shipment() { }
+
+    public Shipment(Warehouse warehouse, string orderNo, string destination, string service)
+        : base(Guid.NewGuid().ToString())
+    {
+        Warehouse = warehouse ?? throw new ArgumentNullException(nameof(warehouse));
+        WarehouseId = warehouse.Id;
+
+        SetOrderNo(orderNo);
+        ChangeDestination(destination);
+        ChangeService(service);
+    }
+
+    public string WarehouseId { get; private set; } = null!;
+
+    public Warehouse Warehouse { get; private set; } = null!;
+
+    public string OrderNo { get; private set; } = null!;
+
+    public string Destination { get; private set; } = null!;
+
+    public string Service { get; private set; } = null!;
+
+    public DateTimeOffset? ShippedAt { get; private set; }
+
+    public bool IsShipped => ShippedAt.HasValue;
+
+    public IReadOnlyCollection<ShipmentItem> Items => items;
+
+    public void SetOrderNo(string orderNo)
+    {
+        if (IsShipped)
+        {
+            throw new InvalidOperationException("Cannot modify a shipment that has already been shipped.");
+        }
+
+        if (string.IsNullOrWhiteSpace(orderNo))
+        {
+            throw new ArgumentException("Order number cannot be empty.", nameof(orderNo));
+        }
+
+        OrderNo = orderNo.Trim();
+    }
+
+    public void ChangeDestination(string destination)
+    {
+        if (IsShipped)
+        {
+            throw new InvalidOperationException("Cannot modify a shipment that has already been shipped.");
+        }
+
+        if (string.IsNullOrWhiteSpace(destination))
+        {
+            throw new ArgumentException("Destination cannot be empty.", nameof(destination));
+        }
+
+        Destination = destination.Trim();
+    }
+
+    public void ChangeService(string service)
+    {
+        if (IsShipped)
+        {
+            throw new InvalidOperationException("Cannot modify a shipment that has already been shipped.");
+        }
+
+        if (string.IsNullOrWhiteSpace(service))
+        {
+            throw new ArgumentException("Service cannot be empty.", nameof(service));
+        }
+
+        Service = service.Trim();
+    }
+
+    public ShipmentItem AddItem(WarehouseItem warehouseItem, int quantity)
+    {
+        if (warehouseItem is null)
+        {
+            throw new ArgumentNullException(nameof(warehouseItem));
+        }
+
+        if (warehouseItem.WarehouseId != WarehouseId)
+        {
+            throw new InvalidOperationException("Warehouse item does not belong to the shipment warehouse.");
+        }
+
+        if (IsShipped)
+        {
+            throw new InvalidOperationException("Cannot modify a shipment that has already been shipped.");
+        }
+
+        if (quantity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(quantity));
+        }
+
+        if (items.Any(x => x.WarehouseItemId == warehouseItem.Id))
+        {
+            throw new InvalidOperationException("Item has already been added to the shipment.");
+        }
+
+        var shipmentItem = new ShipmentItem(this, warehouseItem, quantity);
+        items.Add(shipmentItem);
+
+        return shipmentItem;
+    }
+
+    public ShipmentItem GetItem(string shipmentItemId)
+    {
+        var shipmentItem = items.FirstOrDefault(x => x.Id == shipmentItemId);
+
+        if (shipmentItem is null)
+        {
+            throw new InvalidOperationException("Shipment item was not found on this shipment.");
+        }
+
+        return shipmentItem;
+    }
+
+    public void UpdateItemQuantity(string shipmentItemId, int quantity)
+    {
+        if (IsShipped)
+        {
+            throw new InvalidOperationException("Cannot modify a shipment that has already been shipped.");
+        }
+
+        var shipmentItem = GetItem(shipmentItemId);
+        shipmentItem.ChangeQuantity(quantity);
+    }
+
+    public void RemoveItem(string shipmentItemId)
+    {
+        if (IsShipped)
+        {
+            throw new InvalidOperationException("Cannot modify a shipment that has already been shipped.");
+        }
+
+        var shipmentItem = GetItem(shipmentItemId);
+        shipmentItem.Cancel();
+        items.Remove(shipmentItem);
+    }
+
+    public void Ship(DateTimeOffset? shippedAt = null)
+    {
+        if (IsShipped)
+        {
+            throw new InvalidOperationException("Shipment has already been shipped.");
+        }
+
+        if (!items.Any())
+        {
+            throw new InvalidOperationException("Cannot ship an empty shipment.");
+        }
+
+        foreach (var item in items)
+        {
+            item.Ship(shippedAt);
+        }
+
+        ShippedAt = shippedAt ?? DateTimeOffset.UtcNow;
+    }
+
+    public void Cancel()
+    {
+        if (IsShipped)
+        {
+            throw new InvalidOperationException("Cannot cancel a shipment that has already been shipped.");
+        }
+
+        foreach (var item in items.ToList())
+        {
+            item.Cancel();
+            items.Remove(item);
+        }
+    }
+
+}

--- a/src/Inventory/Inventory/Domain/Entities/ShipmentItem.cs
+++ b/src/Inventory/Inventory/Domain/Entities/ShipmentItem.cs
@@ -1,0 +1,105 @@
+using System;
+
+using YourBrand.Inventory.Domain.Common;
+
+namespace YourBrand.Inventory.Domain.Entities;
+
+public class ShipmentItem : AuditableEntity<string>
+{
+    protected ShipmentItem() { }
+
+    internal ShipmentItem(Shipment shipment, WarehouseItem warehouseItem, int quantity)
+        : base(Guid.NewGuid().ToString())
+    {
+        Shipment = shipment ?? throw new ArgumentNullException(nameof(shipment));
+        ShipmentId = shipment.Id;
+
+        WarehouseItem = warehouseItem ?? throw new ArgumentNullException(nameof(warehouseItem));
+        WarehouseItemId = warehouseItem.Id;
+
+        ChangeQuantityInternal(quantity);
+    }
+
+    public string ShipmentId { get; private set; } = null!;
+
+    public Shipment Shipment { get; private set; } = null!;
+
+    public string WarehouseItemId { get; private set; } = null!;
+
+    public WarehouseItem WarehouseItem { get; private set; } = null!;
+
+    public int Quantity { get; private set; }
+
+    public bool IsShipped { get; private set; }
+
+    public DateTimeOffset? ShippedAt { get; private set; }
+
+    public void ChangeQuantity(int quantity)
+    {
+        if (Shipment.IsShipped)
+        {
+            throw new InvalidOperationException("Cannot modify items of a shipment that has already been shipped.");
+        }
+
+        ChangeQuantityInternal(quantity);
+    }
+
+    public void Cancel()
+    {
+        if (IsShipped)
+        {
+            return;
+        }
+
+        if (Quantity > 0)
+        {
+            WarehouseItem.Unpick(Quantity);
+        }
+
+        Quantity = 0;
+    }
+
+    public void Ship(DateTimeOffset? shippedAt = null)
+    {
+        if (IsShipped)
+        {
+            throw new InvalidOperationException("Shipment item has already been shipped.");
+        }
+
+        if (Quantity <= 0)
+        {
+            throw new InvalidOperationException("Cannot ship an item with zero quantity.");
+        }
+
+        WarehouseItem.Ship(Quantity, fromPicked: true);
+
+        IsShipped = true;
+        ShippedAt = shippedAt ?? DateTimeOffset.UtcNow;
+    }
+
+    private void ChangeQuantityInternal(int quantity)
+    {
+        if (quantity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(quantity));
+        }
+
+        if (Quantity == quantity)
+        {
+            return;
+        }
+
+        if (quantity > Quantity)
+        {
+            var diff = quantity - Quantity;
+            WarehouseItem.Pick(diff);
+        }
+        else
+        {
+            var diff = Quantity - quantity;
+            WarehouseItem.Unpick(diff);
+        }
+
+        Quantity = quantity;
+    }
+}

--- a/src/Inventory/Inventory/Domain/IInventoryContext.cs
+++ b/src/Inventory/Inventory/Domain/IInventoryContext.cs
@@ -15,6 +15,8 @@ public interface IInventoryContext
     DbSet<SupplierItem> SupplierItems { get; }
     DbSet<SupplierOrder> SupplierOrders { get; }
     DbSet<SupplierOrderLine> SupplierOrderLines { get; }
+    DbSet<Shipment> Shipments { get; }
+    DbSet<ShipmentItem> ShipmentItems { get; }
 
     Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Inventory/Inventory/Domain/ValueObjects/ShippingDetails.cs
+++ b/src/Inventory/Inventory/Domain/ValueObjects/ShippingDetails.cs
@@ -1,0 +1,25 @@
+using YourBrand.Domain;
+
+namespace YourBrand.Inventory.Domain.ValueObjects;
+
+public class ShippingDetails
+{
+    public string FirstName { get; set; } = null!;
+
+    public string LastName { get; set; } = null!;
+
+    public string? CareOf { get; set; }
+
+    public Address Address { get; set; } = new();
+
+    public ShippingDetails Copy()
+    {
+        return new ShippingDetails
+        {
+            FirstName = FirstName,
+            LastName = LastName,
+            CareOf = CareOf,
+            Address = Address.Copy()
+        };
+    }
+}

--- a/src/Inventory/Inventory/Infrastructure/Persistence/Configurations/ShipmentConfiguration.cs
+++ b/src/Inventory/Inventory/Infrastructure/Persistence/Configurations/ShipmentConfiguration.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using YourBrand.Inventory.Domain.Entities;
+
+namespace YourBrand.Inventory.Infrastructure.Persistence.Configurations;
+
+public class ShipmentConfiguration : IEntityTypeConfiguration<Shipment>
+{
+    public void Configure(EntityTypeBuilder<Shipment> builder)
+    {
+        builder.ToTable("Shipments");
+
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.OrderNo)
+            .IsRequired()
+            .HasMaxLength(64);
+
+        builder.Property(x => x.Destination)
+            .IsRequired()
+            .HasMaxLength(256);
+
+        builder.Property(x => x.Service)
+            .IsRequired()
+            .HasMaxLength(64);
+
+        builder.HasOne(x => x.Warehouse)
+            .WithMany()
+            .HasForeignKey(x => x.WarehouseId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasMany(x => x.Items)
+            .WithOne(x => x.Shipment)
+            .HasForeignKey(x => x.ShipmentId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/Inventory/Inventory/Infrastructure/Persistence/Configurations/ShipmentConfiguration.cs
+++ b/src/Inventory/Inventory/Infrastructure/Persistence/Configurations/ShipmentConfiguration.cs
@@ -17,9 +17,49 @@ public class ShipmentConfiguration : IEntityTypeConfiguration<Shipment>
             .IsRequired()
             .HasMaxLength(64);
 
-        builder.Property(x => x.Destination)
-            .IsRequired()
-            .HasMaxLength(256);
+        builder.OwnsOne(x => x.Destination, destination =>
+        {
+            destination.Property(x => x.FirstName)
+                .IsRequired()
+                .HasMaxLength(128);
+
+            destination.Property(x => x.LastName)
+                .IsRequired()
+                .HasMaxLength(128);
+
+            destination.Property(x => x.CareOf)
+                .HasMaxLength(128);
+
+            destination.OwnsOne(x => x.Address, address =>
+            {
+                address.Property(x => x.Street)
+                    .IsRequired()
+                    .HasMaxLength(256);
+
+                address.Property(x => x.AddressLine2)
+                    .HasMaxLength(256);
+
+                address.Property(x => x.City)
+                    .IsRequired()
+                    .HasMaxLength(128);
+
+                address.Property(x => x.StateOrProvince)
+                    .HasMaxLength(128);
+
+                address.Property(x => x.PostalCode)
+                    .IsRequired()
+                    .HasMaxLength(32);
+
+                address.Property(x => x.Country)
+                    .IsRequired()
+                    .HasMaxLength(128);
+
+                address.Property(x => x.CareOf)
+                    .HasMaxLength(128);
+            });
+        });
+
+        builder.Navigation(x => x.Destination).IsRequired();
 
         builder.Property(x => x.Service)
             .IsRequired()

--- a/src/Inventory/Inventory/Infrastructure/Persistence/Configurations/ShipmentItemConfiguration.cs
+++ b/src/Inventory/Inventory/Infrastructure/Persistence/Configurations/ShipmentItemConfiguration.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using YourBrand.Inventory.Domain.Entities;
+
+namespace YourBrand.Inventory.Infrastructure.Persistence.Configurations;
+
+public class ShipmentItemConfiguration : IEntityTypeConfiguration<ShipmentItem>
+{
+    public void Configure(EntityTypeBuilder<ShipmentItem> builder)
+    {
+        builder.ToTable("ShipmentItems");
+
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.Quantity)
+            .IsRequired();
+
+        builder.HasIndex(x => new { x.ShipmentId, x.WarehouseItemId })
+            .IsUnique();
+
+        builder.HasOne(x => x.Shipment)
+            .WithMany(x => x.Items)
+            .HasForeignKey(x => x.ShipmentId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(x => x.WarehouseItem)
+            .WithMany()
+            .HasForeignKey(x => x.WarehouseItemId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/Inventory/Inventory/Infrastructure/Persistence/InventoryContext.cs
+++ b/src/Inventory/Inventory/Infrastructure/Persistence/InventoryContext.cs
@@ -47,6 +47,10 @@ public class InventoryContext(
 
     public DbSet<SupplierOrderLine> SupplierOrderLines { get; set; } = null!;
 
+    public DbSet<Shipment> Shipments { get; set; } = null!;
+
+    public DbSet<ShipmentItem> ShipmentItems { get; set; } = null!;
+
     public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
     {
         var entities = ChangeTracker

--- a/src/Inventory/Inventory/Inventory.csproj
+++ b/src/Inventory/Inventory/Inventory.csproj
@@ -47,5 +47,6 @@
     <ProjectReference Include="..\..\Common\Identity.EFCore\Identity.EFCore.csproj" />
     <ProjectReference Include="..\..\Common\Organizations.EFCore\Organizations.EFCore.csproj" />
     <ProjectReference Include="..\..\Common\Domain.Auditability.Abstractions\Domain.Auditability.Abstractions.csproj" />
-	</ItemGroup>
+    <ProjectReference Include="..\..\Common\Domain.Addresses\Domain.Addresses.csproj" />
+        </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- introduce Shipment and ShipmentItem domain entities to manage shipment lifecycle and inventory adjustments
- configure persistence and mappings for shipments and expose DTOs for clients
- add application handlers and API endpoints to create shipments, manage shipment items, and complete shipment fulfillment

## Testing
- dotnet build src/Inventory/Inventory/Inventory.csproj

------
https://chatgpt.com/codex/tasks/task_e_690a4e62d23c832fae28c87d9fb5101b