### PR TITLE
Fix product import to align with current domain

### DIFF
--- a/src/Catalog/Catalog.UnitTests/Catalog.UnitTests.csproj
+++ b/src/Catalog/Catalog.UnitTests/Catalog.UnitTests.csproj
@@ -11,6 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -28,7 +30,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Catalog.API\Catalog.csproj">
+    <ProjectReference Include="..\Catalog\Catalog.csproj">
       <GlobalPropertiesToRemove></GlobalPropertiesToRemove>
     </ProjectReference>
     <ProjectReference Include="..\..\Core\Core.csproj">

--- a/src/Catalog/Catalog.UnitTests/ImportProductsTests.cs
+++ b/src/Catalog/Catalog.UnitTests/ImportProductsTests.cs
@@ -1,0 +1,176 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+using YourBrand.Catalog.Domain.Entities;
+using YourBrand.Catalog.Features.ProductManagement.Import;
+using YourBrand.Catalog.Features.ProductManagement.Products.Images;
+using YourBrand.Catalog.Persistence;
+using YourBrand.Domain;
+using YourBrand.Tenancy;
+
+namespace YourBrand.Catalog.UnitTests;
+
+public class ImportProductsTests
+{
+    [Fact]
+    public async Task Imports_products_and_uploads_images()
+    {
+        // Arrange
+        var tenantId = new TenantId("tenant-1");
+        var organizationId = new OrganizationId("org-1");
+
+        var tenantContext = new TestTenantContext { TenantId = tenantId };
+
+        var options = new DbContextOptionsBuilder<CatalogContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        await using var context = new CatalogContext(options, tenantContext, NullLogger<CatalogContext>.Instance);
+
+        var currency = new Currency("USD", "US Dollar", "$");
+        context.Currencies.Add(currency);
+
+        var store = new Store("Main store", "store-1", currency)
+        {
+            TenantId = tenantId,
+            OrganizationId = organizationId
+        };
+
+        context.Stores.Add(store);
+
+        var category = new ProductCategory(1)
+        {
+            TenantId = tenantId,
+            OrganizationId = organizationId,
+            Store = store,
+            StoreId = store.Id,
+            Name = "Category",
+            Handle = "category",
+            Path = "category",
+            CanAddProducts = true
+        };
+
+        store.AddCategory(category);
+        context.ProductCategories.Add(category);
+
+        var brand = new Brand("Acme", "acme")
+        {
+            TenantId = tenantId,
+            OrganizationId = organizationId
+        };
+
+        context.Brands.Add(brand);
+
+        await context.SaveChangesAsync();
+
+        var csv = "StoreIdOrHandle,Sku,Name,Handle,Description,Brand,CategoryId,CategoryName,ParentSku,Image,Price,RegularPrice,Listed\n" +
+                  "store-1,SKU-1,Imported Product,imported-product,Description,acme,1,Category,,image.jpg,9.99,10.99,true\n";
+
+        var imageContent = Encoding.UTF8.GetBytes("image-bytes");
+
+        var archiveManager = new InMemoryProductImportArchiveManager(new Dictionary<string, byte[]>
+        {
+            ["products.csv"] = Encoding.UTF8.GetBytes(csv),
+            ["image.jpg"] = imageContent
+        });
+
+        var imageUploader = new FakeProductImageUploader();
+
+        var handler = new ImportProducts.Handler(context, imageUploader, archiveManager);
+
+        using var archiveStream = new MemoryStream(Encoding.UTF8.GetBytes("ignored"));
+        var request = new ImportProducts(organizationId, archiveStream);
+
+        // Act
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+        Assert.Empty(result.GetValue().Diagnostics);
+
+        var product = await context.Products.Include(p => p.Images).SingleAsync();
+
+        Assert.Equal("SKU-1", product.Sku);
+        Assert.Equal(store.Id, product.StoreId);
+        Assert.Equal(organizationId, product.OrganizationId);
+        Assert.Equal(brand.Id, product.BrandId);
+        Assert.Equal(9.99m, product.Price);
+        Assert.Single(product.Images);
+
+        var upload = Assert.Single(imageUploader.Uploads);
+        Assert.Equal(product.Id, upload.ProductId);
+        Assert.Equal("image.jpg", upload.FileName);
+        Assert.Equal("image/jpeg", upload.ContentType);
+        Assert.Equal(imageContent, upload.Content);
+
+        var deleteRequest = Assert.Single(imageUploader.DeletedImages);
+        Assert.Equal(product.Id, deleteRequest.ProductId);
+        Assert.Equal("image.jpg", deleteRequest.FileName);
+    }
+
+    private sealed class TestTenantContext : ITenantContext
+    {
+        public TenantId? TenantId { get; set; }
+    }
+
+    private sealed class InMemoryProductImportArchiveManager(Dictionary<string, byte[]> files)
+        : IProductImportArchiveManager
+    {
+        public Task<IProductImportArchive> CreateArchive(Stream stream, CancellationToken cancellationToken)
+        {
+            IProductImportArchive archive = new InMemoryProductImportArchive(new Dictionary<string, byte[]>(files));
+            return Task.FromResult(archive);
+        }
+
+        private sealed class InMemoryProductImportArchive(Dictionary<string, byte[]> files)
+            : IProductImportArchive
+        {
+            public Task<Stream> OpenFileAsync(string relativePath, CancellationToken cancellationToken)
+            {
+                if (!files.TryGetValue(relativePath, out var content))
+                {
+                    throw new FileNotFoundException(relativePath);
+                }
+
+                return Task.FromResult<Stream>(new MemoryStream(content, writable: false));
+            }
+
+            public Task DeleteFileAsync(string relativePath, CancellationToken cancellationToken)
+            {
+                files.Remove(relativePath);
+                return Task.CompletedTask;
+            }
+
+            public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class FakeProductImageUploader : IProductImageUploader
+    {
+        public List<(int ProductId, string FileName, string ContentType, byte[] Content)> Uploads { get; } = new();
+
+        public List<(int ProductId, string FileName)> DeletedImages { get; } = new();
+
+        public Task<string> GetPlaceholderImageUrl() => Task.FromResult("placeholder");
+
+        public Task<bool> TryDeleteProductImage(int productId, string fileName)
+        {
+            DeletedImages.Add((productId, fileName));
+            return Task.FromResult(true);
+        }
+
+        public async Task<string> UploadProductImage(int productId, string fileName, Stream stream, string contentType)
+        {
+            using var memoryStream = new MemoryStream();
+            await stream.CopyToAsync(memoryStream);
+
+            Uploads.Add((productId, fileName, contentType, memoryStream.ToArray()));
+
+            return $"https://example.com/products/{productId}/{fileName}";
+        }
+    }
+}

--- a/src/Catalog/Catalog/Features/ProductManagement/Products/Import/FileSystemProductImportArchiveManager.cs
+++ b/src/Catalog/Catalog/Features/ProductManagement/Products/Import/FileSystemProductImportArchiveManager.cs
@@ -1,0 +1,78 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Reflection;
+
+namespace YourBrand.Catalog.Features.ProductManagement.Import;
+
+public sealed class FileSystemProductImportArchiveManager : IProductImportArchiveManager
+{
+    public async Task<IProductImportArchive> CreateArchive(Stream stream, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        var uploadsPath = GetUploadsPath();
+        Directory.CreateDirectory(uploadsPath);
+
+        var archiveName = DateTime.UtcNow.Ticks.ToString();
+        var archiveDirectory = Path.Combine(uploadsPath, archiveName);
+        Directory.CreateDirectory(archiveDirectory);
+
+        var archiveFile = Path.Combine(uploadsPath, $"{archiveName}.zip");
+
+        await using (var file = File.Open(archiveFile, FileMode.Create, FileAccess.ReadWrite, FileShare.None))
+        {
+            await stream.CopyToAsync(file, cancellationToken);
+        }
+
+        ZipFile.ExtractToDirectory(archiveFile, archiveDirectory);
+
+        File.Delete(archiveFile);
+
+        return new FileSystemProductImportArchive(archiveDirectory);
+    }
+
+    private static string GetUploadsPath()
+    {
+        var assemblyLocation = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
+        return Path.Combine(assemblyLocation, "uploads");
+    }
+
+    private sealed class FileSystemProductImportArchive(string rootPath) : IProductImportArchive
+    {
+        public Task<Stream> OpenFileAsync(string relativePath, CancellationToken cancellationToken)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+
+            if (!File.Exists(fullPath))
+            {
+                throw new FileNotFoundException($"File '{relativePath}' not found in archive.", fullPath);
+            }
+
+            Stream stream = File.Open(fullPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            return Task.FromResult(stream);
+        }
+
+        public Task DeleteFileAsync(string relativePath, CancellationToken cancellationToken)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+
+            if (File.Exists(fullPath))
+            {
+                File.Delete(fullPath);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, true);
+            }
+
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/src/Catalog/Catalog/Features/ProductManagement/Products/Import/IProductImportArchiveManager.cs
+++ b/src/Catalog/Catalog/Features/ProductManagement/Products/Import/IProductImportArchiveManager.cs
@@ -1,0 +1,15 @@
+using System.IO;
+
+namespace YourBrand.Catalog.Features.ProductManagement.Import;
+
+public interface IProductImportArchiveManager
+{
+    Task<IProductImportArchive> CreateArchive(Stream stream, CancellationToken cancellationToken);
+}
+
+public interface IProductImportArchive : IAsyncDisposable
+{
+    Task<Stream> OpenFileAsync(string relativePath, CancellationToken cancellationToken);
+
+    Task DeleteFileAsync(string relativePath, CancellationToken cancellationToken);
+}

--- a/src/Catalog/Catalog/Features/ProductManagement/Products/ServicesExtensions.cs
+++ b/src/Catalog/Catalog/Features/ProductManagement/Products/ServicesExtensions.cs
@@ -1,3 +1,4 @@
+using YourBrand.Catalog.Features.ProductManagement.Import;
 using YourBrand.Catalog.Features.ProductManagement.Products.Images;
 
 namespace YourBrand.Catalog.Features.ProductManagement.Products;
@@ -10,6 +11,7 @@ public static class ServicesExtensions
         services.AddScoped<ProductOptionValidationService>();
 
         services.AddScoped<IProductImageUploader, ProductImageUploader>();
+        services.AddScoped<IProductImportArchiveManager, FileSystemProductImportArchiveManager>();
 
         return services;
     }


### PR DESCRIPTION
## Summary
- refresh the product import handler to clear cached lookups and track imported product/image metadata
- assign current store, organization, brand, and pricing details to new products while capturing image filenames for upload
- ensure uploaded product images are stored with store context and created from the extracted archive

## Testing
- `dotnet build src/Catalog/Catalog/Catalog.csproj`


------
https://chatgpt.com/codex/tasks/task_e_690c74ba72ac832f9b32d7e678e70bbc