### PR TITLE
Add transfer orders for warehouse inventory movements

### DIFF
--- a/src/Inventory/Inventory.Client/OpenAPIs/inventory.yaml
+++ b/src/Inventory/Inventory.Client/OpenAPIs/inventory.yaml
@@ -725,6 +725,130 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Shipment'
+  /v1/TransferOrders:
+    get:
+      tags:
+      - TransferOrders
+      operationId: TransferOrders_GetTransferOrders
+      parameters:
+      - name: page
+        in: query
+        schema:
+          type: integer
+          format: int32
+          default: 1
+        x-position: 1
+      - name: pageSize
+        in: query
+        schema:
+          type: integer
+          format: int32
+          default: 10
+        x-position: 2
+      - name: sourceWarehouseId
+        in: query
+        schema:
+          type: string
+          nullable: true
+        x-position: 3
+      - name: destinationWarehouseId
+        in: query
+        schema:
+          type: string
+          nullable: true
+        x-position: 4
+      - name: searchString
+        in: query
+        schema:
+          type: string
+          nullable: true
+        x-position: 5
+      - name: sortBy
+        in: query
+        schema:
+          type: string
+          nullable: true
+        x-position: 6
+      - name: sortDirection
+        in: query
+        schema:
+          oneOf:
+          - nullable: true
+            oneOf:
+            - $ref: '#/components/schemas/SortDirection'
+        x-position: 7
+      responses:
+        200:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ItemsResultOfTransferOrder'
+    post:
+      tags:
+      - TransferOrders
+      operationId: TransferOrders_CreateTransferOrder
+      requestBody:
+        x-name: dto
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateTransferOrder'
+        required: true
+        x-position: 1
+      responses:
+        200:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransferOrder'
+  /v1/TransferOrders/{id}:
+    get:
+      tags:
+      - TransferOrders
+      operationId: TransferOrders_GetTransferOrder
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        x-position: 1
+      responses:
+        200:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransferOrder'
+  /v1/TransferOrders/{id}/Complete:
+    post:
+      tags:
+      - TransferOrders
+      operationId: TransferOrders_CompleteTransferOrder
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        x-position: 1
+      requestBody:
+        x-name: dto
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CompleteTransferOrder'
+        required: true
+        x-position: 2
+      responses:
+        200:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TransferOrder'
   /v1/Sites:
     get:
       tags:
@@ -1264,6 +1388,17 @@ components:
         totalItems:
           type: integer
           format: int32
+    ItemsResultOfTransferOrder:
+      type: object
+      additionalProperties: false
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/TransferOrder'
+        totalItems:
+          type: integer
+          format: int32
     Shipment:
       type: object
       additionalProperties: false
@@ -1306,6 +1441,40 @@ components:
           type: string
           format: date-time
           nullable: true
+    TransferOrder:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+        sourceWarehouse:
+          $ref: '#/components/schemas/Warehouse'
+        destinationWarehouse:
+          $ref: '#/components/schemas/Warehouse'
+        created:
+          type: string
+          format: date-time
+        completedAt:
+          type: string
+          format: date-time
+          nullable: true
+        isCompleted:
+          type: boolean
+        lines:
+          type: array
+          items:
+            $ref: '#/components/schemas/TransferOrderLine'
+    TransferOrderLine:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+        item:
+          $ref: '#/components/schemas/Item'
+        quantity:
+          type: integer
+          format: int32
     ShippingDetails:
       type: object
       additionalProperties: false
@@ -1379,6 +1548,35 @@ components:
       additionalProperties: false
       properties:
         shippedAt:
+          type: string
+          format: date-time
+          nullable: true
+    CreateTransferOrder:
+      type: object
+      additionalProperties: false
+      properties:
+        sourceWarehouseId:
+          type: string
+        destinationWarehouseId:
+          type: string
+        lines:
+          type: array
+          items:
+            $ref: '#/components/schemas/CreateTransferOrderLine'
+    CreateTransferOrderLine:
+      type: object
+      additionalProperties: false
+      properties:
+        itemId:
+          type: string
+        quantity:
+          type: integer
+          format: int32
+    CompleteTransferOrder:
+      type: object
+      additionalProperties: false
+      properties:
+        completedAt:
           type: string
           format: date-time
           nullable: true

--- a/src/Inventory/Inventory.Client/OpenAPIs/inventory.yaml
+++ b/src/Inventory/Inventory.Client/OpenAPIs/inventory.yaml
@@ -133,6 +133,127 @@ paths:
       responses:
         200:
           description: ''
+  /v1/Companies:
+    get:
+      tags:
+      - Companies
+      operationId: Companies_GetCompanies
+      parameters:
+      - name: page
+        in: query
+        schema:
+          type: integer
+          format: int32
+          default: 1
+        x-position: 1
+      - name: pageSize
+        in: query
+        schema:
+          type: integer
+          format: int32
+          default: 10
+        x-position: 2
+      - name: searchString
+        in: query
+        schema:
+          type: string
+          nullable: true
+        x-position: 3
+      - name: sortBy
+        in: query
+        schema:
+          type: string
+          nullable: true
+        x-position: 4
+      - name: sortDirection
+        in: query
+        schema:
+          oneOf:
+          - nullable: true
+            oneOf:
+            - $ref: '#/components/schemas/SortDirection'
+        x-position: 5
+      responses:
+        200:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ItemsResultOfCompany'
+    post:
+      tags:
+      - Companies
+      operationId: Companies_CreateCompany
+      requestBody:
+        x-name: dto
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCompany'
+        required: true
+        x-position: 1
+      responses:
+        200:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Company'
+  /v1/Companies/{id}:
+    get:
+      tags:
+      - Companies
+      operationId: Companies_GetCompany
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        x-position: 1
+      responses:
+        200:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Company'
+    put:
+      tags:
+      - Companies
+      operationId: Companies_UpdateCompany
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        x-position: 1
+      requestBody:
+        x-name: dto
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateCompany'
+        required: true
+        x-position: 2
+      responses:
+        200:
+          description: ''
+    delete:
+      tags:
+      - Companies
+      operationId: Companies_DeleteCompany
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        x-position: 1
+      responses:
+        200:
+          description: ''
   /v1/Warehouses/{warehouseId}/Items:
     get:
       tags:
@@ -1296,6 +1417,17 @@ components:
         totalItems:
           type: integer
           format: int32
