### PR TITLE
Implement product price tier support

### DIFF
--- a/src/Catalog/Catalog.Client/OpenAPIs/catalog.yaml
+++ b/src/Catalog/Catalog.Client/OpenAPIs/catalog.yaml
@@ -1834,6 +1834,152 @@ paths:
           description: ''
       security:
       - JWT: []
+  /v1/products/{idOrHandle}/price/tiers:
+    get:
+      tags:
+      - Products
+      operationId: Products_GetProductPriceTiers
+      parameters:
+      - name: organizationId
+        in: query
+        required: true
+        schema:
+          type: string
+        x-position: 1
+      - name: idOrHandle
+        in: path
+        required: true
+        schema:
+          type: string
+        x-position: 2
+      responses:
+        200:
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ProductPriceTier'
+        404:
+          description: ''
+      security:
+      - JWT: []
+    post:
+      tags:
+      - Products
+      operationId: Products_CreateProductPriceTier
+      parameters:
+      - name: organizationId
+        in: query
+        required: true
+        schema:
+          type: string
+        x-position: 1
+      - name: idOrHandle
+        in: path
+        required: true
+        schema:
+          type: string
+        x-position: 2
+      requestBody:
+        x-name: request
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateProductPriceTierRequest'
+        required: true
+        x-position: 3
+      responses:
+        200:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductPriceTier'
+        400:
+          description: ''
+        404:
+          description: ''
+      security:
+      - JWT: []
+  /v1/products/{idOrHandle}/price/tiers/{tierId}:
+    put:
+      tags:
+      - Products
+      operationId: Products_UpdateProductPriceTier
+      parameters:
+      - name: organizationId
+        in: query
+        required: true
+        schema:
+          type: string
+        x-position: 1
+      - name: idOrHandle
+        in: path
+        required: true
+        schema:
+          type: string
+        x-position: 2
+      - name: tierId
+        in: path
+        required: true
+        schema:
+          type: string
+        x-position: 3
+      requestBody:
+        x-name: request
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateProductPriceTierRequest'
+        required: true
+        x-position: 4
+      responses:
+        200:
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProductPriceTier'
+        400:
+          description: ''
+        404:
+          description: ''
+      security:
+      - JWT: []
+    delete:
+      tags:
+      - Products
+      operationId: Products_DeleteProductPriceTier
+      parameters:
+      - name: organizationId
+        in: query
+        required: true
+        schema:
+          type: string
+        x-position: 1
+      - name: idOrHandle
+        in: path
+        required: true
+        schema:
+          type: string
+        x-position: 2
+      - name: tierId
+        in: path
+        required: true
+        schema:
+          type: string
+        x-position: 3
+      responses:
+        204:
+          description: ''
+        400:
+          description: ''
+        404:
+          description: ''
+      security:
+      - JWT: []
   /v1/products/{idOrHandle}/images:
     post:
       tags:
@@ -3851,12 +3997,34 @@ components:
         optionsTotal:
           type: number
           format: decimal
-        discountAmount:
+        quantity:
+          type: integer
+          format: int32
+        unitPrice:
+          type: number
+          format: decimal
+        tierDiscount:
+          type: number
+          format: decimal
+        productDiscount:
+          type: number
+          format: decimal
+        subscriptionDiscount:
           type: number
           format: decimal
         total:
           type: number
           format: decimal
+        discountAmount:
+          type: number
+          format: decimal
+          readOnly: true
+        priceTier:
+          $ref: '#/components/schemas/ProductPriceTierApplication'
+        optionBreakdown:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProductOptionPriceDetail'
     CalculateProductPriceRequest:
       type: object
       additionalProperties: false
@@ -3865,6 +4033,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ProductOptionValue'
+        quantity:
+          type: integer
+          format: int32
+          default: 1
         subscriptionPlanId:
           type: string
           nullable: true
@@ -3881,6 +4053,103 @@ components:
         choiceValueId:
           type: string
           nullable: true
+    ProductOptionPriceDetail:
+      type: object
+      additionalProperties: false
+      properties:
+        optionId:
+          type: string
+        price:
+          type: number
+          format: decimal
+    ProductPriceTier:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+        fromQuantity:
+          type: integer
+          format: int32
+        toQuantity:
+          type: integer
+          format: int32
+          nullable: true
+        tierType:
+          $ref: '#/components/schemas/ProductPriceTierType'
+        value:
+          type: number
+          format: decimal
+    ProductPriceTierApplication:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+        fromQuantity:
+          type: integer
+          format: int32
+        toQuantity:
+          type: integer
+          format: int32
+          nullable: true
+        tierType:
+          $ref: '#/components/schemas/ProductPriceTierType'
+        value:
+          type: number
+          format: decimal
+        discountedUnits:
+          type: integer
+          format: int32
+        effectiveUnitPrice:
+          type: number
+          format: decimal
+    ProductPriceTierType:
+      type: string
+      enum:
+      - PricePerUnit
+      - DiscountPerUnit
+      - DiscountPerAdditionalUnit
+    CreateProductPriceTierRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        fromQuantity:
+          type: integer
+          format: int32
+        toQuantity:
+          type: integer
+          format: int32
+          nullable: true
+        tierType:
+          $ref: '#/components/schemas/ProductPriceTierType'
+        value:
+          type: number
+          format: decimal
+      required:
+      - fromQuantity
+      - tierType
+      - value
+    UpdateProductPriceTierRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        fromQuantity:
+          type: integer
+          format: int32
+        toQuantity:
+          type: integer
+          format: int32
+          nullable: true
+        tierType:
+          $ref: '#/components/schemas/ProductPriceTierType'
+        value:
+          type: number
+          format: decimal
+      required:
+      - fromQuantity
+      - tierType
+      - value
     CreateProductRequest:
       type: object
       additionalProperties: false

--- a/src/Catalog/Catalog.UI/Products/PriceUpdateView.razor
+++ b/src/Catalog/Catalog.UI/Products/PriceUpdateView.razor
@@ -1,3 +1,5 @@
+@implements IDisposable
+
 <EditForm Model="@Model" OnValidSubmit="Model.UpdatePrice">
     <DataAnnotationsValidator />
 
@@ -23,8 +25,98 @@
     <MudButton Variant="Variant.Filled" Class="mt-4" OnClick="@Model.RestoreRegularPrice">Restore regular price</MudButton>
 }
 
+<MudPaper Class="mt-6 pa-4">
+    <MudStack Spacing="2">
+        <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
+            <MudText Typo="Typo.h6">Price tiers</MudText>
+            <MudButton Variant="Variant.Outlined" OnClick="AddPriceTier">Add price tier</MudButton>
+        </MudStack>
+
+        @if (Model.PriceTiers.Count == 0)
+        {
+            <MudText Color="Color.Secondary">No price tiers configured.</MudText>
+        }
+        else
+        {
+            <MudTable Items="Model.PriceTiers" Dense="true" Hover="true">
+                <HeaderContent>
+                    <MudTh>From</MudTh>
+                    <MudTh>To</MudTh>
+                    <MudTh>Type</MudTh>
+                    <MudTh>Value</MudTh>
+                    <MudTh></MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd DataLabel="From">@context.FromQuantity</MudTd>
+                    <MudTd DataLabel="To">@(context.ToQuantity is null ? "∞" : context.ToQuantity?.ToString())</MudTd>
+                    <MudTd DataLabel="Type">@context.TierType</MudTd>
+                    <MudTd DataLabel="Value">@context.Value</MudTd>
+                    <MudTd>
+                        <MudIconButton Icon="@Icons.Material.Filled.Edit" OnClick="() => EditPriceTier(context)" />
+                        <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" OnClick="() => RemovePriceTier(context)" />
+                    </MudTd>
+                </RowTemplate>
+            </MudTable>
+        }
+    </MudStack>
+</MudPaper>
+
 @code
 {
     [Parameter]
     public PriceUpdateViewModel Model { get; set; }
+
+    private Func<Task>? _priceTiersChangedHandler;
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (Model is not null)
+        {
+            _priceTiersChangedHandler = OnPriceTiersChanged;
+            Model.PriceTiersChanged += _priceTiersChangedHandler;
+            await Model.InitializeAsync();
+        }
+    }
+
+    private Task OnPriceTiersChanged()
+    {
+        return InvokeAsync(StateHasChanged);
+    }
+
+    private async Task AddPriceTier()
+    {
+        var formData = await Model.PromptPriceTierAsync("Add price tier");
+        if (formData is null)
+        {
+            return;
+        }
+
+        await Model.CreatePriceTier(formData);
+    }
+
+    private async Task EditPriceTier(ProductPriceTier tier)
+    {
+        var existing = new PriceUpdateViewModel.PriceTierFormData(tier.FromQuantity, tier.ToQuantity, tier.TierType, tier.Value);
+        var formData = await Model.PromptPriceTierAsync("Edit price tier", existing);
+        if (formData is null)
+        {
+            return;
+        }
+
+        await Model.UpdatePriceTier(tier, formData);
+    }
+
+    private async Task RemovePriceTier(ProductPriceTier tier)
+    {
+        await Model.DeletePriceTier(tier);
+    }
+
+    public void Dispose()
+    {
+        if (Model is not null && _priceTiersChangedHandler is not null)
+        {
+            Model.PriceTiersChanged -= _priceTiersChangedHandler;
+        }
+
+    }
 }

--- a/src/Catalog/Catalog.UI/Products/PriceUpdateViewModel.cs
+++ b/src/Catalog/Catalog.UI/Products/PriceUpdateViewModel.cs
@@ -1,8 +1,12 @@
+using System.Collections.ObjectModel;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
 
 using MudBlazor;
 
 using YourBrand.AppService.Client;
+using YourBrand.Catalog;
 
 namespace YourBrand.Catalog.Products;
 
@@ -31,6 +35,15 @@ public class PriceUpdateViewModel(IProductsClient productsClient, IDialogService
 
     public int ProductId { get; private set; }
 
+    public ObservableCollection<ProductPriceTier> PriceTiers { get; } = new();
+
+    public event Func<Task>? PriceTiersChanged;
+
+    public async Task InitializeAsync()
+    {
+        await LoadPriceTiers();
+    }
+
     public async Task UpdatePrice()
     {
         try
@@ -46,6 +59,118 @@ public class PriceUpdateViewModel(IProductsClient productsClient, IDialogService
         {
             snackbar.Add("Failed to update product price", Severity.Error);
         }
+    }
+
+    public async Task LoadPriceTiers()
+    {
+        try
+        {
+            var tiers = await productsClient.GetProductPriceTiersAsync(OrganizationId, ProductId.ToString());
+
+            PriceTiers.Clear();
+
+            foreach (var tier in tiers.OrderBy(x => x.FromQuantity).ThenBy(x => x.ToQuantity ?? int.MaxValue))
+            {
+                PriceTiers.Add(tier);
+            }
+
+            await NotifyPriceTiersChanged();
+        }
+        catch
+        {
+            snackbar.Add("Failed to load price tiers", Severity.Error);
+        }
+    }
+
+    public async Task CreatePriceTier(PriceTierFormData data)
+    {
+        try
+        {
+            var created = await productsClient.CreateProductPriceTierAsync(OrganizationId, ProductId.ToString(), new CreateProductPriceTierRequest
+            {
+                FromQuantity = data.FromQuantity,
+                ToQuantity = data.ToQuantity,
+                TierType = data.TierType,
+                Value = data.Value
+            });
+
+            PriceTiers.Add(created);
+            await NotifyPriceTiersChanged();
+            snackbar.Add("Price tier created", Severity.Success);
+        }
+        catch
+        {
+            snackbar.Add("Failed to create price tier", Severity.Error);
+        }
+    }
+
+    public async Task UpdatePriceTier(ProductPriceTier tier, PriceTierFormData data)
+    {
+        try
+        {
+            var updated = await productsClient.UpdateProductPriceTierAsync(OrganizationId, ProductId.ToString(), tier.Id!, new UpdateProductPriceTierRequest
+            {
+                FromQuantity = data.FromQuantity,
+                ToQuantity = data.ToQuantity,
+                TierType = data.TierType,
+                Value = data.Value
+            });
+
+            var index = PriceTiers.IndexOf(tier);
+            if (index >= 0)
+            {
+                PriceTiers[index] = updated;
+            }
+
+            await NotifyPriceTiersChanged();
+            snackbar.Add("Price tier updated", Severity.Success);
+        }
+        catch
+        {
+            snackbar.Add("Failed to update price tier", Severity.Error);
+        }
+    }
+
+    public async Task DeletePriceTier(ProductPriceTier tier)
+    {
+        try
+        {
+            await productsClient.DeleteProductPriceTierAsync(OrganizationId, ProductId.ToString(), tier.Id!);
+
+            PriceTiers.Remove(tier);
+            await NotifyPriceTiersChanged();
+            snackbar.Add("Price tier deleted", Severity.Info);
+        }
+        catch
+        {
+            snackbar.Add("Failed to delete price tier", Severity.Error);
+        }
+    }
+
+    public async Task<PriceTierFormData?> PromptPriceTierAsync(string title, PriceTierFormData? initialData = null)
+    {
+        var parameters = new DialogParameters
+        {
+            { nameof(ProductPriceTierDialog.Title), title },
+            { nameof(ProductPriceTierDialog.InitialData), initialData }
+        };
+
+        var options = new DialogOptions
+        {
+            CloseButton = true,
+            FullWidth = true,
+            MaxWidth = MaxWidth.Small
+        };
+
+        var dialog = dialogService.Show<ProductPriceTierDialog>(title, parameters, options);
+        var result = await dialog.Result;
+
+        if (result.Canceled)
+        {
+            return null;
+        }
+
+        return result.Data is PriceTierFormData data ? data : null;
     }
 
     public async Task SetDiscountPrice()
@@ -79,4 +204,14 @@ public class PriceUpdateViewModel(IProductsClient productsClient, IDialogService
         RegularPrice = null;
         DiscountRate = null;
     }
+
+    private async Task NotifyPriceTiersChanged()
+    {
+        if (PriceTiersChanged is not null)
+        {
+            await PriceTiersChanged.Invoke();
+        }
+    }
+
+    public sealed record PriceTierFormData(int FromQuantity, int? ToQuantity, ProductPriceTierType TierType, decimal Value);
 }

--- a/src/Catalog/Catalog.UI/Products/ProductPriceTierDialog.razor
+++ b/src/Catalog/Catalog.UI/Products/ProductPriceTierDialog.razor
@@ -1,0 +1,108 @@
+@using System.ComponentModel.DataAnnotations
+@using MudBlazor
+@using YourBrand.Catalog
+@using YourBrand.Catalog.Products
+
+<MudDialog>
+    <DialogTitle>@Title</DialogTitle>
+    <EditForm Model="_model" OnValidSubmit="HandleValidSubmit">
+        <DataAnnotationsValidator />
+        <DialogContent>
+            <MudGrid>
+                <MudItem xs="12" sm="6">
+                    <MudNumericField Label="From quantity" @bind-Value="_model.FromQuantity" Variant="Variant.Outlined" Required="true"
+                        For="() => _model.FromQuantity" />
+                </MudItem>
+                <MudItem xs="12" sm="6">
+                    <MudNumericField Label="To quantity" @bind-Value="_model.ToQuantity" Variant="Variant.Outlined"
+                        For="() => _model.ToQuantity" HelperText="Leave empty for no upper limit" />
+                </MudItem>
+                <MudItem xs="12">
+                    <MudSelect @bind-Value="_model.TierType" Label="Tier type" Variant="Variant.Outlined">
+                        @foreach (var value in Enum.GetValues<ProductPriceTierType>())
+                        {
+                            <MudSelectItem Value="value">@value</MudSelectItem>
+                        }
+                    </MudSelect>
+                </MudItem>
+                <MudItem xs="12">
+                    <MudNumericField Label="Value" @bind-Value="_model.Value" Variant="Variant.Outlined" For="() => _model.Value"
+                        Adornment="Adornment.End" AdornmentText="@ValueLabel" />
+                </MudItem>
+            </MudGrid>
+        </DialogContent>
+        <DialogActions>
+            <MudButton Variant="Variant.Text" OnClick="Cancel">Cancel</MudButton>
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" ButtonType="ButtonType.Submit">Save</MudButton>
+        </DialogActions>
+    </EditForm>
+</MudDialog>
+
+@code {
+    [CascadingParameter]
+    public IMudDialogInstance MudDialog { get; set; } = default!;
+
+    [Parameter]
+    public string Title { get; set; } = "Price tier";
+
+    [Parameter]
+    public PriceUpdateViewModel.PriceTierFormData? InitialData { get; set; }
+
+    private PriceTierFormModel _model = new();
+
+    private string ValueLabel => _model.TierType switch
+    {
+        ProductPriceTierType.PricePerUnit => "Price",
+        ProductPriceTierType.DiscountPerUnit => "Discount",
+        ProductPriceTierType.DiscountPerAdditionalUnit => "Discount",
+        _ => string.Empty
+    };
+
+    protected override void OnInitialized()
+    {
+        if (InitialData is PriceUpdateViewModel.PriceTierFormData data)
+        {
+            _model = PriceTierFormModel.FromData(data);
+        }
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+
+    private void HandleValidSubmit()
+    {
+        var data = new PriceUpdateViewModel.PriceTierFormData(
+            _model.FromQuantity,
+            _model.ToQuantity,
+            _model.TierType,
+            _model.Value);
+
+        MudDialog.Close(DialogResult.Ok(data));
+    }
+
+    private sealed record PriceTierFormModel
+    {
+        [Required]
+        [Range(1, int.MaxValue)]
+        public int FromQuantity { get; set; } = 1;
+
+        [Range(1, int.MaxValue)]
+        public int? ToQuantity { get; set; }
+
+        [Required]
+        public ProductPriceTierType TierType { get; set; } = ProductPriceTierType.PricePerUnit;
+
+        [Range(typeof(decimal), "0", "79228162514264337593543950335")]
+        public decimal Value { get; set; }
+
+        public static PriceTierFormModel FromData(PriceUpdateViewModel.PriceTierFormData data)
+        {
+            return new PriceTierFormModel
+            {
+                FromQuantity = data.FromQuantity,
+                ToQuantity = data.ToQuantity,
+                TierType = data.TierType,
+                Value = data.Value
+            };
+        }
+    }
+}

--- a/src/Catalog/Catalog.UnitTests/ProductPricingServiceTests.cs
+++ b/src/Catalog/Catalog.UnitTests/ProductPricingServiceTests.cs
@@ -1,0 +1,96 @@
+using System;
+
+using YourBrand.Catalog.Domain.Entities;
+using YourBrand.Catalog.Features.ProductManagement;
+using Xunit;
+
+namespace YourBrand.Catalog.UnitTests;
+
+public class ProductPricingServiceTests
+{
+    private readonly ProductPricingService _service = new();
+
+    [Fact]
+    public void CalculatePrice_WithNoTiers_UsesBasePrice()
+    {
+        var product = CreateProduct(100m);
+
+        var result = _service.CalculatePrice(product, Array.Empty<ProductOptionValue>(), null, quantity: 3);
+
+        Assert.Equal(100m, result.BasePrice);
+        Assert.Equal(3, result.Quantity);
+        Assert.Equal(0m, result.TierDiscount);
+        Assert.Equal(300m, result.Total);
+        Assert.Equal(100m, result.UnitPrice);
+    }
+
+    [Fact]
+    public void CalculatePrice_AppliesPricePerUnitTier()
+    {
+        var product = CreateProduct(120m);
+        var price = product.CurrentPrice;
+        price.AddPriceTier(new ProductPriceTier(price.Id, 5, null, ProductPriceTierType.PricePerUnit, 90m));
+
+        var result = _service.CalculatePrice(product, Array.Empty<ProductOptionValue>(), null, quantity: 5);
+
+        Assert.Equal(5, result.Quantity);
+        Assert.Equal(120m * 5 - 90m * 5, result.TierDiscount);
+        Assert.Equal(90m, result.UnitPrice);
+        Assert.Equal(450m, result.Total);
+    }
+
+    [Fact]
+    public void CalculatePrice_AppliesDiscountPerUnitTier()
+    {
+        var product = CreateProduct(80m);
+        var price = product.CurrentPrice;
+        price.AddPriceTier(new ProductPriceTier(price.Id, 3, 10, ProductPriceTierType.DiscountPerUnit, 15m));
+
+        var result = _service.CalculatePrice(product, Array.Empty<ProductOptionValue>(), null, quantity: 4);
+
+        Assert.Equal(4, result.Quantity);
+        Assert.Equal(15m * 4, result.TierDiscount);
+        Assert.Equal(80m * 4 - 15m * 4, result.Total);
+    }
+
+    [Fact]
+    public void CalculatePrice_AppliesDiscountPerAdditionalUnitTier()
+    {
+        var product = CreateProduct(50m);
+        var price = product.CurrentPrice;
+        price.AddPriceTier(new ProductPriceTier(price.Id, 2, null, ProductPriceTierType.DiscountPerAdditionalUnit, 10m));
+
+        var result = _service.CalculatePrice(product, Array.Empty<ProductOptionValue>(), null, quantity: 5);
+
+        Assert.Equal(5, result.Quantity);
+        Assert.Equal(10m * 4, result.TierDiscount);
+        Assert.Equal(50m * 5 - 40m, result.Total);
+    }
+
+    [Fact]
+    public void CalculatePrice_RespectsAdditionalUnitUpperBound()
+    {
+        var product = CreateProduct(60m);
+        var price = product.CurrentPrice;
+        price.AddPriceTier(new ProductPriceTier(price.Id, 2, 4, ProductPriceTierType.DiscountPerAdditionalUnit, 5m));
+
+        var result = _service.CalculatePrice(product, Array.Empty<ProductOptionValue>(), null, quantity: 6);
+
+        Assert.Equal(6, result.Quantity);
+        Assert.Equal(5m * 3, result.TierDiscount);
+        Assert.Equal(60m * 6 - 15m, result.Total);
+    }
+
+    private static Product CreateProduct(decimal price)
+    {
+        var product = new Product("Test", Guid.NewGuid().ToString())
+        {
+            PricingModel = PricingModel.FixedPrice,
+            DiscountApplicationMode = DiscountApplicationMode.OnBasePrice
+        };
+
+        product.SetPrice(price);
+
+        return product;
+    }
+}

--- a/src/Catalog/Catalog/Domain/Entities/ProductPrice.cs
+++ b/src/Catalog/Catalog/Domain/Entities/ProductPrice.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 using Core;
 
 using YourBrand.Auditability;
@@ -9,6 +11,8 @@ namespace YourBrand.Catalog.Domain.Entities;
 
 public class ProductPrice : IAuditableEntity<string>, ISoftDeletableWithAudit, IHasTenant, IHasOrganization
 {
+    readonly HashSet<ProductPriceTier> _priceTiers = new();
+
     decimal _price;
     decimal? _regularPrice;
 
@@ -132,6 +136,46 @@ public class ProductPrice : IAuditableEntity<string>, ISoftDeletableWithAudit, I
 
     public DateTimeOffset? ValidFrom { get; set; }
     public DateTimeOffset? ValidTo { get; set; }
+
+    public IReadOnlyCollection<ProductPriceTier> PriceTiers => _priceTiers;
+
+    public void AddPriceTier(ProductPriceTier priceTier)
+    {
+        ArgumentNullException.ThrowIfNull(priceTier);
+
+        if (priceTier.ProductPriceId != Id)
+        {
+            throw new InvalidOperationException("The price tier must belong to this price instance.");
+        }
+
+        _priceTiers.Add(priceTier);
+    }
+
+    public ProductPriceTier? GetPriceTier(string tierId)
+    {
+        ArgumentNullException.ThrowIfNull(tierId);
+
+        return _priceTiers.FirstOrDefault(x => x.Id == tierId);
+    }
+
+    public void UpdatePriceTier(ProductPriceTier priceTier, int fromQuantity, int? toQuantity, ProductPriceTierType tierType, decimal value)
+    {
+        ArgumentNullException.ThrowIfNull(priceTier);
+
+        if (!_priceTiers.Contains(priceTier))
+        {
+            throw new InvalidOperationException("The price tier must belong to this price instance.");
+        }
+
+        priceTier.Update(fromQuantity, toQuantity, tierType, value);
+    }
+
+    public void RemovePriceTier(ProductPriceTier priceTier)
+    {
+        ArgumentNullException.ThrowIfNull(priceTier);
+
+        _priceTiers.Remove(priceTier);
+    }
 
     public UserId? CreatedById { get; set; }
     public DateTimeOffset Created { get; set; }

--- a/src/Catalog/Catalog/Domain/Entities/ProductPriceTier.cs
+++ b/src/Catalog/Catalog/Domain/Entities/ProductPriceTier.cs
@@ -1,0 +1,87 @@
+using System;
+
+using YourBrand.Auditability;
+using YourBrand.Domain;
+using YourBrand.Identity;
+using YourBrand.Tenancy;
+
+namespace YourBrand.Catalog.Domain.Entities;
+
+public class ProductPriceTier : Entity<string>, IHasTenant, IHasOrganization, IAuditableEntity<string>, ISoftDeletableWithAudit
+{
+    private ProductPriceTier()
+    {
+    }
+
+    public ProductPriceTier(
+        string productPriceId,
+        int fromQuantity,
+        int? toQuantity,
+        ProductPriceTierType tierType,
+        decimal value) : base(Guid.NewGuid().ToString())
+    {
+        ProductPriceId = productPriceId ?? throw new ArgumentNullException(nameof(productPriceId));
+
+        Update(fromQuantity, toQuantity, tierType, value);
+    }
+
+    public TenantId TenantId { get; set; }
+
+    public OrganizationId OrganizationId { get; set; }
+
+    public string ProductPriceId { get; private set; } = default!;
+
+    public ProductPrice ProductPrice { get; private set; } = default!;
+
+    public int FromQuantity { get; private set; }
+
+    public int? ToQuantity { get; private set; }
+
+    public ProductPriceTierType TierType { get; private set; }
+
+    public decimal Value { get; private set; }
+
+    public void Update(int fromQuantity, int? toQuantity, ProductPriceTierType tierType, decimal value)
+    {
+        if (fromQuantity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(fromQuantity), "Quantity must be greater than zero.");
+        }
+
+        if (toQuantity is not null && toQuantity < fromQuantity)
+        {
+            throw new ArgumentException("The upper quantity bound must be greater than or equal to the lower bound.", nameof(toQuantity));
+        }
+
+        if (value < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(value), "Value cannot be negative.");
+        }
+
+        FromQuantity = fromQuantity;
+        ToQuantity = toQuantity;
+        TierType = tierType;
+        Value = value;
+    }
+
+    public UserId? CreatedById { get; set; }
+
+    public DateTimeOffset Created { get; set; }
+
+    public UserId? LastModifiedById { get; set; }
+
+    public DateTimeOffset? LastModified { get; set; }
+
+    public bool IsDeleted { get; set; }
+
+    public DateTimeOffset? Deleted { get; set; }
+
+    public UserId? DeletedById { get; set; }
+}
+
+public enum ProductPriceTierType
+{
+    PricePerUnit = 1,
+    DiscountPerUnit = 2,
+    DiscountPerAdditionalUnit = 3
+}

--- a/src/Catalog/Catalog/Features/ProductManagement/ProductPricingService.cs
+++ b/src/Catalog/Catalog/Features/ProductManagement/ProductPricingService.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 using YourBrand.Catalog.Domain.Entities;
 
 namespace YourBrand.Catalog.Features.ProductManagement;
@@ -7,20 +9,32 @@ public class ProductPricingService
     public ProductPriceResult CalculatePrice(
         Product product,
         IEnumerable<ProductOptionValue> selectedOptionValues,
-        ProductSubscriptionPlan? subscriptionPlan = null)
+        ProductSubscriptionPlan? subscriptionPlan = null,
+        int quantity = 1)
     {
+        ArgumentNullException.ThrowIfNull(product);
+
+        if (quantity <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(quantity));
+        }
+
         var p = product.Prices.First();