+    ItemsResultOfCompany:
+      type: object
+      additionalProperties: false
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Company'
+        totalItems:
+          type: integer
+          format: int32
     Warehouse:
       type: object
       additionalProperties: false
@@ -1306,6 +1438,8 @@ components:
           type: string
         site:
           $ref: '#/components/schemas/Site'
+        company:
+          $ref: '#/components/schemas/Company'
     Site:
       type: object
       additionalProperties: false
@@ -1314,6 +1448,19 @@ components:
           type: string
         name:
           type: string
+    Company:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        currency:
+          type: string
+        totalStockValue:
+          type: number
+          format: double
     SortDirection:
       type: string
       description: ''
@@ -1331,6 +1478,8 @@ components:
           type: string
         siteId:
           type: string
+        companyId:
+          type: string
     UpdateWarehouse:
       type: object
       additionalProperties: false
@@ -1338,6 +1487,24 @@ components:
         name:
           type: string
         siteId:
+          type: string
+        companyId:
+          type: string
+    CreateCompany:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+        currency:
+          type: string
+    UpdateCompany:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+        currency:
           type: string
     ItemsResultOfWarehouseItem:
       type: object
@@ -1377,6 +1544,12 @@ components:
         quantityThreshold:
           type: integer
           format: int32
+        unitCost:
+          type: number
+          format: double
+        stockValue:
+          type: number
+          format: double
     ItemsResultOfShipment:
       type: object
       additionalProperties: false
@@ -1636,6 +1809,9 @@ components:
         quantityThreshold:
           type: integer
           format: int32
+        unitCost:
+          type: number
+          format: double
     UpdateWarehouseItem:
       type: object
       additionalProperties: false
@@ -1681,6 +1857,9 @@ components:
         quantity:
           type: integer
           format: int32
+        unitCost:
+          type: number
+          format: double
     ItemsResultOfSite:
       type: object
       additionalProperties: false
@@ -1700,6 +1879,8 @@ components:
           type: string
         createWarehouse:
           type: boolean
+        companyId:
+          type: string
     UpdateSite:
       type: object
       additionalProperties: false

--- a/src/Inventory/Inventory.UI/ModuleInitializer.cs
+++ b/src/Inventory/Inventory.UI/ModuleInitializer.cs
@@ -39,6 +39,7 @@ public class ModuleInitializer : IModuleInitializer
         group.CreateItem("items", () => resources["Items"], MudBlazor.Icons.Material.Filled.ListAlt, "/inventory/items");
         group.CreateItem("warehouses", () => resources["Warehouses"], MudBlazor.Icons.Material.Filled.ListAlt, "/inventory/warehouses");
         group.CreateItem("shipments", () => resources["Shipments"], MudBlazor.Icons.Material.Filled.LocalShipping, "/inventory/shipments");
+        group.CreateItem("transfer-orders", () => resources["TransferOrders"], MudBlazor.Icons.Material.Filled.CompareArrows, "/inventory/transfer-orders");
         group.CreateItem("sites", () => resources["Sites"], MudBlazor.Icons.Material.Filled.ListAlt, "/inventory/sites");
 
         return Task.CompletedTask;

--- a/src/Inventory/Inventory.UI/Resources.resx
+++ b/src/Inventory/Inventory.UI/Resources.resx
@@ -24,6 +24,9 @@
     <data name="Shipments">
         <value>Shipments</value>
     </data>
+    <data name="TransferOrders">
+        <value>Transfer orders</value>
+    </data>
     <data name="Sites">
         <value>Sites</value>
     </data>

--- a/src/Inventory/Inventory.UI/Resources.sv.resx
+++ b/src/Inventory/Inventory.UI/Resources.sv.resx
@@ -24,6 +24,9 @@
     <data name="Shipments">
         <value>Leveranser</value>
     </data>
+    <data name="TransferOrders">
+        <value>Interna överföringar</value>
+    </data>
     <data name="Sites">
         <value>Platser</value>
     </data>

--- a/src/Inventory/Inventory.UI/Sites/SiteDialog.razor
+++ b/src/Inventory/Inventory.UI/Sites/SiteDialog.razor
@@ -9,10 +9,15 @@
             <MudContainer Style="max-height: 500px; overflow-y: scroll">
                 <MudTextField Label="Name" Variant="Variant.Outlined" Class="mt-4" @bind-Value="Name"
                               For="@(() => Name)" />
-                @if(SiteId is null) 
+                @if(SiteId is null)
                 {
                     <MudCheckBox Label="Create warehouse" Variant="Variant.Outlined" Class="mt-4" @bind-Value="CreateWarehouse"
                                 For="@(() => CreateWarehouse)" />
+
+                    @if(CreateWarehouse)
+                    {
+                        <CompanySelector Label="Company" Class="mt-4" Variant="Variant.Outlined" @bind-Value="Company" For="() => Company" />
+                    }
                 }
             </MudContainer>
         </DialogContent>
@@ -49,24 +54,41 @@
 
     public bool CreateWarehouse { get; set; }
 