-            
+
         var basePrice = p.Price;
         var optionDetails = new List<ProductOptionPriceDetail>();
 
         var optionsTotal = CalculateOptionsTotal(product, selectedOptionValues, optionDetails);
 
-        decimal subtotal = basePrice;
+        var optionsSubtotal = product.PricingModel == PricingModel.OptionsBased ? optionsTotal * quantity : 0m;
+
+        var tierResult = CalculateTierAdjustment(p, quantity);
+
+        decimal subtotal = tierResult.SubtotalAfterTier;
 
         if (product.PricingModel == PricingModel.OptionsBased)
         {
-            subtotal += optionsTotal;
+            subtotal += optionsSubtotal;
         }
 
         decimal productDiscount = 0;
@@ -29,9 +43,9 @@ public class ProductPricingService
         {
             if (product.DiscountApplicationMode == DiscountApplicationMode.OnBasePrice)
             {
-                var discountedBase = ApplyDiscount(basePrice, p.DiscountRate.Value);
-                productDiscount = basePrice - discountedBase;
-                subtotal = discountedBase + optionsTotal;
+                var discountedBase = ApplyDiscount(tierResult.SubtotalAfterTier, p.DiscountRate.Value);
+                productDiscount = tierResult.SubtotalAfterTier - discountedBase;
+                subtotal = discountedBase + optionsSubtotal;
             }
             else if (product.DiscountApplicationMode == DiscountApplicationMode.AfterOptions)
             {
@@ -52,9 +66,13 @@ public class ProductPricingService
         {
             BasePrice = basePrice,
             OptionsTotal = optionsTotal,
+            Quantity = quantity,
+            TierDiscount = tierResult.TierDiscount,
             ProductDiscount = productDiscount,
             SubscriptionDiscount = subscriptionDiscount,
             Total = subtotal,
+            UnitPrice = subtotal / quantity,
+            PriceTier = tierResult.ToApplication(),
             OptionBreakdown = optionDetails
         };
     }
@@ -116,6 +134,104 @@ public class ProductPricingService
 
         return optionsTotal;
     }
+
+    private static TierCalculationResult CalculateTierAdjustment(ProductPrice price, int quantity)
+    {
+        var baseSubtotal = price.Price * quantity;
+
+        var tier = price.PriceTiers
+            .Where(t => t.FromQuantity <= quantity && (t.ToQuantity is null || quantity <= t.ToQuantity))
+            .OrderByDescending(t => t.FromQuantity)
+            .ThenByDescending(t => t.ToQuantity ?? int.MaxValue)
+            .FirstOrDefault();
+
+        if (tier is null)
+        {
+            return TierCalculationResult.None(baseSubtotal, price.Price);
+        }
+
+        return tier.TierType switch
+        {
+            ProductPriceTierType.PricePerUnit => CalculatePricePerUnitTier(tier, baseSubtotal, quantity),
+            ProductPriceTierType.DiscountPerUnit => CalculateDiscountPerUnitTier(price, tier, baseSubtotal, quantity),
+            ProductPriceTierType.DiscountPerAdditionalUnit => CalculateDiscountPerAdditionalUnitTier(price, tier, baseSubtotal, quantity),
+            _ => TierCalculationResult.None(baseSubtotal, price.Price)
+        };
+    }
+
+    private static TierCalculationResult CalculatePricePerUnitTier(ProductPriceTier tier, decimal baseSubtotal, int quantity)
+    {
+        var subtotalAfterTier = tier.Value * quantity;
+        var tierDiscount = Math.Max(0, baseSubtotal - subtotalAfterTier);
+
+        return new TierCalculationResult(
+            tier,
+            ClampNonNegative(subtotalAfterTier),
+            tierDiscount,
+            quantity,
+            tier.Value);
+    }
+
+    private static TierCalculationResult CalculateDiscountPerUnitTier(ProductPrice price, ProductPriceTier tier, decimal baseSubtotal, int quantity)
+    {
+        var discountPerUnit = Math.Min(tier.Value, price.Price);
+        var tierDiscount = discountPerUnit * quantity;
+        var subtotalAfterTier = ClampNonNegative(baseSubtotal - tierDiscount);
+
+        return new TierCalculationResult(
+            tier,
+            subtotalAfterTier,
+            tierDiscount,
+            quantity,
+            quantity > 0 ? subtotalAfterTier / quantity : price.Price);
+    }
+
+    private static TierCalculationResult CalculateDiscountPerAdditionalUnitTier(ProductPrice price, ProductPriceTier tier, decimal baseSubtotal, int quantity)
+    {
+        var upperBound = tier.ToQuantity ?? quantity;
+        var eligibleUnits = Math.Min(quantity, upperBound) - tier.FromQuantity + 1;
+        if (eligibleUnits < 0)
+        {
+            eligibleUnits = 0;
+        }
+
+        var discountPerUnit = Math.Min(tier.Value, price.Price);
+        var tierDiscount = discountPerUnit * eligibleUnits;
+        var subtotalAfterTier = ClampNonNegative(baseSubtotal - tierDiscount);
+
+        return new TierCalculationResult(
+            tier,
+            subtotalAfterTier,
+            tierDiscount,
+            eligibleUnits,
+            quantity > 0 ? subtotalAfterTier / quantity : price.Price);
+    }
+
+    private static decimal ClampNonNegative(decimal value) => value < 0 ? 0 : value;
+
+    private sealed record TierCalculationResult(ProductPriceTier? Tier, decimal SubtotalAfterTier, decimal TierDiscount, int DiscountedUnits, decimal EffectiveUnitPrice)
+    {
+        public static TierCalculationResult None(decimal subtotal, decimal unitPrice) => new(null, subtotal, 0m, 0, unitPrice);
+
+        public ProductPriceTierApplication? ToApplication()
+        {
+            if (Tier is null)
+            {
+                return null;
+            }
+
+            return new ProductPriceTierApplication
+            {
+                Id = Tier.Id,
+                FromQuantity = Tier.FromQuantity,
+                ToQuantity = Tier.ToQuantity,
+                TierType = Tier.TierType,
+                Value = Tier.Value,
+                DiscountedUnits = DiscountedUnits,
+                EffectiveUnitPrice = EffectiveUnitPrice
+            };
+        }
+    }
 }
 
 public class ProductOptionValue