+    [Required]
+    public Company Company { get; set; } = null!;
+
     protected override async Task OnInitializedAsync()
     {
-        context = new EditContext(this);
-
-        if (SiteId is not null) 
+        if (SiteId is not null)
         {
             var site = await SitesClient.GetSiteAsync(SiteId);
             Name = site.Name;
+            Company = new Company
+            {
+                Id = string.Empty,
+                Name = string.Empty,
+                Currency = string.Empty,
+                TotalStockValue = 0d
+            };
         }
+
+        context = new EditContext(this);
     }
 
     public async Task OnValidSubmit()
     {
-        if(SiteId is null) 
+        if(SiteId is null)
         {
+            if(CreateWarehouse && Company is null)
+            {
+                Snackbar.Add("Please select a company to create the warehouse.", Severity.Error);
+                return;
+            }
+
             await SitesClient.CreateSiteAsync(new CreateSite {
                 Name = Name,
-                CreateWarehouse = CreateWarehouse
+                CreateWarehouse = CreateWarehouse,
+                CompanyId = CreateWarehouse ? Company.Id : null
             });
 
             //Dialog.Close(site);

--- a/src/Inventory/Inventory.UI/TransferOrders/TransferOrderDialog.razor
+++ b/src/Inventory/Inventory.UI/TransferOrders/TransferOrderDialog.razor
@@ -1,0 +1,150 @@
+@using System.Linq
+@inject ITransferOrdersClient TransferOrdersClient
+@inject ISnackbar Snackbar
+
+<MudDialog>
+    <DialogContent>
+        <MudStack Spacing="2">
+            <WarehouseSelector Label="Source warehouse" Value="SourceWarehouse" ValueChanged="OnSourceWarehouseChanged" For="() => SourceWarehouse" />
+            <WarehouseSelector Label="Destination warehouse" Value="DestinationWarehouse" ValueChanged="OnDestinationWarehouseChanged" For="() => DestinationWarehouse" />
+
+            @if (SourceWarehouse is not null && DestinationWarehouse is not null && SourceWarehouse.Id == DestinationWarehouse.Id)
+            {
+                <MudAlert Severity="Severity.Warning">Source and destination warehouses must be different.</MudAlert>
+            }
+
+            <MudDivider Class="my-2" />
+
+            <MudButton Variant="Variant.Outlined" StartIcon="@Icons.Material.Filled.Add" OnClick="AddLine" Disabled="@(SourceWarehouse is null)">
+                Add item
+            </MudButton>
+
+            <MudTable Items="Lines" Hover="true" Bordered="false" Dense="true">
+                <HeaderContent>
+                    <MudTh>Item</MudTh>
+                    <MudTh>Quantity</MudTh>
+                    <MudTh></MudTh>
+                </HeaderContent>
+                <RowTemplate Context="line">
+                    <MudTd>
+                        <ItemSelector Value="line.Item" ValueChanged="item => OnItemChanged(line, item)" WarehouseId="SourceWarehouse?.Id" Class="w-100" />
+                    </MudTd>
+                    <MudTd>
+                        <MudNumericField T="int" Min="1" Value="line.Quantity" ValueChanged="quantity => OnQuantityChanged(line, quantity)" Immediate="true" Class="w-100" />
+                    </MudTd>
+                    <MudTd Align="Align.Right">
+                        <MudIconButton Size="Size.Small" Icon="@Icons.Material.Filled.Delete" Color="Color.Error" OnClick="() => RemoveLine(line)" />
+                    </MudTd>
+                </RowTemplate>
+                <NoRecordsContent>
+                    <MudText Typo="Typo.caption">Select a source warehouse and add at least one item.</MudText>
+                </NoRecordsContent>
+            </MudTable>
+        </MudStack>
+    </DialogContent>
+    <DialogActions>
+        <MudButton Variant="Variant.Text" Color="Color.Secondary" OnClick="Cancel">Cancel</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@(!CanSave)" OnClick="Save">Create</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter]
+    public IMudDialogInstance Dialog { get; set; } = null!;
+
+    private Warehouse? SourceWarehouse { get; set; }
+    private Warehouse? DestinationWarehouse { get; set; }
+    private readonly List<TransferOrderLineModel> Lines = new();
+
+    private bool CanSave => SourceWarehouse is not null
+        && DestinationWarehouse is not null
+        && SourceWarehouse.Id != DestinationWarehouse.Id
+        && Lines.Count > 0
+        && Lines.All(x => x.Item is not null && x.Quantity > 0);
+
+    private void AddLine()
+    {
+        Lines.Add(new TransferOrderLineModel());
+    }
+
+    private void RemoveLine(TransferOrderLineModel line)
+    {
+        Lines.Remove(line);
+    }
+
+    private void OnItemChanged(TransferOrderLineModel line, Item? item)
+    {
+        line.Item = item;
+    }
+
+    private void OnQuantityChanged(TransferOrderLineModel line, int quantity)
+    {
+        line.Quantity = Math.Max(1, quantity);
+    }
+
+    private Task OnSourceWarehouseChanged(Warehouse warehouse)
+    {
+        SourceWarehouse = warehouse;
+
+        foreach (var line in Lines)
+        {
+            line.Item = null;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private Task OnDestinationWarehouseChanged(Warehouse warehouse)
+    {
+        DestinationWarehouse = warehouse;
+        return Task.CompletedTask;
+    }
+
+    private async Task Save()
+    {
+        if (!CanSave)
+        {
+            return;
+        }
+
+        try
+        {
+            var dto = new CreateTransferOrder
+            {
+                SourceWarehouseId = SourceWarehouse!.Id,
+                DestinationWarehouseId = DestinationWarehouse!.Id,
+                Lines = Lines.Select(x => new CreateTransferOrderLine
+                {
+                    ItemId = x.Item!.Id,
+                    Quantity = x.Quantity
+                }).ToList()
+            };
+
+            await TransferOrdersClient.CreateTransferOrderAsync(dto);
+            Dialog.Close(DialogResult.Ok(true));
+        }
+        catch (AccessTokenNotAvailableException exception)
+        {
+            exception.Redirect();
+        }
+        catch (ApiException ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+    private void Cancel()
+    {
+        Dialog.Cancel();
+    }
+
+    private class TransferOrderLineModel
+    {
+        public Item? Item { get; set; }
+        public int Quantity { get; set; } = 1;
+    }
+}

--- a/src/Inventory/Inventory.UI/TransferOrders/TransferOrdersPage.razor
+++ b/src/Inventory/Inventory.UI/TransferOrders/TransferOrdersPage.razor
@@ -1,0 +1,167 @@
+@page "/inventory/transfer-orders"
+@using System.Linq
+@attribute [Authorize]
+@inject ITransferOrdersClient TransferOrdersClient
+@inject IDialogService DialogService
+@inject ISnackbar Snackbar
+
+<AppPageTitle>Transfer Orders</AppPageTitle>
+
+<MudText Typo="Typo.h3" Class="mb-4">Transfer Orders</MudText>
+
+<MudButton Variant="Variant.Filled" OnClick="async () => await OnCreateTransferOrder()" StartIcon="@Icons.Material.Filled.Add" Color="Color.Default" Class="mb-2 me-2">
+    New transfer order
+</MudButton>
+
+<MudPaper Class="pa-4" Elevation="25">
+    <MudTable @ref="table" T="TransferOrder" Elevation="0" ServerData="LoadData" Hover="true" Bordered="false" Striped="true">
+        <ToolBarContent>
+            <WarehouseSelector Label="Source" Value="SourceWarehouse" ValueChanged="OnSourceWarehouseChanged" For="() => SourceWarehouse" Class="me-4" />
+            <WarehouseSelector Label="Destination" Value="DestinationWarehouse" ValueChanged="OnDestinationWarehouseChanged" For="() => DestinationWarehouse" />
+            <MudSpacer />
+            <MudTextField T="string" Value="searchString" ValueChanged="OnSearch" Placeholder="Search" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Immediate="true" DebounceInterval="200" />
+        </ToolBarContent>
+        <HeaderContent>
+            <MudTh><MudTableSortLabel T="TransferOrder" SortLabel="Created">Created</MudTableSortLabel></MudTh>
+            <MudTh>Source</MudTh>
+            <MudTh>Destination</MudTh>
+            <MudTh>Items</MudTh>
+            <MudTh><MudTableSortLabel T="TransferOrder" SortLabel="CompletedAt">Completed</MudTableSortLabel></MudTh>
+            <MudTh>Status</MudTh>
+            <MudTh></MudTh>
+        </HeaderContent>
+        <RowTemplate Context="order">
+            <MudTd DataLabel="Created">@order.Created.ToLocalTime().ToString("g")</MudTd>
+            <MudTd DataLabel="Source">@order.SourceWarehouse.Name</MudTd>
+            <MudTd DataLabel="Destination">@order.DestinationWarehouse.Name</MudTd>
+            <MudTd DataLabel="Items">@GetItemsSummary(order)</MudTd>
+            <MudTd DataLabel="Completed">@order.CompletedAt?.ToLocalTime().ToString("g")</MudTd>
+            <MudTd DataLabel="Status">
+                @if (order.IsCompleted)
+                {
+                    <MudChip Color="Color.Success" Variant="Variant.Filled" Size="Size.Small">Completed</MudChip>
+                }
+                else
+                {
+                    <MudChip Color="Color.Info" Variant="Variant.Filled" Size="Size.Small">Pending</MudChip>
+                }
+            </MudTd>
+            <MudTd>
+                <MudIconButton Size="Size.Small" Icon="@Icons.Material.Filled.CheckCircle" Color="Color.Primary" OnClick="async () => await OnComplete(order)" Disabled="@order.IsCompleted" />
+            </MudTd>
+        </RowTemplate>
+        <PagerContent>
+            <MudTablePager />
+        </PagerContent>
+    </MudTable>
+</MudPaper>
+
+@code {
+    private MudTable<TransferOrder>? table;
+    private string? searchString;
+    public Warehouse? SourceWarehouse { get; set; }
+    public Warehouse? DestinationWarehouse { get; set; }
+
+    private async Task<TableData<TransferOrder>> LoadData(TableState state, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var sortLabel = state.SortDirection == MudBlazor.SortDirection.None ? null : state.SortLabel;
+            var sortDirection = state.SortDirection == MudBlazor.SortDirection.None
+                ? (YourBrand.Inventory.Client.SortDirection?)null
+                : (state.SortDirection == MudBlazor.SortDirection.Ascending ? YourBrand.Inventory.Client.SortDirection.Asc : YourBrand.Inventory.Client.SortDirection.Desc);
+
+            var results = await TransferOrdersClient.GetTransferOrdersAsync(state.Page + 1, state.PageSize, SourceWarehouse?.Id, DestinationWarehouse?.Id, searchString, sortLabel, sortDirection, cancellationToken);
+            return new TableData<TransferOrder> { Items = results.Items, TotalItems = results.TotalItems };
+        }
+        catch (AccessTokenNotAvailableException exception)
+        {
+            exception.Redirect();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+
+        return new TableData<TransferOrder>
+        {
+            Items = Array.Empty<TransferOrder>(),
+            TotalItems = 0
+        };
+    }
+
+    private void OnSearch(string? value)
+    {
+        searchString = string.IsNullOrWhiteSpace(value) ? null : value;
+        table?.ReloadServerData();
+    }
+
+    private Task OnSourceWarehouseChanged(Warehouse warehouse)
+    {
+        SourceWarehouse = warehouse;
+        table?.ReloadServerData();
+        return Task.CompletedTask;
+    }
+
+    private Task OnDestinationWarehouseChanged(Warehouse warehouse)
+    {
+        DestinationWarehouse = warehouse;
+        table?.ReloadServerData();
+        return Task.CompletedTask;
+    }
+
+    private async Task OnCreateTransferOrder()
+    {
+        try
+        {
+            var options = new DialogOptions
+            {
+                MaxWidth = MaxWidth.ExtraLarge,
+                FullWidth = true
+            };
+
+            var dialog = await DialogService.ShowAsync<TransferOrderDialog>("New Transfer Order", options: options);
+            var result = await dialog.Result;
+
+            if (!result.Canceled && table is not null)
+            {
+                await table.ReloadServerData();
+            }
+        }
+        catch (AccessTokenNotAvailableException exception)
+        {
+            exception.Redirect();
+        }
+    }
+
+    private async Task OnComplete(TransferOrder order)
+    {
+        try
+        {
+            await TransferOrdersClient.CompleteTransferOrderAsync(order.Id, new CompleteTransferOrder());
+
+            if (table is not null)
+            {
+                await table.ReloadServerData();
+            }
+        }
+        catch (AccessTokenNotAvailableException exception)
+        {
+            exception.Redirect();
+        }
+        catch (Exception ex)
+        {
+            Snackbar.Add(ex.Message, Severity.Error);
+        }
+    }
+
+    private static string GetItemsSummary(TransferOrder order)
+    {
+        if (order.Lines is null || order.Lines.Count == 0)
+        {
+            return "-";
+        }
+
+        return string.Join(", ", order.Lines.Select(x => $"{x.Item.Name} ({x.Quantity})"));
+    }
+}

--- a/src/Inventory/Inventory/Application/Mappings.cs
+++ b/src/Inventory/Inventory/Application/Mappings.cs
@@ -6,6 +6,7 @@ using YourBrand.Inventory.Application.Sites;
 using YourBrand.Inventory.Application.Warehouses;
 using YourBrand.Inventory.Application.Warehouses.Items;
 using YourBrand.Inventory.Application.Warehouses.Shipments;
+using YourBrand.Inventory.Application.Warehouses.TransferOrders;
 using YourBrand.Inventory.Application.Suppliers;
 using YourBrand.Inventory.Domain.Entities;
 using YourBrand.Inventory.Domain.ValueObjects;
@@ -132,6 +133,26 @@ public static class Mappings
             shipmentItem.Quantity,
             shipmentItem.IsShipped,
             shipmentItem.ShippedAt);
+    }
+
+    public static TransferOrderDto ToDto(this TransferOrder transferOrder)
+    {
+        return new TransferOrderDto(
+            transferOrder.Id,
+            transferOrder.SourceWarehouse.ToDto(),
+            transferOrder.DestinationWarehouse.ToDto(),
+            transferOrder.Created,
+            transferOrder.CompletedAt,
+            transferOrder.IsCompleted,
+            transferOrder.Lines.Select(x => x.ToDto()).ToList());
+    }
+
+    public static TransferOrderLineDto ToDto(this TransferOrderLine line)
+    {
+        return new TransferOrderLineDto(
+            line.Id,
+            line.Item.ToDto(),
+            line.Quantity);
     }
 
     public static ShippingDetailsDto ToDto(this ShippingDetails destination)

--- a/src/Inventory/Inventory/Application/Warehouse/TransferOrders/Commands/CompleteTransferOrder.cs
+++ b/src/Inventory/Inventory/Application/Warehouse/TransferOrders/Commands/CompleteTransferOrder.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Inventory.Domain;
+using YourBrand.Inventory.Domain.Entities;
+
+namespace YourBrand.Inventory.Application.Warehouses.TransferOrders.Commands;
+
+public record CompleteTransferOrder(string TransferOrderId, DateTimeOffset? CompletedAt) : IRequest<TransferOrderDto>;
+
+public class CompleteTransferOrderHandler(IInventoryContext context) : IRequestHandler<CompleteTransferOrder, TransferOrderDto>
+{
+    public async Task<TransferOrderDto> Handle(CompleteTransferOrder request, CancellationToken cancellationToken)
+    {
+        var transferOrder = await context.TransferOrders
+            .Include(x => x.SourceWarehouse)
+                .ThenInclude(x => x.Site)
+            .Include(x => x.DestinationWarehouse)
+                .ThenInclude(x => x.Site)
+            .Include(x => x.Lines)
+                .ThenInclude(x => x.Item)
+                    .ThenInclude(x => x.Group)
+            .FirstOrDefaultAsync(x => x.Id == request.TransferOrderId, cancellationToken)
+            ?? throw new InvalidOperationException("Transfer order not found.");
+
+        if (transferOrder.IsCompleted)
+        {
+            throw new InvalidOperationException("Transfer order has already been completed.");
+        }
+
+        var itemIds = transferOrder.Lines.Select(x => x.ItemId).Distinct().ToList();
+
+        var sourceItems = await context.WarehouseItems
+            .Include(x => x.Item)
+                .ThenInclude(x => x.Group)
+            .Include(x => x.Warehouse)
+            .Where(x => x.WarehouseId == transferOrder.SourceWarehouseId && itemIds.Contains(x.ItemId))
+            .ToDictionaryAsync(x => x.ItemId, cancellationToken);
+
+        if (sourceItems.Count != itemIds.Count)
+        {
+            throw new InvalidOperationException("The source warehouse is missing one or more items required for this transfer order.");
+        }
+
+        var destinationItems = await context.WarehouseItems
+            .Include(x => x.Item)
+                .ThenInclude(x => x.Group)
+            .Include(x => x.Warehouse)
+            .Where(x => x.WarehouseId == transferOrder.DestinationWarehouseId && itemIds.Contains(x.ItemId))
+            .ToDictionaryAsync(x => x.ItemId, cancellationToken);
+
+        foreach (var line in transferOrder.Lines)
+        {
+            var sourceItem = sourceItems[line.ItemId];
+
+            if (line.Quantity > sourceItem.QuantityAvailable)
+            {
+                throw new InvalidOperationException($"Insufficient quantity available for item '{sourceItem.Item.Name}'.");
+            }
+
+            if (!destinationItems.TryGetValue(line.ItemId, out var destinationItem))
+            {
+                destinationItem = new WarehouseItem(
+                    sourceItem.Item,
+                    transferOrder.DestinationWarehouse,
+                    sourceItem.Location,
+                    0,
+                    sourceItem.QuantityThreshold);
+
+                context.WarehouseItems.Add(destinationItem);
+                destinationItems[line.ItemId] = destinationItem;
+            }
+
+            sourceItem.TransferTo(destinationItem, line.Quantity);
+        }
+
+        transferOrder.Complete(request.CompletedAt);
+
+        await context.SaveChangesAsync(cancellationToken);
+
+        return transferOrder.ToDto();
+    }
+}

--- a/src/Inventory/Inventory/Application/Warehouse/TransferOrders/Commands/CreateTransferOrder.cs
+++ b/src/Inventory/Inventory/Application/Warehouse/TransferOrders/Commands/CreateTransferOrder.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Inventory.Domain;
+using YourBrand.Inventory.Domain.Entities;
+
+namespace YourBrand.Inventory.Application.Warehouses.TransferOrders.Commands;
+
+public record CreateTransferOrder(
+    string SourceWarehouseId,
+    string DestinationWarehouseId,
+    IReadOnlyCollection<CreateTransferOrderLineDto> Lines) : IRequest<TransferOrderDto>;
+
+public class CreateTransferOrderHandler(IInventoryContext context) : IRequestHandler<CreateTransferOrder, TransferOrderDto>
+{
+    public async Task<TransferOrderDto> Handle(CreateTransferOrder request, CancellationToken cancellationToken)
+    {
+        if (request.SourceWarehouseId == request.DestinationWarehouseId)
+        {
+            throw new InvalidOperationException("Source and destination warehouses must be different.");
+        }
+
+        if (request.Lines is null || !request.Lines.Any())
+        {
+            throw new InvalidOperationException("A transfer order must contain at least one line.");
+        }
+
+        var sourceWarehouse = await context.Warehouses
+            .Include(x => x.Site)
+            .FirstOrDefaultAsync(x => x.Id == request.SourceWarehouseId, cancellationToken)
+            ?? throw new InvalidOperationException("Source warehouse not found.");
+
+        var destinationWarehouse = await context.Warehouses
+            .Include(x => x.Site)
+            .FirstOrDefaultAsync(x => x.Id == request.DestinationWarehouseId, cancellationToken)
+            ?? throw new InvalidOperationException("Destination warehouse not found.");
+
+        var itemIds = request.Lines.Select(x => x.ItemId).Distinct().ToList();
+
+        var items = await context.Items
+            .Include(x => x.Group)
+            .Where(x => itemIds.Contains(x.Id))
+            .ToDictionaryAsync(x => x.Id, cancellationToken);
+
+        if (items.Count != itemIds.Count)
+        {
+            throw new InvalidOperationException("One or more items in the transfer order could not be found.");
+        }
+
+        var transferOrder = new TransferOrder(sourceWarehouse, destinationWarehouse);
+
+        foreach (var line in request.Lines)
+        {
+            if (line.Quantity <= 0)
+            {
+                throw new InvalidOperationException("Line quantity must be greater than zero.");
+            }
+
+            transferOrder.AddLine(items[line.ItemId], line.Quantity);
+        }
+
+        context.TransferOrders.Add(transferOrder);
+
+        await context.SaveChangesAsync(cancellationToken);
+
+        var persisted = await context.TransferOrders
+            .AsNoTracking()
+            .Where(x => x.Id == transferOrder.Id)
+            .Include(x => x.SourceWarehouse)
+                .ThenInclude(x => x.Site)
+            .Include(x => x.DestinationWarehouse)
+                .ThenInclude(x => x.Site)
+            .Include(x => x.Lines)
+                .ThenInclude(x => x.Item)
+                    .ThenInclude(x => x.Group)
+            .FirstAsync(cancellationToken);
+
+        return persisted.ToDto();
+    }
+}

--- a/src/Inventory/Inventory/Application/Warehouse/TransferOrders/Queries/GetTransferOrder.cs
+++ b/src/Inventory/Inventory/Application/Warehouse/TransferOrders/Queries/GetTransferOrder.cs
@@ -1,0 +1,31 @@
+using System.Linq;
+
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Inventory.Domain;
+
+namespace YourBrand.Inventory.Application.Warehouses.TransferOrders.Queries;
+
+public record GetTransferOrder(string Id) : IRequest<TransferOrderDto?>;
+
+public class GetTransferOrderHandler(IInventoryContext context) : IRequestHandler<GetTransferOrder, TransferOrderDto?>
+{
+    public async Task<TransferOrderDto?> Handle(GetTransferOrder request, CancellationToken cancellationToken)
+    {
+        var transferOrder = await context.TransferOrders
+            .AsNoTracking()
+            .Where(x => x.Id == request.Id)
+            .Include(x => x.SourceWarehouse)
+                .ThenInclude(x => x.Site)
+            .Include(x => x.DestinationWarehouse)
+                .ThenInclude(x => x.Site)
+            .Include(x => x.Lines)
+                .ThenInclude(x => x.Item)
+                    .ThenInclude(x => x.Group)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        return transferOrder?.ToDto();
+    }
+}

--- a/src/Inventory/Inventory/Application/Warehouse/TransferOrders/Queries/GetTransferOrders.cs
+++ b/src/Inventory/Inventory/Application/Warehouse/TransferOrders/Queries/GetTransferOrders.cs
@@ -1,0 +1,83 @@
+using System.Linq;
+
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Inventory.Application.Common.Models;
+using YourBrand.Inventory.Domain;
+
+using ModelSortDirection = YourBrand.Inventory.Application.Common.Models.SortDirection;
+
+namespace YourBrand.Inventory.Application.Warehouses.TransferOrders.Queries;
+
+public record GetTransferOrders(
+    int Page,
+    int PageSize,
+    string? SourceWarehouseId,
+    string? DestinationWarehouseId,
+    string? SearchString = null,
+    string? SortBy = null,
+    ModelSortDirection? SortDirection = null) : IRequest<ItemsResult<TransferOrderDto>>;
+
+public class GetTransferOrdersHandler(IInventoryContext context) : IRequestHandler<GetTransferOrders, ItemsResult<TransferOrderDto>>
+{
+    public async Task<ItemsResult<TransferOrderDto>> Handle(GetTransferOrders request, CancellationToken cancellationToken)
+    {
+        var query = context.TransferOrders
+            .AsNoTracking();
+
+        if (!string.IsNullOrWhiteSpace(request.SourceWarehouseId))
+        {
+            query = query.Where(x => x.SourceWarehouseId == request.SourceWarehouseId);
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.DestinationWarehouseId))
+        {
+            query = query.Where(x => x.DestinationWarehouseId == request.DestinationWarehouseId);
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.SearchString))
+        {
+            var search = request.SearchString.Trim();
+
+            query = query.Where(x =>
+                x.SourceWarehouse.Name.Contains(search) ||
+                x.DestinationWarehouse.Name.Contains(search) ||
+                x.Lines.Any(l => l.Item.Name.Contains(search)));
+        }
+
+        var sortDesc = request.SortDirection switch
+        {
+            ModelSortDirection.Asc => false,
+            ModelSortDirection.Desc => true,
+            _ => true
+        };
+
+        query = request.SortBy switch
+        {
+            "created" when sortDesc => query.OrderByDescending(x => x.Created),
+            "created" => query.OrderBy(x => x.Created),
+            "completedAt" when sortDesc => query.OrderByDescending(x => x.CompletedAt),
+            "completedAt" => query.OrderBy(x => x.CompletedAt),
+            _ when sortDesc => query.OrderByDescending(x => x.Created),
+            _ => query.OrderBy(x => x.Created)
+        };
+
+        var total = await query.CountAsync(cancellationToken);
+
+        var transferOrders = await query
+            .Skip(request.Page * request.PageSize)
+            .Take(request.PageSize)
+            .Include(x => x.SourceWarehouse)
+                .ThenInclude(x => x.Site)
+            .Include(x => x.DestinationWarehouse)
+                .ThenInclude(x => x.Site)
+            .Include(x => x.Lines)
+                .ThenInclude(x => x.Item)
+                    .ThenInclude(x => x.Group)
+            .ToListAsync(cancellationToken);
+
+        return new ItemsResult<TransferOrderDto>(transferOrders.Select(x => x.ToDto()), total);
+    }
+}

--- a/src/Inventory/Inventory/Application/Warehouse/TransferOrders/TransferOrderDto.cs
+++ b/src/Inventory/Inventory/Application/Warehouse/TransferOrders/TransferOrderDto.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+
+using YourBrand.Inventory.Application.Items;
+using YourBrand.Inventory.Application.Warehouses;
+
+namespace YourBrand.Inventory.Application.Warehouses.TransferOrders;
+
+public record TransferOrderDto(
+    string Id,
+    WarehouseDto SourceWarehouse,
+    WarehouseDto DestinationWarehouse,
+    DateTimeOffset Created,
+    DateTimeOffset? CompletedAt,
+    bool IsCompleted,
+    IReadOnlyCollection<TransferOrderLineDto> Lines);
+
+public record TransferOrderLineDto(
+    string Id,
+    ItemDto Item,
+    int Quantity);
+
+public record CreateTransferOrderDto(
+    string SourceWarehouseId,
+    string DestinationWarehouseId,
+    IReadOnlyCollection<CreateTransferOrderLineDto> Lines);
+
+public record CreateTransferOrderLineDto(
+    string ItemId,
+    int Quantity);
+
+public record CompleteTransferOrderDto(DateTimeOffset? CompletedAt);

--- a/src/Inventory/Inventory/Application/Warehouse/TransferOrders/TransferOrdersController.cs
+++ b/src/Inventory/Inventory/Application/Warehouse/TransferOrders/TransferOrdersController.cs
@@ -1,0 +1,51 @@
+using Asp.Versioning;
+
+using MediatR;
+
+using Microsoft.AspNetCore.Mvc;
+
+using YourBrand.Inventory.Application.Common.Models;
+using YourBrand.Inventory.Application.Warehouses.TransferOrders.Commands;
+using YourBrand.Inventory.Application.Warehouses.TransferOrders.Queries;
+
+using ModelSortDirection = YourBrand.Inventory.Application.Common.Models.SortDirection;
+
+namespace YourBrand.Inventory.Application.Warehouses.TransferOrders;
+
+[ApiController]
+[ApiVersion("1")]
+[Route("v{version:apiVersion}/[controller]")]
+public class TransferOrdersController(IMediator mediator) : ControllerBase
+{
+    [HttpGet]
+    public async Task<ItemsResult<TransferOrderDto>> GetTransferOrders(
+        int page = 1,
+        int pageSize = 10,
+        string? sourceWarehouseId = null,
+        string? destinationWarehouseId = null,
+        string? searchString = null,
+        string? sortBy = null,
+        ModelSortDirection? sortDirection = null,
+        CancellationToken cancellationToken = default)
+    {
+        return await mediator.Send(new GetTransferOrders(page - 1, pageSize, sourceWarehouseId, destinationWarehouseId, searchString, sortBy, sortDirection), cancellationToken);
+    }
+
+    [HttpGet("{id}")]
+    public async Task<TransferOrderDto?> GetTransferOrder(string id, CancellationToken cancellationToken)
+    {
+        return await mediator.Send(new GetTransferOrder(id), cancellationToken);
+    }
+
+    [HttpPost]
+    public async Task<TransferOrderDto> CreateTransferOrder(CreateTransferOrderDto dto, CancellationToken cancellationToken)
+    {
+        return await mediator.Send(new CreateTransferOrder(dto.SourceWarehouseId, dto.DestinationWarehouseId, dto.Lines), cancellationToken);
+    }
+
+    [HttpPost("{id}/Complete")]
+    public async Task<TransferOrderDto> CompleteTransferOrder(string id, CompleteTransferOrderDto dto, CancellationToken cancellationToken)
+    {
+        return await mediator.Send(new CompleteTransferOrder(id, dto.CompletedAt), cancellationToken);
+    }
+}

--- a/src/Inventory/Inventory/Domain/Entities/TransferOrder.cs
+++ b/src/Inventory/Inventory/Domain/Entities/TransferOrder.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using YourBrand.Inventory.Domain.Common;
+
+namespace YourBrand.Inventory.Domain.Entities;
+
+public class TransferOrder : AuditableEntity<string>
+{
+    private readonly HashSet<TransferOrderLine> lines = new();
+
+    protected TransferOrder()
+    {
+    }
+
+    public TransferOrder(Warehouse sourceWarehouse, Warehouse destinationWarehouse, string? reference = null)
+        : base(Guid.NewGuid().ToString())
+    {
+        if (sourceWarehouse is null)
+        {
+            throw new ArgumentNullException(nameof(sourceWarehouse));
+        }
+
+        if (destinationWarehouse is null)
+        {
+            throw new ArgumentNullException(nameof(destinationWarehouse));
+        }
+
+        if (sourceWarehouse.Id == destinationWarehouse.Id)
+        {
+            throw new InvalidOperationException("Source and destination warehouses must be different.");
+        }
+
+        SourceWarehouse = sourceWarehouse;
+        DestinationWarehouse = destinationWarehouse;
+        SourceWarehouseId = sourceWarehouse.Id;
+        DestinationWarehouseId = destinationWarehouse.Id;
+        Reference = string.IsNullOrWhiteSpace(reference) ? null : reference.Trim();
+    }
+
+    public string SourceWarehouseId { get; private set; } = null!;
+
+    public Warehouse SourceWarehouse { get; private set; } = null!;
+
+    public string DestinationWarehouseId { get; private set; } = null!;
+
+    public Warehouse DestinationWarehouse { get; private set; } = null!;
+
+    public string? Reference { get; private set; }
+
+    public DateTimeOffset? CompletedAt { get; private set; }
+
+    public bool IsCompleted => CompletedAt.HasValue;
+
+    public IReadOnlyCollection<TransferOrderLine> Lines => lines;
+
+    public TransferOrderLine AddLine(Item item, int quantity)
+    {
+        if (IsCompleted)
+        {
+            throw new InvalidOperationException("Cannot modify a completed transfer order.");
+        }
+
+        if (item is null)
+        {
+            throw new ArgumentNullException(nameof(item));
+        }
+
+        if (lines.Any(x => x.ItemId == item.Id))
+        {
+            throw new InvalidOperationException("The transfer order already contains this item.");
+        }
+
+        var line = new TransferOrderLine(this, item, quantity);
+        AttachLine(line);
+        return line;
+    }
+
+    public void Complete(DateTimeOffset? completedAt = null)
+    {
+        if (IsCompleted)
+        {
+            throw new InvalidOperationException("Transfer order has already been completed.");
+        }
+
+        if (!lines.Any())
+        {
+            throw new InvalidOperationException("Cannot complete a transfer order without any lines.");
+        }
+
+        CompletedAt = completedAt ?? DateTimeOffset.UtcNow;
+    }
+
+    internal void AttachLine(TransferOrderLine line)
+    {
+        if (line is null)
+        {
+            throw new ArgumentNullException(nameof(line));
+        }
+
+        lines.Add(line);
+    }
+
+    internal void DetachLine(TransferOrderLine line)
+    {
+        if (line is null)
+        {
+            throw new ArgumentNullException(nameof(line));
+        }
+
+        lines.Remove(line);
+    }
+}

--- a/src/Inventory/Inventory/Domain/Entities/TransferOrderLine.cs
+++ b/src/Inventory/Inventory/Domain/Entities/TransferOrderLine.cs
@@ -1,0 +1,50 @@
+using System;
+
+using YourBrand.Inventory.Domain.Common;
+
+namespace YourBrand.Inventory.Domain.Entities;
+
+public class TransferOrderLine : Entity<string>
+{
+    protected TransferOrderLine()
+    {
+    }
+
+    internal TransferOrderLine(TransferOrder transferOrder, Item item, int quantity)
+        : base(Guid.NewGuid().ToString())
+    {
+        TransferOrder = transferOrder ?? throw new ArgumentNullException(nameof(transferOrder));
+        TransferOrderId = transferOrder.Id;
+        Item = item ?? throw new ArgumentNullException(nameof(item));
+        ItemId = item.Id;
+
+        ChangeQuantity(quantity);
+
+        transferOrder.AttachLine(this);
+    }
+
+    public string TransferOrderId { get; private set; } = null!;
+
+    public TransferOrder TransferOrder { get; private set; } = null!;
+
+    public string ItemId { get; private set; } = null!;
+
+    public Item Item { get; private set; } = null!;
+
+    public int Quantity { get; private set; }
+
+    public void ChangeQuantity(int quantity)
+    {
+        if (TransferOrder.IsCompleted)
+        {
+            throw new InvalidOperationException("Cannot modify a completed transfer order.");
+        }
+
+        if (quantity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(quantity));
+        }
+
+        Quantity = quantity;
+    }
+}