@@ -129,9 +245,16 @@ public class ProductPriceResult
 {
     public decimal BasePrice { get; set; }
     public decimal OptionsTotal { get; set; }
+    public int Quantity { get; set; } = 1;
+    public decimal TierDiscount { get; set; }
     public decimal ProductDiscount { get; set; }
     public decimal SubscriptionDiscount { get; set; }
     public decimal Total { get; set; }
+    public decimal UnitPrice { get; set; }
+
+    public decimal DiscountAmount => TierDiscount + ProductDiscount + SubscriptionDiscount;
+
+    public ProductPriceTierApplication? PriceTier { get; set; }
 
     public List<ProductOptionPriceDetail>? OptionBreakdown { get; set; }
 }
@@ -140,4 +263,15 @@ public class ProductOptionPriceDetail
 {
     public string OptionId { get; set; } = default!;
     public decimal Price { get; set; }
+}
+
+public class ProductPriceTierApplication
+{
+    public string Id { get; set; } = default!;
+    public int FromQuantity { get; set; }
+    public int? ToQuantity { get; set; }
+    public ProductPriceTierType TierType { get; set; }
+    public decimal Value { get; set; }
+    public int DiscountedUnits { get; set; }
+    public decimal EffectiveUnitPrice { get; set; }
 }

--- a/src/Catalog/Catalog/Features/ProductManagement/Products/CalculateProductPrice.cs
+++ b/src/Catalog/Catalog/Features/ProductManagement/Products/CalculateProductPrice.cs
@@ -7,7 +7,12 @@ using YourBrand.Catalog.Persistence;
 
 namespace YourBrand.Catalog.Features.ProductManagement.Products;
 
-public sealed record CalculateProductPrice(string OrganizationId, string IdOrHandle, List<ProductOptionValue> OptionValues, string? SubscriptionPlanId = null) : IRequest<ProductPriceResult>
+public sealed record CalculateProductPrice(
+    string OrganizationId,
+    string IdOrHandle,
+    List<ProductOptionValue> OptionValues,
+    int Quantity,
+    string? SubscriptionPlanId = null) : IRequest<ProductPriceResult>
 {
     public sealed class Handler(CatalogContext catalogContext, ProductPricingService productPricingService) : IRequestHandler<CalculateProductPrice, ProductPriceResult>
     {
@@ -33,7 +38,7 @@ public sealed record CalculateProductPrice(string OrganizationId, string IdOrHan
                 subscriptionPlan = product.SubscriptionPlans.FirstOrDefault(x => x.Id == request.SubscriptionPlanId);
             }
 
-            return productPricingService.CalculatePrice(product, request.OptionValues, subscriptionPlan);
+            return productPricingService.CalculatePrice(product, request.OptionValues, subscriptionPlan, request.Quantity);
         }
     }
 }

--- a/src/Catalog/Catalog/Features/ProductManagement/Products/CalculateProductPrice.cs
+++ b/src/Catalog/Catalog/Features/ProductManagement/Products/CalculateProductPrice.cs
@@ -24,6 +24,7 @@ public sealed record CalculateProductPrice(
                 .InOrganization(request.OrganizationId)
                 .IncludeAll()
                 .Include(x => x.Prices)
+                    .ThenInclude(x => x.PriceTiers)
                 .AsSplitQuery()
                 .AsQueryable();
 

--- a/src/Catalog/Catalog/Features/ProductManagement/Products/Endpoints.cs
+++ b/src/Catalog/Catalog/Features/ProductManagement/Products/Endpoints.cs
@@ -12,6 +12,7 @@ using YourBrand.Catalog.Features.ProductManagement.ProductCategories;
 using YourBrand.Catalog.Features.ProductManagement.Products.Attributes;
 using YourBrand.Catalog.Features.ProductManagement.Products.Images;
 using YourBrand.Catalog.Features.ProductManagement.Products.Options;
+using YourBrand.Catalog.Features.ProductManagement.Products.PriceTiers;
 using YourBrand.Catalog.Features.ProductManagement.SubscriptionPlans.SubscriptionPlans;
 using YourBrand.Catalog.Features.Stores;
 using YourBrand.Catalog.Model;
@@ -27,6 +28,7 @@ public static partial class Endpoints
 
         app.MapProductAttributesEndpoints()
             .MapProductOptionsEndpoints()
+            .MapProductPriceTiersEndpoints()
             .MapProductSubscriptionPlansEndpoints();
 
         var versionedApi = app.NewVersionedApi("Products");
@@ -139,7 +141,8 @@ public static partial class Endpoints
     
     private static async Task<Results<Ok<ProductPriceResult>, NotFound>> CalculateProductPrice(string organizationId, string idOrHandle, CalculateProductPriceRequest request, IMediator mediator, CancellationToken cancellationToken)
     {
-        var result = await mediator.Send(new CalculateProductPrice(organizationId, idOrHandle, request.OptionValues, request.SubscriptionPlanId), cancellationToken);
+        var quantity = request.Quantity <= 0 ? 1 : request.Quantity;
+        var result = await mediator.Send(new CalculateProductPrice(organizationId, idOrHandle, request.OptionValues, quantity, request.SubscriptionPlanId), cancellationToken);
 
         return TypedResults.Ok(result);
     }
@@ -404,4 +407,6 @@ public record class UpdateProductImageData(string? Title, string? Text);
 public record class SetMainProductImageData();
 
 public record class CalculateProductPriceRequest(
-        List<ProductOptionValue> OptionValues, string? SubscriptionPlanId = null);
+    List<ProductOptionValue> OptionValues,
+    int Quantity = 1,
+    string? SubscriptionPlanId = null);

--- a/src/Catalog/Catalog/Features/ProductManagement/Products/Errors.cs
+++ b/src/Catalog/Catalog/Features/ProductManagement/Products/Errors.cs
@@ -17,4 +17,8 @@ public static class Errors
     public readonly static Error BrandNotFound = new("brand-not-found", "Brand not found", "");
 
     public readonly static Error VatRateNotFound = new("vatrate-not-found", "VAT Rate not found", "");
+
+    public readonly static Error ProductPriceMissing = new("product-price-missing", "Product is missing price information", "");
+
+    public readonly static Error ProductPriceTierNotFound = new("product-price-tier-not-found", "Product price tier not found", "");
 }

--- a/src/Catalog/Catalog/Features/ProductManagement/Products/PriceTiers/CreateProductPriceTier.cs
+++ b/src/Catalog/Catalog/Features/ProductManagement/Products/PriceTiers/CreateProductPriceTier.cs
@@ -1,0 +1,61 @@
+using System.Linq;
+
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Catalog.Domain.Entities;
+using YourBrand.Catalog.Features.ProductManagement.Products;
+using YourBrand.Catalog.Persistence;
+
+namespace YourBrand.Catalog.Features.ProductManagement.Products.PriceTiers;
+
+public sealed record CreateProductPriceTier(
+    string OrganizationId,
+    string IdOrHandle,
+    int FromQuantity,
+    int? ToQuantity,
+    ProductPriceTierType TierType,
+    decimal Value) : IRequest<Result<ProductPriceTierDto>>
+{
+    public sealed class Handler(CatalogContext catalogContext) : IRequestHandler<CreateProductPriceTier, Result<ProductPriceTierDto>>
+    {
+        public async Task<Result<ProductPriceTierDto>> Handle(CreateProductPriceTier request, CancellationToken cancellationToken)
+        {
+            var isId = int.TryParse(request.IdOrHandle, out var id);
+
+            var productQuery = catalogContext.Products
+                .InOrganization(request.OrganizationId)
+                .Include(x => x.Prices)
+                    .ThenInclude(x => x.PriceTiers);
+
+            var product = isId
+                ? await productQuery.FirstOrDefaultAsync(x => x.Id == id, cancellationToken)
+                : await productQuery.FirstOrDefaultAsync(x => x.Handle == request.IdOrHandle, cancellationToken);
+
+            if (product is null)
+            {
+                return Result.Failure<ProductPriceTierDto>(Errors.ProductNotFound);
+            }
+
+            var price = product.Prices.FirstOrDefault();
+
+            if (price is null)
+            {
+                return Result.Failure<ProductPriceTierDto>(Errors.ProductPriceMissing);
+            }
+
+            var priceTier = new ProductPriceTier(price.Id, request.FromQuantity, request.ToQuantity, request.TierType, request.Value)
+            {
+                OrganizationId = product.OrganizationId,
+                TenantId = product.TenantId
+            };
+
+            price.AddPriceTier(priceTier);
+
+            await catalogContext.SaveChangesAsync(cancellationToken);
+
+            return Result.SuccessWith(priceTier.ToDto());
+        }
+    }
+}

--- a/src/Catalog/Catalog/Features/ProductManagement/Products/PriceTiers/DeleteProductPriceTier.cs
+++ b/src/Catalog/Catalog/Features/ProductManagement/Products/PriceTiers/DeleteProductPriceTier.cs
@@ -1,0 +1,57 @@
+using System.Linq;
+
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Catalog.Features.ProductManagement.Products;
+using YourBrand.Catalog.Persistence;
+
+namespace YourBrand.Catalog.Features.ProductManagement.Products.PriceTiers;
+
+public sealed record DeleteProductPriceTier(string OrganizationId, string IdOrHandle, string TierId) : IRequest<Result>
+{
+    public sealed class Handler(CatalogContext catalogContext) : IRequestHandler<DeleteProductPriceTier, Result>
+    {
+        public async Task<Result> Handle(DeleteProductPriceTier request, CancellationToken cancellationToken)
+        {
+            var isId = int.TryParse(request.IdOrHandle, out var id);
+
+            var productQuery = catalogContext.Products
+                .InOrganization(request.OrganizationId)
+                .Include(x => x.Prices)
+                    .ThenInclude(x => x.PriceTiers);
+
+            var product = isId
+                ? await productQuery.FirstOrDefaultAsync(x => x.Id == id, cancellationToken)
+                : await productQuery.FirstOrDefaultAsync(x => x.Handle == request.IdOrHandle, cancellationToken);
+
+            if (product is null)
+            {
+                return Result.Failure(Errors.ProductNotFound);
+            }
+
+            var price = product.Prices.FirstOrDefault();
+
+            if (price is null)
+            {
+                return Result.Failure(Errors.ProductPriceMissing);
+            }
+
+            var tier = price.GetPriceTier(request.TierId) ?? await catalogContext.ProductPriceTiers
+                .InOrganization(request.OrganizationId)
+                .FirstOrDefaultAsync(x => x.Id == request.TierId, cancellationToken);
+
+            if (tier is null)
+            {
+                return Result.Failure(Errors.ProductPriceTierNotFound);
+            }
+
+            catalogContext.ProductPriceTiers.Remove(tier);
+
+            await catalogContext.SaveChangesAsync(cancellationToken);
+
+            return Result.Success;
+        }
+    }
+}

--- a/src/Catalog/Catalog/Features/ProductManagement/Products/PriceTiers/Endpoints.cs
+++ b/src/Catalog/Catalog/Features/ProductManagement/Products/PriceTiers/Endpoints.cs
@@ -1,0 +1,165 @@
+using FluentValidation;
+
+using MediatR;
+
+using Microsoft.AspNetCore.Http.HttpResults;
+
+using YourBrand.Catalog.Domain.Entities;
+using YourBrand.Catalog.Features.ProductManagement.Products;
+using YourBrand.Extensions;
+
+namespace YourBrand.Catalog.Features.ProductManagement.Products.PriceTiers;
+
+public static class Endpoints
+{
+    public static IEndpointRouteBuilder MapProductPriceTiersEndpoints(this IEndpointRouteBuilder app)
+    {
+        var versionedApi = app.NewVersionedApi("Products");
+
+        var group = versionedApi.MapGroup("/v{version:apiVersion}/products/{idOrHandle}/price/tiers")
+            .WithTags("Products")
+            .HasApiVersion(ApiVersions.V1)
+            .WithOpenApi()
+            .RequireAuthorization();
+
+        group.MapGet("/", GetProductPriceTiers)
+            .WithName($"Products_{nameof(GetProductPriceTiers)}");
+
+        group.MapPost("/", CreateProductPriceTier)
+            .AddEndpointFilter<ValidationFilter<CreateProductPriceTierRequest>>()
+            .WithName($"Products_{nameof(CreateProductPriceTier)}");
+
+        group.MapPut("/{tierId}", UpdateProductPriceTier)
+            .AddEndpointFilter<ValidationFilter<UpdateProductPriceTierRequest>>()
+            .WithName($"Products_{nameof(UpdateProductPriceTier)}");
+
+        group.MapDelete("/{tierId}", DeleteProductPriceTier)
+            .WithName($"Products_{nameof(DeleteProductPriceTier)}");
+
+        return app;
+    }
+
+    private static async Task<Results<Ok<IEnumerable<ProductPriceTierDto>>, NotFound>> GetProductPriceTiers(
+        string organizationId,
+        string idOrHandle,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new GetProductPriceTiers(organizationId, idOrHandle), cancellationToken);
+
+        return result.IsSuccess
+            ? TypedResults.Ok(result.GetValue())
+            : TypedResults.NotFound();
+    }
+
+    private static async Task<Results<Ok<ProductPriceTierDto>, NotFound, BadRequest>> CreateProductPriceTier(
+        string organizationId,
+        string idOrHandle,
+        CreateProductPriceTierRequest request,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new CreateProductPriceTier(
+            organizationId,
+            idOrHandle,
+            request.FromQuantity,
+            request.ToQuantity,
+            request.TierType,
+            request.Value),
+            cancellationToken);
+
+        if (result.IsFailure)
+        {
+            return result.HasError(Products.Errors.ProductNotFound)
+                ? TypedResults.NotFound()
+                : TypedResults.BadRequest();
+        }
+
+        return TypedResults.Ok(result.GetValue());
+    }
+
+    private static async Task<Results<Ok<ProductPriceTierDto>, NotFound, BadRequest>> UpdateProductPriceTier(
+        string organizationId,
+        string idOrHandle,
+        string tierId,
+        UpdateProductPriceTierRequest request,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new UpdateProductPriceTier(
+            organizationId,
+            idOrHandle,
+            tierId,
+            request.FromQuantity,
+            request.ToQuantity,
+            request.TierType,
+            request.Value),
+            cancellationToken);
+
+        if (result.IsFailure)
+        {
+            if (result.HasError(Products.Errors.ProductNotFound) || result.HasError(Products.Errors.ProductPriceTierNotFound))
+            {
+                return TypedResults.NotFound();
+            }
+
+            return TypedResults.BadRequest();
+        }
+
+        return TypedResults.Ok(result.GetValue());
+    }
+
+    private static async Task<Results<NoContent, NotFound, BadRequest>> DeleteProductPriceTier(
+        string organizationId,
+        string idOrHandle,
+        string tierId,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new DeleteProductPriceTier(organizationId, idOrHandle, tierId), cancellationToken);
+
+        if (result.IsFailure)
+        {
+            if (result.HasError(Products.Errors.ProductNotFound) || result.HasError(Products.Errors.ProductPriceTierNotFound))
+            {
+                return TypedResults.NotFound();
+            }
+
+            return TypedResults.BadRequest();
+        }
+
+        return TypedResults.NoContent();
+    }
+}
+
+public sealed record CreateProductPriceTierRequest(
+    int FromQuantity,
+    int? ToQuantity,
+    ProductPriceTierType TierType,
+    decimal Value);
+
+public sealed record UpdateProductPriceTierRequest(
+    int FromQuantity,
+    int? ToQuantity,
+    ProductPriceTierType TierType,
+    decimal Value);
+
+public sealed class CreateProductPriceTierRequestValidator : AbstractValidator<CreateProductPriceTierRequest>
+{
+    public CreateProductPriceTierRequestValidator()
+    {
+        RuleFor(x => x.FromQuantity).GreaterThan(0);
+        RuleFor(x => x.ToQuantity).GreaterThanOrEqualTo(x => x.FromQuantity).When(x => x.ToQuantity.HasValue);
+        RuleFor(x => x.Value).GreaterThanOrEqualTo(0);
+    }
+}
+
+public sealed class UpdateProductPriceTierRequestValidator : AbstractValidator<UpdateProductPriceTierRequest>
+{
+    public UpdateProductPriceTierRequestValidator()
+    {
+        RuleFor(x => x.FromQuantity).GreaterThan(0);
+        RuleFor(x => x.ToQuantity).GreaterThanOrEqualTo(x => x.FromQuantity).When(x => x.ToQuantity.HasValue);
+        RuleFor(x => x.Value).GreaterThanOrEqualTo(0);
+    }
+}