--- a/src/Inventory/Inventory/Domain/Events/ItemEvents.cs
+++ b/src/Inventory/Inventory/Domain/Events/ItemEvents.cs
@@ -25,3 +25,5 @@ public record WarehouseItemsReturned(string ItemId, string WarehouseId, int Quan
 public record WarehouseItemsUnpicked(string ItemId, string WarehouseId, int Quantity) : DomainEvent;
 
 public record WarehouseItemsShipped(string ItemId, string WarehouseId, int Quantity) : DomainEvent;
+
+public record WarehouseItemsTransferred(string ItemId, string SourceWarehouseId, string DestinationWarehouseId, int Quantity) : DomainEvent;

--- a/src/Inventory/Inventory/Domain/IInventoryContext.cs
+++ b/src/Inventory/Inventory/Domain/IInventoryContext.cs
@@ -17,6 +17,8 @@ public interface IInventoryContext
     DbSet<SupplierOrderLine> SupplierOrderLines { get; }
     DbSet<Shipment> Shipments { get; }
     DbSet<ShipmentItem> ShipmentItems { get; }
+    DbSet<TransferOrder> TransferOrders { get; }
+    DbSet<TransferOrderLine> TransferOrderLines { get; }
 
     Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
 }

--- a/src/Inventory/Inventory/Infrastructure/Persistence/Configurations/TransferOrderConfiguration.cs
+++ b/src/Inventory/Inventory/Infrastructure/Persistence/Configurations/TransferOrderConfiguration.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using YourBrand.Inventory.Domain.Entities;
+
+namespace YourBrand.Inventory.Infrastructure.Persistence.Configurations;
+
+public class TransferOrderConfiguration : IEntityTypeConfiguration<TransferOrder>
+{
+    public void Configure(EntityTypeBuilder<TransferOrder> builder)
+    {
+        builder.ToTable("TransferOrders");
+
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.Reference)
+            .HasMaxLength(128);
+
+        builder.HasOne(x => x.SourceWarehouse)
+            .WithMany()
+            .HasForeignKey(x => x.SourceWarehouseId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne(x => x.DestinationWarehouse)
+            .WithMany()
+            .HasForeignKey(x => x.DestinationWarehouseId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasMany(x => x.Lines)
+            .WithOne(x => x.TransferOrder)
+            .HasForeignKey(x => x.TransferOrderId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/Inventory/Inventory/Infrastructure/Persistence/Configurations/TransferOrderLineConfiguration.cs
+++ b/src/Inventory/Inventory/Infrastructure/Persistence/Configurations/TransferOrderLineConfiguration.cs
@@ -1,0 +1,24 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using YourBrand.Inventory.Domain.Entities;
+
+namespace YourBrand.Inventory.Infrastructure.Persistence.Configurations;
+
+public class TransferOrderLineConfiguration : IEntityTypeConfiguration<TransferOrderLine>
+{
+    public void Configure(EntityTypeBuilder<TransferOrderLine> builder)
+    {
+        builder.ToTable("TransferOrderLines");
+
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.Quantity)
+            .IsRequired();
+
+        builder.HasOne(x => x.Item)
+            .WithMany()
+            .HasForeignKey(x => x.ItemId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/Inventory/Inventory/Infrastructure/Persistence/InventoryContext.cs
+++ b/src/Inventory/Inventory/Infrastructure/Persistence/InventoryContext.cs
@@ -51,6 +51,10 @@ public class InventoryContext(
 
     public DbSet<ShipmentItem> ShipmentItems { get; set; } = null!;
 
+    public DbSet<TransferOrder> TransferOrders { get; set; } = null!;
+
+    public DbSet<TransferOrderLine> TransferOrderLines { get; set; } = null!;
+
     public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
     {
         var entities = ChangeTracker


### PR DESCRIPTION
## Summary
- add domain, persistence, and application support for transfer orders between warehouses
- expose transfer order API endpoints and update client schema
- provide a UI to create and complete transfer orders and update navigation labels

## Testing
- dotnet build src/Inventory/Inventory/Inventory.csproj

------
https://chatgpt.com/codex/tasks/task_e_690b1436d948832f9e026163bb14e767