--- a/src/Catalog/Catalog/Features/ProductManagement/Products/PriceTiers/GetProductPriceTiers.cs
+++ b/src/Catalog/Catalog/Features/ProductManagement/Products/PriceTiers/GetProductPriceTiers.cs
@@ -1,0 +1,50 @@
+using System.Linq;
+
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Catalog.Features.ProductManagement.Products;
+using YourBrand.Catalog.Persistence;
+
+namespace YourBrand.Catalog.Features.ProductManagement.Products.PriceTiers;
+
+public sealed record GetProductPriceTiers(string OrganizationId, string IdOrHandle) : IRequest<Result<IEnumerable<ProductPriceTierDto>>>
+{
+    public sealed class Handler(CatalogContext catalogContext) : IRequestHandler<GetProductPriceTiers, Result<IEnumerable<ProductPriceTierDto>>>
+    {
+        public async Task<Result<IEnumerable<ProductPriceTierDto>>> Handle(GetProductPriceTiers request, CancellationToken cancellationToken)
+        {
+            var isId = int.TryParse(request.IdOrHandle, out var id);
+
+            var productQuery = catalogContext.Products
+                .InOrganization(request.OrganizationId)
+                .AsNoTracking()
+                .Include(x => x.Prices)
+                    .ThenInclude(x => x.PriceTiers);
+
+            var product = isId
+                ? await productQuery.FirstOrDefaultAsync(x => x.Id == id, cancellationToken)
+                : await productQuery.FirstOrDefaultAsync(x => x.Handle == request.IdOrHandle, cancellationToken);
+
+            if (product is null)
+            {
+                return Result.Failure<IEnumerable<ProductPriceTierDto>>(Errors.ProductNotFound);
+            }
+
+            var price = product.Prices.FirstOrDefault();
+
+            if (price is null)
+            {
+                return Result.Failure<IEnumerable<ProductPriceTierDto>>(Errors.ProductPriceMissing);
+            }
+
+            var tiers = price.PriceTiers
+                .OrderBy(x => x.FromQuantity)
+                .ThenBy(x => x.ToQuantity ?? int.MaxValue)
+                .Select(x => x.ToDto());
+
+            return Result.SuccessWith(tiers);
+        }
+    }
+}

--- a/src/Catalog/Catalog/Features/ProductManagement/Products/PriceTiers/ProductPriceTierDto.cs
+++ b/src/Catalog/Catalog/Features/ProductManagement/Products/PriceTiers/ProductPriceTierDto.cs
@@ -1,0 +1,23 @@
+using YourBrand.Catalog.Domain.Entities;
+
+namespace YourBrand.Catalog.Features.ProductManagement.Products.PriceTiers;
+
+public sealed record ProductPriceTierDto(
+    string Id,
+    int FromQuantity,
+    int? ToQuantity,
+    ProductPriceTierType TierType,
+    decimal Value);
+
+public static class ProductPriceTierMappings
+{
+    public static ProductPriceTierDto ToDto(this ProductPriceTier tier)
+    {
+        return new ProductPriceTierDto(
+            tier.Id,
+            tier.FromQuantity,
+            tier.ToQuantity,
+            tier.TierType,
+            tier.Value);
+    }
+}

--- a/src/Catalog/Catalog/Features/ProductManagement/Products/PriceTiers/UpdateProductPriceTier.cs
+++ b/src/Catalog/Catalog/Features/ProductManagement/Products/PriceTiers/UpdateProductPriceTier.cs
@@ -1,0 +1,65 @@
+using System.Linq;
+
+using MediatR;
+
+using Microsoft.EntityFrameworkCore;
+
+using YourBrand.Catalog.Domain.Entities;
+using YourBrand.Catalog.Features.ProductManagement.Products;
+using YourBrand.Catalog.Persistence;
+
+namespace YourBrand.Catalog.Features.ProductManagement.Products.PriceTiers;
+
+public sealed record UpdateProductPriceTier(
+    string OrganizationId,
+    string IdOrHandle,
+    string TierId,
+    int FromQuantity,
+    int? ToQuantity,
+    ProductPriceTierType TierType,
+    decimal Value) : IRequest<Result<ProductPriceTierDto>>
+{
+    public sealed class Handler(CatalogContext catalogContext) : IRequestHandler<UpdateProductPriceTier, Result<ProductPriceTierDto>>
+    {
+        public async Task<Result<ProductPriceTierDto>> Handle(UpdateProductPriceTier request, CancellationToken cancellationToken)
+        {
+            var isId = int.TryParse(request.IdOrHandle, out var id);
+
+            var productQuery = catalogContext.Products
+                .InOrganization(request.OrganizationId)
+                .Include(x => x.Prices)
+                    .ThenInclude(x => x.PriceTiers);
+
+            var product = isId
+                ? await productQuery.FirstOrDefaultAsync(x => x.Id == id, cancellationToken)
+                : await productQuery.FirstOrDefaultAsync(x => x.Handle == request.IdOrHandle, cancellationToken);
+
+            if (product is null)
+            {
+                return Result.Failure<ProductPriceTierDto>(Errors.ProductNotFound);
+            }
+
+            var price = product.Prices.FirstOrDefault();
+
+            if (price is null)
+            {
+                return Result.Failure<ProductPriceTierDto>(Errors.ProductPriceMissing);
+            }
+
+            var tier = price.GetPriceTier(request.TierId) ?? await catalogContext.ProductPriceTiers
+                .InOrganization(request.OrganizationId)
+                .FirstOrDefaultAsync(x => x.Id == request.TierId, cancellationToken);
+
+            if (tier is null)
+            {
+                return Result.Failure<ProductPriceTierDto>(Errors.ProductPriceTierNotFound);
+            }
+
+            price.UpdatePriceTier(tier, request.FromQuantity, request.ToQuantity, request.TierType, request.Value);
+
+            await catalogContext.SaveChangesAsync(cancellationToken);
+
+            return Result.SuccessWith(tier.ToDto());
+        }
+    }
+}

--- a/src/Catalog/Catalog/Persistence/CatalogContext.cs
+++ b/src/Catalog/Catalog/Persistence/CatalogContext.cs
@@ -70,6 +70,8 @@ public sealed class CatalogContext(
 
     public DbSet<Option> Options { get; set; } = null!;
 
+    public DbSet<ProductPriceTier> ProductPriceTiers { get; set; } = null!;
+
     public DbSet<SelectableOption> SelectableOptions { get; set; } = null!;
 
     public DbSet<ChoiceOption> ChoiceOptions { get; set; } = null!;

--- a/src/Catalog/Catalog/Persistence/Configurations/ProductPriceTierConfiguration.cs
+++ b/src/Catalog/Catalog/Persistence/Configurations/ProductPriceTierConfiguration.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using YourBrand.Catalog.Domain.Entities;
+
+namespace YourBrand.Catalog.Persistence.Configurations;
+
+public class ProductPriceTierConfiguration : IEntityTypeConfiguration<ProductPriceTier>
+{
+    public void Configure(EntityTypeBuilder<ProductPriceTier> builder)
+    {
+        builder.ToTable("ProductPriceTiers");
+
+        builder.HasKey(x => new { x.OrganizationId, x.Id });
+
+        builder.Property(x => x.FromQuantity)
+            .IsRequired();
+
+        builder.Property(x => x.Value)
+            .HasColumnType("decimal(18,2)");
+
+        builder.Property(x => x.TierType)
+            .HasConversion<int>();
+
+        builder.HasOne(x => x.ProductPrice)
+            .WithMany(x => x.PriceTiers)
+            .HasForeignKey(x => new { x.OrganizationId, x.ProductPriceId });
+    }
+}

--- a/src/Catalog/Catalog/Persistence/Migrations/20251106141806_AddProductPriceTiers.Designer.cs
+++ b/src/Catalog/Catalog/Persistence/Migrations/20251106141806_AddProductPriceTiers.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using YourBrand.Catalog.Persistence;
 
@@ -11,9 +12,11 @@ using YourBrand.Catalog.Persistence;
 namespace YourBrand.Catalog.Persistence.Migrations
 {
     [DbContext(typeof(CatalogContext))]
-    partial class CatalogContextModelSnapshot : ModelSnapshot
+    [Migration("20251106141806_AddProductPriceTiers")]
+    partial class AddProductPriceTiers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Catalog/Catalog/Persistence/Migrations/20251106141806_AddProductPriceTiers.cs
+++ b/src/Catalog/Catalog/Persistence/Migrations/20251106141806_AddProductPriceTiers.cs
@@ -1,0 +1,73 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace YourBrand.Catalog.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProductPriceTiers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ProductPriceTiers",
+                columns: table => new
+                {
+                    OrganizationId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    TenantId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    ProductPriceId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    FromQuantity = table.Column<int>(type: "int", nullable: false),
+                    ToQuantity = table.Column<int>(type: "int", nullable: true),
+                    TierType = table.Column<int>(type: "int", nullable: false),
+                    Value = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                    CreatedById = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Created = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    LastModifiedById = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    LastModified = table.Column<DateTimeOffset?>(type: "datetimeoffset", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "bit", nullable: false),
+                    Deleted = table.Column<DateTimeOffset?>(type: "datetimeoffset", nullable: true),
+                    DeletedById = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProductPriceTiers", x => new { x.OrganizationId, x.Id });
+                    table.ForeignKey(
+                        name: "FK_ProductPriceTiers_ProductPrices_OrganizationId_ProductPriceId",
+                        columns: x => new { x.OrganizationId, x.ProductPriceId },
+                        principalTable: "ProductPrices",
+                        principalColumns: new[] { "OrganizationId", "Id" },
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProductPriceTiers_IsDeleted",
+                table: "ProductPriceTiers",
+                column: "IsDeleted");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProductPriceTiers_OrganizationId",
+                table: "ProductPriceTiers",
+                column: "OrganizationId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProductPriceTiers_OrganizationId_ProductPriceId",
+                table: "ProductPriceTiers",
+                columns: new[] { "OrganizationId", "ProductPriceId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProductPriceTiers_TenantId",
+                table: "ProductPriceTiers",
+                column: "TenantId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ProductPriceTiers");
+        }
+    }
+}

--- a/src/Store/Web/Shared/Products/ProductViewModel.cs
+++ b/src/Store/Web/Shared/Products/ProductViewModel.cs
@@ -51,8 +51,8 @@ public class ProductViewModel
             .Where(x => x.IsSelected || x.NumericalValue is not null || x.SelectedValueId is not null)
             .Select(x => new ProductOptionValue(x.Id, x.NumericalValue, x.SelectedValueId));
 
-        var result = await this.productsService.CalculatePrice(Product!.Handle, new CalculateProductPriceRequest([.. x], SubscriptionPlanId));
-        Total = (decimal)Quantity * result.Total;
+        var result = await productsService.CalculatePrice(Product!.Handle, new CalculateProductPriceRequest([.. x], Quantity, SubscriptionPlanId));
+        Total = result.Total;
     }
 
     public int Quantity { get; set; } = 1;

--- a/src/StoreFront/StoreFront.Client/OpenAPIs/storefront-svc.yaml
+++ b/src/StoreFront/StoreFront.Client/OpenAPIs/storefront-svc.yaml
@@ -1136,12 +1136,34 @@ components:
         optionsTotal:
           type: number
           format: decimal
-        discountAmount:
+        quantity:
+          type: integer
+          format: int32
+        unitPrice:
+          type: number
+          format: decimal
+        tierDiscount:
+          type: number
+          format: decimal
+        productDiscount:
+          type: number
+          format: decimal
+        subscriptionDiscount:
           type: number
           format: decimal
         total:
           type: number
           format: decimal
+        discountAmount:
+          type: number
+          format: decimal
+          readOnly: true
+        priceTier:
+          $ref: '#/components/schemas/ProductPriceTierApplication'
+        optionBreakdown:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProductOptionPriceDetail'
     CalculateProductPriceRequest:
       type: object
       additionalProperties: false
@@ -1150,6 +1172,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ProductOptionValue'
+        quantity:
+          type: integer
+          format: int32
+          default: 1
         subscriptionPlanId:
           type: string
           nullable: true
@@ -1166,6 +1192,45 @@ components:
         choiceValueId:
           type: string
           nullable: true
+    ProductOptionPriceDetail:
+      type: object
+      additionalProperties: false
+      properties:
+        optionId:
+          type: string
+        price:
+          type: number
+          format: decimal
+    ProductPriceTierApplication:
+      type: object
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+        fromQuantity:
+          type: integer
+          format: int32
+        toQuantity:
+          type: integer
+          format: int32
+          nullable: true
+        tierType:
+          $ref: '#/components/schemas/ProductPriceTierType'
+        value:
+          type: number
+          format: decimal
+        discountedUnits:
+          type: integer
+          format: int32
+        effectiveUnitPrice:
+          type: number
+          format: decimal
+    ProductPriceTierType:
+      type: string
+      enum:
+      - PricePerUnit
+      - DiscountPerUnit
+      - DiscountPerAdditionalUnit
     PagedResultOfProductSubscriptionPlan:
       type: object
       additionalProperties: false


### PR DESCRIPTION
## Summary
- add product price tier CRUD handlers and validations and expose them via product endpoints
- extend pricing calculations to honor quantity tiers and emit tier application details with unit coverage
- update catalog UI, API contracts, and store clients to manage price tiers and send quantity when calculating prices

## Testing
- dotnet build src/Catalog/Catalog/Catalog.csproj
- dotnet build src/Catalog/Catalog.UI/Catalog.UI.csproj
- dotnet build src/Store/Web/Shared/Shared.csproj

------
https://chatgpt.com/codex/tasks/task_e_690ca7b8b0e8832f887ac9652239ccf4